### PR TITLE
Fix a bug in the default dtype when loading models

### DIFF
--- a/eval/bbh/run_eval.py
+++ b/eval/bbh/run_eval.py
@@ -156,7 +156,7 @@ def main(args):
             model_name_or_path=args.model_name_or_path, 
             tokenizer_name_or_path=args.tokenizer_name_or_path, 
             load_in_8bit=args.load_in_8bit, 
-            load_in_half=True,
+            device_map="balanced_low_0" if torch.cuda.device_count() > 1 else "auto",
             gptq_model=args.gptq
         )
 

--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -34,7 +34,6 @@ def main(args):
             model_name_or_path=args.model_name_or_path, 
             tokenizer_name_or_path=args.tokenizer_name_or_path, 
             load_in_8bit=args.load_in_8bit, 
-            load_in_half=True,
             # device map is determined by the number of gpus available.
             device_map="balanced_low_0" if torch.cuda.device_count() > 1 else "auto",
             gptq_model=args.gptq

--- a/eval/creative_tasks/perplexity_eval.py
+++ b/eval/creative_tasks/perplexity_eval.py
@@ -3,6 +3,7 @@ import random
 import json
 import os
 import tqdm
+import torch
 from eval.utils import load_hf_lm_and_tokenizer, score_completions
 
 
@@ -19,7 +20,7 @@ def main(args):
         model_name_or_path=args.model_name_or_path, 
         tokenizer_name_or_path=args.tokenizer_name_or_path, 
         load_in_8bit=args.load_in_8bit, 
-        load_in_half=True,
+        device_map="balanced_low_0" if torch.cuda.device_count() > 1 else "auto",
         gptq_model=args.gptq
     )
 

--- a/eval/gsm/run_eval.py
+++ b/eval/gsm/run_eval.py
@@ -3,6 +3,7 @@ import os
 import re
 import json
 import random
+import torch
 import evaluate
 from eval.utils import generate_completions, load_hf_lm_and_tokenizer, query_openai_chat_model
 from eval.gsm.examplars import EXAMPLARS as GSM_EXAMPLARS
@@ -68,7 +69,7 @@ def main(args):
             model_name_or_path=args.model_name_or_path, 
             tokenizer_name_or_path=args.tokenizer_name_or_path, 
             load_in_8bit=args.load_in_8bit, 
-            load_in_half=True,
+            device_map="balanced_low_0" if torch.cuda.device_count() > 1 else "auto",
             gptq_model=args.gptq
         )
         new_line_token = tokenizer.encode("\n", add_special_tokens=False)[-1] # get the last token because the tokenizer may add space tokens at the start.

--- a/eval/mgsm/run_eval.py
+++ b/eval/mgsm/run_eval.py
@@ -3,6 +3,7 @@ import os
 import re
 import json
 import random
+import torch
 import tqdm
 import evaluate
 from eval.utils import generate_completions, load_hf_lm_and_tokenizer
@@ -43,7 +44,7 @@ def main(args):
         model_name_or_path=args.model_name_or_path, 
         tokenizer_name_or_path=args.tokenizer_name_or_path, 
         load_in_8bit=args.load_in_8bit, 
-        load_in_half=True,
+        device_map="balanced_low_0" if torch.cuda.device_count() > 1 else "auto",
         gptq_model=args.gptq
     )
 

--- a/eval/mmlu/run_eval.py
+++ b/eval/mmlu/run_eval.py
@@ -136,7 +136,7 @@ def main(args):
             model_name_or_path=args.model_name_or_path, 
             tokenizer_name_or_path=args.tokenizer_name_or_path,
             load_in_8bit=args.load_in_8bit, 
-            load_in_half=True,
+            device_map="balanced_low_0" if torch.cuda.device_count() > 1 else "auto",
             gptq_model=args.gptq
         )
     

--- a/eval/superni/run_eval.py
+++ b/eval/superni/run_eval.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         model_name_or_path=args.model, 
         tokenizer_name_or_path=args.tokenizer, 
         load_in_8bit=args.load_in_8bit, 
-        load_in_half=True,
+        device_map="balanced_low_0" if torch.cuda.device_count() > 1 else "auto",
         gptq_model=args.gptq
     )
 

--- a/eval/tydiqa/run_eval.py
+++ b/eval/tydiqa/run_eval.py
@@ -96,7 +96,7 @@ def main(args):
             model_name_or_path=args.model_name_or_path, 
             tokenizer_name_or_path=args.tokenizer_name_or_path, 
             load_in_8bit=args.load_in_8bit, 
-            load_in_half=True,
+            device_map="balanced_low_0" if torch.cuda.device_count() > 1 else "auto",
             gptq_model=args.gptq
         )
     else:

--- a/eval/utils.py
+++ b/eval/utils.py
@@ -190,7 +190,7 @@ def load_hf_lm_and_tokenizer(
         tokenizer_name_or_path=None, 
         device_map="auto", 
         load_in_8bit=False, 
-        load_in_half=False,
+        convert_to_half=False,
         gptq_model=False,
         use_fast_tokenizer=False,
         padding_side="left",
@@ -227,7 +227,7 @@ def load_hf_lm_and_tokenizer(
             model = AutoModelForCausalLM.from_pretrained(model_name_or_path)
             if torch.cuda.is_available():
                 model = model.cuda()
-        if load_in_half:
+        if convert_to_half:
             model = model.half()
     model.eval()
     return model, tokenizer


### PR DESCRIPTION
Fix a bug: when loading models, the code now will use `auto` torch_dtype, and only convert to half if the user explicitly specifies that.