### PR TITLE
Better HumanEval instructions

### DIFF
--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -42,7 +42,7 @@ def main(args):
             answer = "Here is the function:\n\n```python\n"
             stop_sequences.append("\n```")
         else:
-            print(f"Could not find HumanEvalPack file at {args.data_file_hep}, using default instructions. This will result in significantly worse performance. You can download it at https://hf.co/datasets/bigcode/humanevalpack/blob/main/data/python/data/humanevalpack.jsonl")
+            print(f"Could not find HumanEvalPack file at {args.data_file_hep}, which will result in significantly worse performance. You can download it at https://hf.co/datasets/bigcode/humanevalpack/blob/main/data/python/data/humanevalpack.jsonl")
             instructions_dict = None
             answer = "Here is the completed function:\n\n\n"
 

--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -29,7 +29,7 @@ def main(args):
         prompts = []
         chat_formatting_function = dynamic_import_function(args.chat_formatting_function)
         # If available use more realistic instructions from HumanEvalPack (https://hf.co/datasets/bigcode/humanevalpack)
-        if os.ispath(args.data_file_hep):
+        if os.path.exists(args.data_file_hep):
             with open(args.data_file_hep, "r") as f:
                 instructions = [json.loads(l) for l in f]
                 instructions_dict = {

--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -29,6 +29,7 @@ def main(args):
         prompts = []
         chat_formatting_function = dynamic_import_function(args.chat_formatting_function)
         for example in test_data:
+            # For better instructions you may want to use HumanEvalSynthesize here: https://github.com/bigcode-project/bigcode-evaluation-harness/tree/main/docs#humanevalpack
             messages = [{"role": "user", "content": "Complete the following python function.\n\n\n" + example["prompt"]}]
             prompt = chat_formatting_function(messages, add_bos=False)
             if prompt[-1] in ["\n", " "]:

--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -55,6 +55,7 @@ def main(args):
         for example in test_data:
             if instructions_dict is not None:
                 instruction = instructions_dict[example["task_id"]]
+            # return partials that we will finalise once we have the tokenizer.
             prompts.append(lambda tokenizer: apply_chat_format(example, tokenizer, instruction, answer))
     else:
         prompts = [example["prompt"] for example in test_data]

--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -28,14 +28,28 @@ def main(args):
     if args.use_chat_format:
         prompts = []
         chat_formatting_function = dynamic_import_function(args.chat_formatting_function)
+        # If available use more realistic instructions from HumanEvalPack (https://hf.co/datasets/bigcode/humanevalpack)
+        if os.ispath(args.data_file_hep):
+            with open(args.data_file_hep, "r") as f:
+                instructions = [json.loads(l) for l in f]
+                instructions_dict = {
+                    x["task_id"].replace("Python", "HumanEval"): x["instruction"] for x in instructions
+                }
+            answer = "Here is the function:\n\n\n"
+        else:
+            instructions_dict = None
+            answer = "Here is the completed function:\n\n\n"
+        
+        instruction = "Complete the following python function.\n\n\n"
         for example in test_data:
-            # For better instructions you may want to use HumanEvalSynthesize here: https://github.com/bigcode-project/bigcode-evaluation-harness/tree/main/docs#humanevalpack
-            messages = [{"role": "user", "content": "Complete the following python function.\n\n\n" + example["prompt"]}]
+            if instructions_dict is not None:
+                instruction = instructions_dict[example["task_id"]]
+            messages = [{"role": "user", "content": instruction + example["prompt"]}]
             prompt = chat_formatting_function(messages, add_bos=False)
             if prompt[-1] in ["\n", " "]:
-                prompt += "Here is the completed function:\n\n\n" + example["prompt"]
+                prompt += answer + example["prompt"]
             else:
-                prompt += " Here is the completed function:\n\n\n" + example["prompt"]
+                prompt += " " + answer + example["prompt"]
             prompts.append(prompt)
     else:
         prompts = [example["prompt"] for example in test_data]
@@ -148,6 +162,12 @@ if __name__ == "__main__":
         default="data/codex_eval/HumanEval.jsonl.gz",
         help="Path to the HumanEval data file."
     )
+    parser.add_argument(
+        "--data_file_hep", 
+        type=str, 
+        default="data/codex_eval/humanevalpack.jsonl",
+        help="Path to the HumanEvalPack data file."
+    )    
     parser.add_argument(
         "--max_num_examples", 
         type=int, 

--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -42,21 +42,23 @@ def main(args):
             answer = "Here is the function:\n\n```python\n"
             stop_sequences.append("\n```")
         else:
+            print(f"Could not find HumanEvalPack file at {args.data_file_hep}, using default instructions. This will result in significantly worse performance. You can download it at https://hf.co/datasets/bigcode/humanevalpack/blob/main/data/python/data/humanevalpack.jsonl")
             instructions_dict = None
             answer = "Here is the completed function:\n\n\n"
 
-        def apply_chat_format(example, tokenizer, instruction, answer):
-            messages = [{"role": "user", "content": instruction + example["prompt"]}]
+        def apply_chat_format(tokenizer, inst, suffix):
+            messages = [{"role": "user", "content": inst}]
             prompt = chat_formatting_function(messages, tokenizer, add_bos=False)
-            prefix = " " if prompt[-1] in ["\n", " "] else ""
-            return prompt + prefix + answer + example["prompt"]      
+            prefix = "" if prompt[-1] in ["\n", " "] else " "
+            return prompt + prefix + suffix
             
         instruction = "Complete the following python function.\n\n\n"
         for example in test_data:
             if instructions_dict is not None:
                 instruction = instructions_dict[example["task_id"]]
-            # return partials that we will finalise once we have the tokenizer.
-            prompts.append(lambda tokenizer: apply_chat_format(example, tokenizer, instruction, answer))
+                prompts.append((instruction, answer + example["prompt"]))
+            else:
+                prompts.append((instruction + example["prompt"], answer))   
     else:
         prompts = [example["prompt"] for example in test_data]
         
@@ -70,16 +72,13 @@ def main(args):
             )
             sampling_params = vllm.SamplingParams(
                 n=args.unbiased_sampling_size_n,
-                temperature=args.temperature, 
+                temperature=args.temperature,
                 top_p=0.95,
                 max_tokens=512,
                 stop=stop_sequences,
             )
             if args.use_chat_format:
