### PR TITLE
[Bug Fix] Fix step misalignment when resuming from a checkpoint

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -550,61 +550,55 @@ def main():
     # Potentially load in the weights and states from a previous save
     if args.resume_from_checkpoint:
         if args.resume_from_checkpoint is not None or args.resume_from_checkpoint != "":
-            accelerator.print(f"Resumed from checkpoint: {args.resume_from_checkpoint}")
-            accelerator.load_state(args.resume_from_checkpoint)
+            checkpoint_path = args.resume_from_checkpoint
             path = os.path.basename(args.resume_from_checkpoint)
         else:
             # Get the most recent checkpoint
             dirs = [f.name for f in os.scandir(os.getcwd()) if f.is_dir()]
             dirs.sort(key=os.path.getctime)
-            path = dirs[-1]  # Sorts folders by date modified, most recent checkpoint is the last
+            path = dirs[
+                -1
+            ]  # Sorts folders by date modified, most recent checkpoint is the last
+            checkpoint_path = path
+            path = os.path.basename(checkpoint_path)
+
+        accelerator.print(f"Resumed from checkpoint: {checkpoint_path}")
+        accelerator.load_state(path)
         # Extract `epoch_{i}` or `step_{i}`
         training_difference = os.path.splitext(path)[0]
 
         if "epoch" in training_difference:
             starting_epoch = int(training_difference.replace("epoch_", "")) + 1
             resume_step = None
+            completed_steps = starting_epoch * num_update_steps_per_epoch
         else:
             # need to multiply `gradient_accumulation_steps` to reflect real steps
-            resume_step = int(training_difference.replace("step_", "")) * args.gradient_accumulation_steps
+            resume_step = (
+                int(training_difference.replace("step_", ""))
+                * args.gradient_accumulation_steps
+            )
             starting_epoch = resume_step // len(train_dataloader)
+            completed_steps = resume_step // args.gradient_accumulation_steps
             resume_step -= starting_epoch * len(train_dataloader)
 
     # update the progress_bar if load from checkpoint
-    progress_bar.update(starting_epoch * num_update_steps_per_epoch)
-    completed_steps = starting_epoch * num_update_steps_per_epoch
+    progress_bar.update(completed_steps)
 
     for epoch in range(starting_epoch, args.num_train_epochs):
         model.train()
         total_loss = 0
-        for step, batch in enumerate(train_dataloader):
-            # We need to skip steps until we reach the resumed step
-            if args.resume_from_checkpoint and epoch == starting_epoch:
-                # Note 1: `completed_steps` update as the optimizer steps,
-                # while `step` as the dataloader,
-                # so there is a scaling factor of `gradient_accumulation_steps` between them.
-                # Note 2: `step` starts from 0, while `completed_steps` starts from 1,
-                # so we need to add 1 to `step` to decide whether to add 1 to `completed_steps`.
-                # Otherwise, e.g. "step_300" , resume_step = 4800, args.gradient_accumulation_steps = 16,
-                # completed_steps < 300 should be skipped, while completed_steps >= 300 should not;
-                # 0 <= step < 4800 should be skipped, while step >= 4800 should not be skipped.
-                # When step = 4784 (0 = 0 * 16, ..., 4784 = 299 * 16) => completed_steps = 299;
-                # after `completed_steps += 1`, completed_steps = 300;
-                # then step = 4785, completed_steps = 300, and this step batch would not be skipped,
-                # which is not what we expect.
-                if (
-                    resume_step is not None
-                    and completed_steps * args.gradient_accumulation_steps < resume_step
-                ):
-                    if (
-                        step + 1
-                    ) % args.gradient_accumulation_steps == 0:  # e.g. step = 15(0->1), 31(1->2), ..., 4783(298->299), 4799(299->300)
-                        progress_bar.update(1)
-                        # e.g. when step = 4799, completed_steps = 299, which is going to become 300
-                        completed_steps += 1
-                        # e.g. when completed_steps becomes 300, step = 4799, which is going to become 4800
-                    continue
-
+        if (
+            args.resume_from_checkpoint
+            and epoch == starting_epoch
+            and resume_step is not None
+        ):
+            # We skip the first `n` batches in the dataloader when resuming from a checkpoint
+            active_dataloader = accelerator.skip_first_batches(
+                train_dataloader, resume_step
+            )
+        else:
+            active_dataloader = train_dataloader
+        for step, batch in enumerate(active_dataloader):
             with accelerator.accumulate(model):
                 outputs = model(**batch, use_cache=False)
                 loss = outputs.loss


### PR DESCRIPTION
**Note 1: `completed_steps` update as the optimizer steps, while `step` as the dataloader**, so there is a scaling factor of `gradient_accumulation_steps` between them.

**Note 2: `step` starts from 0, while `completed_steps` starts from 1**, so we need to add 1 to `step` to decide whether to add 1 to `completed_steps`.
Otherwise, e.g. "step_300" , resume_step = 4800, args.gradient_accumulation_steps = 16, 
completed_steps < 300 should be skipped, while completed_steps >= 300 should not; 
0 <= step < 4800 should be skipped, while step >= 4800 should not be skipped. 
When step = 4784 (0 = 0 * 16, ..., 4784 = 299 * 16) => completed_steps = 299; 
after `completed_steps += 1`, completed_steps = 300; 
then step = 4785, completed_steps = 300, and this step batch would not be skipped, 
which is not what we expect.