### PR TITLE
Use hf tokenizer for portability when preparing data

### DIFF
--- a/scripts/prepare_train_data.sh
+++ b/scripts/prepare_train_data.sh
@@ -68,13 +68,13 @@ echo "Splitting the ShareGPT dataset with 2048 max tokens per conversation..."
 python scripts/split_sharegpt_conversations.py \
     --in-files data/raw_train/sharegpt/sg_90k_part1_html_cleaned.json data/raw_train/sharegpt/sg_90k_part2_html_cleaned.json \
     --out-file data/raw_train/sharegpt/sharegpt_html_cleaned_and_split_2048.json \
-    --model-name-or-path ../hf_llama_models/7B/ \
+    --model-name-or-path oobabooga/llama-tokenizer \
     --max-length 2048
 echo "Splitting the ShareGPT dataset with 4096 max tokens per conversation..."
 python scripts/split_sharegpt_conversations.py \
     --in-files data/raw_train/sharegpt/sg_90k_part1_html_cleaned.json data/raw_train/sharegpt/sg_90k_part2_html_cleaned.json \
     --out-file data/raw_train/sharegpt/sharegpt_html_cleaned_and_split_4096.json \
-    --model-name-or-path ../hf_llama_models/7B/ \
+    --model-name-or-path oobabooga/llama-tokenizer \
     --max-length 4096
 
 


### PR DESCRIPTION
We had a local path in the train script, using a tokenizer from the hf hub means you can run the script out of the box without issues.

Closes #20 