### PR TITLE
Bump alpaca-eval dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,6 +123,9 @@ RUN pip install packaging
 RUN pip install flash-attn==2.2.2 --no-build-isolation
 RUN pip install -r requirements.txt
 
+# Use v1 of alpaca eval.
+ENV IS_ALPACA_EVAL_2=False
+
 COPY open_instruct open_instruct
 COPY eval eval
 COPY ds_configs ds_configs

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ If you just want the dependencies for the weight diff script, use:
 pip install -r weight-diff-requirements.txt
 ```
 
+If you'd like to run experiments within a Docker environment, you can create one using:
+```bash
+docker build --build-arg CUDA=11.8.0 --build-arg TARGET=cudnn8-devel --build-arg DIST=ubuntu20.04 . -t <your tag here>
+```
+
 ## Training
 
 ### Dataset preparation

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ protobuf
 # But this PR is not compatible with the latest version of Transformers library (v4.34.0).
 # To incorporate it, we forked the Transformers library and made some changes to make it compatible with the latest version.
 git+https://github.com/yizhongw/transformers.git@left_padding
-openai<=0.28.1
+openai>=1.5.0
 tiktoken
 rouge_score
 tensorboard
@@ -30,7 +30,7 @@ einops
 flash-attn==2.2.2
 auto-gptq
 fire
-alpaca-eval==0.3.1
+alpaca-eval==0.5.3
 # for human eval web app
 flask
 vllm 

--- a/scripts/eval/alpaca_farm.sh
+++ b/scripts/eval/alpaca_farm.sh
@@ -1,5 +1,8 @@
 # Please make sure OPENAI_API_KEY is set in your environment variables
 
+# Use V1 of alpaca farm evaluation.
+export IS_ALPACA_EVAL_2=False
+
 # use vllm for generation
 python -m eval.alpaca_farm.run_eval \
     --model_name_or_path ../checkpoints/tulu_v1_7B/ \


### PR DESCRIPTION
Bump `alpaca-eval` version. Fixes a bug where alpaca-eval sometimes hung during evaluation.

I upgrade `openai` as well because the current alpaca-eval requires `openai >= 1.5.0`. From what I could tell, the only dependence on `openai` was TruthfulQA, which is broken at present anyway.