### PR TITLE
Support several new datasets, including LIMA, WizardLM, and OpenOrca

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please see our first paper [How Far Can Camels Go? Exploring the State of Instru
 
 ## News
 
+- [2023-08-08] Supported several new instruction dataset, including [LIMA](https://huggingface.co/datasets/GAIR/lima) / [WizardLM](https://github.com/nlpxucan/WizardLM) / [Open-Orca](https://huggingface.co/datasets/Open-Orca/OpenOrca). See the [preparation script](./scripts/prepare_train_data.sh) for details. Performance hasn't been evaluated yet.
 - [2023-08-06] Supported LLaMa 2 finetuning and FlashAttention-2 by bumping the version of transformers and many other dependencies.
 - [2023-06-29] Added [licensing info](#licensing) for our released models.
 - [2023-06-09] Released Tülu (a suite of LLaMa models fully-finetuned on a strong mix of datasets) and many other checkpoints on HuggingFace [[Links]](#released-checkpoints).

--- a/scripts/get_statistics.sh
+++ b/scripts/get_statistics.sh
@@ -1,7 +1,7 @@
 # ["super_ni", "cot", "flan_v2", "self_instruct", "unnatural_instructions", "stanford_alpaca", "dolly", "sharegpt", "code_alpaca", "gpt4_alpaca", "baize", "oasst1"]
 
 # for every dataset, get the statistics
-for dataset in super_ni cot flan_v2 self_instruct unnatural_instructions stanford_alpaca dolly sharegpt code_alpaca gpt4_alpaca baize oasst1; do
+for dataset in super_ni cot flan_v2 self_instruct unnatural_instructions stanford_alpaca dolly sharegpt code_alpaca gpt4_alpaca baize oasst1 lima wizardlm open_orca; do
     echo "Getting statistics for $dataset..."
     python open_instruct/get_statistics.py --data_path data/processed/${dataset}/${dataset}_data.jsonl --save_path data/processed/${dataset}/${dataset}_statistics.json
 done

--- a/scripts/split_sharegpt_conversations.py
+++ b/scripts/split_sharegpt_conversations.py
@@ -95,7 +95,6 @@ def main(args):
         content.extend(json.load(open(file)))
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         args.model_name_or_path,
-        padding_side="right",
         use_fast=False,
     )
     new_content = split_all(content, args.begin, args.end, tokenizer, args.max_length)


### PR DESCRIPTION
This PR does the following:

1. Added several new promising instruction datasets to our list, including LIMA, WizardLM, and OpenOrca.
2. Remove company and model information from the OpenAssistant data.
3. Combine several datasets to create Tulu data mixture in the data preparation script.
4. Update README and other corresponding scripts.