-                formatted_prompts = []
-                for prompt in prompts:
-                    formatted_prompts.append(prompt(model.llm_engine.tokenizer))
-                prompts = formatted_prompts
+                prompts = [apply_chat_format(model.llm_engine.tokenizer, inst, suffix) for (inst, suffix) in prompts]
             generations = model.generate(prompts, sampling_params)
             outputs = [output.text for it in generations for output in it.outputs]
             # Note: early vllm might ignore the first space in the generation, because the processing of _token.
@@ -98,10 +97,7 @@ def main(args):
                 use_fast_tokenizer=not args.use_slow_tokenizer,
             )
             if args.use_chat_format:
-                formatted_prompts = []
-                for prompt in prompts:
-                    formatted_prompts.append(prompt(model.llm_engine.tokenizer))
-                prompts = formatted_prompts
+                prompts = [apply_chat_format(tokenizer, inst, suffix) for (inst, suffix) in prompts]
 
             # these stop sequences are those mentioned in the codex paper.
             stop_sequences = ["\nclass", "\ndef", "\n#", "\nif", "\nprint"]

--- a/eval/gsm/run_eval.py
+++ b/eval/gsm/run_eval.py
@@ -63,17 +63,12 @@ def main(args):
         prompt_prefix = "Answer the following question.\n\n"
 
     if args.use_chat_format:
-        prompts = []
         chat_formatting_function = dynamic_import_function(args.chat_formatting_function)
         def apply_chat_format(example, tokenizer):
             messages = [{"role": "user", "content": prompt_prefix + "Question: " + example["question"].strip()}]
             prompt = chat_formatting_function(messages, tokenizer, add_bos=False)
             prompt += "Answer:" if prompt[-1] in ["\n", " "] else " Answer:"
             return prompt
-        for example in test_data:
-            prompts.append(lambda tokenizer: apply_chat_format(example, tokenizer))
-    else:
-        prompts = [prompt_prefix + "Question: " + example["question"].strip() + "\nAnswer:" for example in test_data]
 
     if args.model_name_or_path:
         print("Loading model and tokenizer...")
@@ -89,7 +84,10 @@ def main(args):
                 max_tokens=512,
                 stop=["\n"] if not args.use_chat_format else None, # we only use stop token for non-chat format (usually applied to vanilla pretrained language models). For chat format, we will rely on the model knows when to stop.
             )
-            prompts = [prompt(model.llm_engine.tokenizer) for prompt in prompts]
+            if args.use_chat_format:
+                prompts = [apply_chat_format(example, model.llm_engine.tokenizer) for example in test_data]
+            else:
+                prompts = [prompt_prefix + "Question: " + example["question"].strip() + "\nAnswer:" for example in test_data]
             # We need to remap the outputs to the prompts because vllm might not return outputs for some prompts (e.g., if the prompt is too long)
             generations = model.generate(prompts, sampling_params)
             prompt_to_output = {
@@ -105,7 +103,10 @@ def main(args):
                 gptq_model=args.gptq,
                 use_fast_tokenizer=not args.use_slow_tokenizer,
             )
-            prompts = [prompt(tokenizer) for prompt in prompts]
+            if args.use_chat_format:
+                prompts = [apply_chat_format(example, tokenizer) for example in test_data]
+            else:
+                prompts = [prompt_prefix + "Question: " + example["question"].strip() + "\nAnswer:" for example in test_data]            
             new_line_token = tokenizer.encode("\n", add_special_tokens=False)[-1] # get the last token because the tokenizer may add space tokens at the start.
             outputs = generate_completions(
                 model=model,

--- a/scripts/prepare_eval_data.sh
+++ b/scripts/prepare_eval_data.sh
@@ -27,7 +27,7 @@ wget -P data/eval/gsm/ https://github.com/openai/grade-school-math/raw/master/gr
 
 # Codex HumanEval
 wget -P data/eval/codex_humaneval https://github.com/openai/human-eval/raw/master/data/HumanEval.jsonl.gz
-
+wget -P data/eval/codex_humaneval https://huggingface.co/datasets/bigcode/humanevalpack/raw/main/data/python/data/humanevalpack.jsonl
 
 # Alpaca Farm reference
 wget -P data/eval/alpaca_farm https://huggingface.co/datasets/hamishivi/alpaca-farm-davinci-003-2048-token/resolve/main/davinci_003_outputs.json


### PR DESCRIPTION
Currently, the chat format is not used for CodexEval / HumanEval. However, this does not correspond to how users use the models.

This PR adds HumanEval instructions from HumanEvalPack to hopefully enable evaluating via the chat format in a realistic setting with good performance.