### PR TITLE
Minor tokenizer assert and typing fixes

### DIFF
--- a/eval/dispatch_openai_requests.py
+++ b/eval/dispatch_openai_requests.py
@@ -5,13 +5,13 @@ Thanks to Graham Neubig for sharing the original code.
 
 import openai
 import asyncio
-from typing import Any
+from typing import Any, List, Dict
 
 async def dispatch_openai_chat_requesets(
-    messages_list: list[list[dict[str,Any]]],
+    messages_list: List[List[Dict[str,Any]]],
     model: str,
     **completion_kwargs: Any,
-) -> list[str]:
+) -> List[str]:
     """Dispatches requests to OpenAI chat completion API asynchronously.
     
     Args:
@@ -33,10 +33,10 @@ async def dispatch_openai_chat_requesets(
 
 
 async def dispatch_openai_prompt_requesets(
-    prompt_list: list[str],
+    prompt_list: List[str],
     model: str,
     **completion_kwargs: Any,
-) -> list[str]:
+) -> List[str]:
     """Dispatches requests to OpenAI text completion API asynchronously.
     
     Args:

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -400,7 +400,7 @@ def main():
             "unk_token": "<unk>",
             "pad_token": "<pad>",
         })
-        assert num_added_tokens == 1, "LlamaTokenizer should only add one special token - the pad_token."
+        assert num_added_tokens in [0, 1], "LlamaTokenizer should only add one special token - the pad_token, or no tokens if pad token present."
     elif isinstance(tokenizer, GPTNeoXTokenizerFast):
         num_added_tokens = tokenizer.add_special_tokens({
             "pad_token": "<pad>",

--- a/open_instruct/finetune_trainer.py
+++ b/open_instruct/finetune_trainer.py
@@ -267,7 +267,7 @@ def main():
             "unk_token": "<unk>",
             "pad_token": "<pad>",
         })
-        assert num_added_tokens == 1, "LlamaTokenizer should only add one special token - the pad_token."
+        assert num_added_tokens in [0, 1], "LlamaTokenizer should only add one special token - the pad_token, or no tokens if pad token present."
     elif isinstance(tokenizer, GPTNeoXTokenizerFast):
         num_added_tokens = tokenizer.add_special_tokens({
             "pad_token": "<pad>",


### PR DESCRIPTION
New tokenizer config already has padding token, so our assert shouldn't yell about 0 new added tokens.
Make typehints a bit more consistent - also should fix #17 