### PR TITLE
Beaker improvements & HF formatting

### DIFF
--- a/eval/bbh/run_eval.py
+++ b/eval/bbh/run_eval.py
@@ -67,6 +67,7 @@ def main(args):
                 tokenizer_mode="slow" if args.use_slow_tokenizer else "auto",
                 tensor_parallel_size=torch.cuda.device_count(),
             )
+            tokenizer = model.llm_engine.tokenizer
         else:
             print("Loading model and tokenizer with huggingface...")
             model, tokenizer = load_hf_lm_and_tokenizer(
@@ -90,7 +91,7 @@ def main(args):
                 for example in task_examples:
                     prompt = task_prompt.strip() + "\n\nQ: " + example["input"]
                     messages = [{"role": "user", "content": prompt}]
-                    prompt = chat_formatting_function(messages, add_bos=False)
+                    prompt = chat_formatting_function(messages, tokenizer, add_bos=False)
                     prompt += "A:" if prompt[-1] in ["\n", " "] else " A:"
                     prompts.append(prompt)
             else:

--- a/eval/mmlu/run_eval.py
+++ b/eval/mmlu/run_eval.py
@@ -56,7 +56,7 @@ def eval_hf_model(args, subject, model, tokenizer, dev_df, test_df, batch_size=1
 
         if args.use_chat_format:
             messages = [{"role": "user", "content": prompt}]
-            prompt = chat_formatting_function(messages, add_bos=False)
+            prompt = chat_formatting_function(messages, tokenizer, add_bos=False)
             if prompt[-1] in ["\n", " "]:
                 prompt += "The answer is:"
             else:
@@ -71,7 +71,7 @@ def eval_hf_model(args, subject, model, tokenizer, dev_df, test_df, batch_size=1
 
             if args.use_chat_format:
                 messages = [{"role": "user", "content": prompt}]
-                prompt = chat_formatting_function(messages, add_bos=False)
+                prompt = chat_formatting_function(messages, tokenizer, add_bos=False)
                 if prompt[-1] in ["\n", " "]:
                     prompt += "The answer is:"
                 else:

--- a/eval/templates.py
+++ b/eval/templates.py
@@ -109,5 +109,8 @@ def create_prompt_with_zephyr_chat_format(messages, tokenizer, bos="<s>", eos="<
     return formatted_text    
 
 # helper for just using the huggingface tokenizer
-def create_prompt_with_huggingface_tokenizer_template(messages, tokenizer):
-    return tokenizer.apply_chat_template(messages, tokenize=False)
+def create_prompt_with_huggingface_tokenizer_template(messages, tokenizer, add_bos=False):
+    formatted_text = tokenizer.apply_chat_template(messages, tokenize=False)
+    if add_bos:
+        formatted_text = tokenizer.bos_token + formatted_text
+    return formatted_text

--- a/eval/templates.py
+++ b/eval/templates.py
@@ -1,5 +1,5 @@
 
-def create_prompt_with_tulu_chat_format(messages, bos="<s>", eos="</s>", add_bos=True):
+def create_prompt_with_tulu_chat_format(messages, tokenizer, bos="<s>", eos="</s>", add_bos=True):
     formatted_text = ""
     for message in messages:
         if message["role"] == "system":
@@ -17,7 +17,7 @@ def create_prompt_with_tulu_chat_format(messages, bos="<s>", eos="</s>", add_bos
     return formatted_text
 
 # weirdness with olmo tokenizer means IP_ADDR is the eos token.
-def create_prompt_with_olmo_chat_format(messages, bos="|||IP_ADDRESS|||", eos="|||IP_ADDRESS|||", add_bos=True):
+def create_prompt_with_olmo_chat_format(messages, tokenizer, bos="|||IP_ADDRESS|||", eos="|||IP_ADDRESS|||", add_bos=True):
     formatted_text = ""
     for message in messages:
         if message["role"] == "system":
@@ -35,7 +35,7 @@ def create_prompt_with_olmo_chat_format(messages, bos="|||IP_ADDRESS|||", eos="|
     return formatted_text
 
 
-def create_prompt_with_llama2_chat_format(messages, bos="<s>", eos="</s>", add_bos=True):
+def create_prompt_with_llama2_chat_format(messages, tokenizer, bos="<s>", eos="</s>", add_bos=True):
     '''
     This function is adapted from the official llama2 chat completion script: 
     https://github.com/facebookresearch/llama/blob/7565eb6fee2175b2d4fe2cfb45067a61b35d7f5e/llama/generation.py#L274
@@ -66,7 +66,7 @@ def create_prompt_with_llama2_chat_format(messages, bos="<s>", eos="</s>", add_b
     return formatted_text
 
 
-def create_prompt_with_xwin_chat_format(messages, bos="<s>", eos="</s>", add_bos=True):
+def create_prompt_with_xwin_chat_format(messages, tokenizer, bos="<s>", eos="</s>", add_bos=True):
     '''
     This function is adapted from the official xwin chat completion script:
     https://huggingface.co/Xwin-LM/Xwin-LM-70B-V0.1
@@ -82,7 +82,7 @@ def create_prompt_with_xwin_chat_format(messages, bos="<s>", eos="</s>", add_bos
     return formatted_text
 
 
-def create_prompt_with_zephyr_chat_format(messages, bos="<s>", eos="</s>", add_bos=True):
+def create_prompt_with_zephyr_chat_format(messages, tokenizer, bos="<s>", eos="</s>", add_bos=True):
     '''
     This function is adapted from the official zephyr chat completion script:
     https://huggingface.co/HuggingFaceH4/zephyr-7b-beta
@@ -106,11 +106,8 @@ def create_prompt_with_zephyr_chat_format(messages, bos="<s>", eos="</s>", add_b
                 "Zephyr chat template only supports 'system', 'user' and 'assistant' roles. Invalid role: {}.".format(message["role"])
                 )
     formatted_text += "<|assistant|>\n"
-    return formatted_text
+    return formatted_text    
 
-            
-
-
-
-    
-
+# helper for just using the huggingface tokenizer
+def create_prompt_with_huggingface_tokenizer_template(messages, tokenizer):
+    return tokenizer.apply_chat_template(messages, tokenize=False)

--- a/eval/toxigen/run_eval.py
+++ b/eval/toxigen/run_eval.py
@@ -63,9 +63,10 @@ def main(args):
         prompts = []
         for example in examples:
             if args.use_chat_format:
+                tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name_or_path if args.model_name_or_path else args.model_name_or_path, use_fast=not args.use_slow_tokenizer)
                 messages = [{"role": "user", "content": "Complete the following: " + example["text"]}]
                 chat_formatting_function = dynamic_import_function(args.chat_formatting_function)
-                prompt = chat_formatting_function(messages, add_bos=False)
+                prompt = chat_formatting_function(messages, tokenizer, add_bos=False)
             else:
                 # we will use the original text from toxigen as the prompt.
                 prompt = example["text"]

--- a/eval/truthfulqa/run_eval.py
+++ b/eval/truthfulqa/run_eval.py
@@ -193,7 +193,7 @@ def run_hf_model(questions, model, tokenizer, tag, preset="qa", batch_size=1, ma
         chat_formatting_function = dynamic_import_function(args.chat_formatting_function)
         for idx, prompt in enumerate(prompts):
             messages = [{"role": "user", "content": prompt}]
-            prompts[idx] = chat_formatting_function(messages, add_bos=False)
+            prompts[idx] = chat_formatting_function(messages, tokenizer, add_bos=False)
             prompt += "A:" if prompt[-1] in ["\n", " "] else " A:"
     
     stop_sequence = tokenizer.encode("\n\n", add_special_tokens=False)[-2:] # get the last token because the tokenizer may add space tokens at the start.
@@ -232,7 +232,7 @@ def run_hf_model_mc(questions, model, tokenizer, tag, batch_size=1, preset='qa')
         if args.use_chat_format:
             chat_formatting_function = dynamic_import_function(args.chat_formatting_function)
             messages = [{"role": "user", "content": prompt}]
-            prompt = chat_formatting_function(messages, add_bos=False)
+            prompt = chat_formatting_function(messages, tokenizer, add_bos=False)
             prompt += "A:" if prompt[-1] in ["\n", " "] else " A:"
         else:
             prompt += "\nA:"

--- a/eval/tydiqa/run_eval.py
+++ b/eval/tydiqa/run_eval.py
@@ -169,7 +169,7 @@ def main(args):
 
         if args.use_chat_format:
             messages = [{"role": "user", "content": prompt}]
-            prompt = chat_formatting_function(messages, add_bos=False)
+            prompt = chat_formatting_function(messages, tokenizer, add_bos=False)
             prompt += a_template if prompt[-1] in ["\n", " "] else " " + a_template
         else:
             prompt += a_template

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -14,8 +14,8 @@ parser.add_argument("--model_name", type=str, default="hf-opt-7B")
 parser.add_argument("--location", type=str, default=None)
 parser.add_argument("--beaker_subfolder", type=str, default=None)
 parser.add_argument("--cluster", type=str, default="ai2/allennlp-cirrascale")
-parser.add_argument("--num_gpus", type=int, default=1)
 parser.add_argument("--is_tuned", action="store_true")
+parser.add_argument("--use_hf_tokenizer_template", action="store_true")
 args = parser.parse_args()
 
 
@@ -300,7 +300,12 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
             # request 2x more GPUs
             d['tasks'][0]['resources']['gpuCount'] = 2 * d['tasks'][0]['resources']['gpuCount']
 
-
+    # if using huggingface tokenizer template, replace the chat formatting function with hf tokenizer one
+    if args.use_hf_tokenizer_template:
+        d['tasks'][0]['arguments'] = [d['tasks'][0]['arguments'][0].replace(
+            "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format", 
+            "--chat_formatting_function eval.templates.create_prompt_with_huggingface_tokenizer_template")
+        ]
     if "llama2-chat" in model_info[0]:
         d['tasks'][0]['arguments'] = [d['tasks'][0]['arguments'][0].replace(
             "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format", 

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -1,25 +1,35 @@
 import copy
 import subprocess
 import yaml
-import random
 import re
 import itertools
 from datetime import date
+import argparse
 
 today = date.today().strftime("%m%d%Y")
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--workspace", type=str, default="hamishivi")
+parser.add_argument("--model_name", type=str, default="hf-opt-7B")
+parser.add_argument("--location", type=str, default=None)
+parser.add_argument("--beaker_subfolder", type=str, default=None)
+parser.add_argument("--cluster", type=str, default="ai2/allennlp-cirrascale")
+parser.add_argument("--num_gpus", type=int, default=1)
+parser.add_argument("--is_tuned", action="store_true")
+args = parser.parse_args()
+
+
+workspace = args.workspace
+model_type = "vanilla_lm" if not args.is_tuned else "tuned_lm"
 
 with open("beaker_configs/default_eval.yaml", 'r') as f:
     default_yaml = f.read()
 d1 = yaml.load(default_yaml, Loader=yaml.FullLoader)
 
-# cluster = "ai2/general-cirrascale"
-cluster = "ai2/allennlp-cirrascale"
-# cluster = "ai2/general-cirrascale-a100-80g-ib"
-# cluster = "ai2/prior-elanding"
-num_gpus = 1
+cluster = args.cluster
+num_gpus = args.num_gpus
 d1['tasks'][0]['context']['cluster'] = cluster
 d1['tasks'][0]['context']['priority'] = "high"
-# d1['tasks'][0]['context']['priority'] = "preemptible"
 d1['tasks'][0]['resources']['gpuCount'] = num_gpus
 
 # modify here for different set of experiments
@@ -39,110 +49,16 @@ experiment_groups = [
     "alpaca_eval",
 ]
 
-# model to evaluate, each in the followng format: model name, their beaker id, checkpoint subfolder
+# format: model name, their beaker id, checkpoint subfolder, tuned or base.
+# or: name, path, None, tuned or base
 models = [
     # llama1 models
     # ("llama1-7B", "01HCCBK1MYKXKQC0C6CSVW1F22", None, "vanilla_lm"),
-    # ("llama1-13B", "01HCCBWB4TWNS35N9R35K47BH8", None, "vanilla_lm"),
-    # ("llama1-30B", "01HCCC7FNXFCQ2TFWGS2HA683Y", None, "vanilla_lm"),
-    # ("llama1-65B", "01HCCCWQTPKS23W7MRFH5PXNHA", None, "vanilla_lm"),
-    
-    # llama2 models
-    # ("llama2-7B", "01HCJYBBWA629B8GJTHPT496TT", None, "vanilla_lm"),
-    # ("llama2-13B", "01HCJZQBM2KGQZSZRPF4HKVBZX", None, "vanilla_lm"),
-    # ("llama2-70B", "01HCK281AFAXV2Y7T54NMNSC55", None, "vanilla_lm"),
-    # ("llama2-chat-7B", "01HCT5D48MSRF0PCNAWNSJDN54", None, "tuned_lm"),
-    # ("llama2-chat-13B", "01HCT5Q7A6FE8RZKY8TYN64ZW2", None, "tuned_lm"),
-    # ("llama2-chat-70B", "01HCT63DVK7YPT6P9SN35XH417", None, "tuned_lm"),
-    
-    # our ablation models
-    # ("finetuned_llama1_7B_dolly", "01GZVKGQZAMQMVG9307KWS4GMN", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_flan_v2", "01GZVKGR5DW1SXXWSMWE2QYWYR", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_cot", "01GZVKGRA3X4SYQF1PZ29DSZFE", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_code_alpaca", "01GZVKGREPDJ6FZM3S4B0J8VB9", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_baize", "01GZVKGRKAHJW2AK3ZF88G13HA", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_oasst1", "01GZVKGRQZ4359W31CAEHWFVSB", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_gpt4_alpaca", "01GZVKGRWJ2VVCXY5KP46814JP", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_super_ni", "01GZVKGS1S527GYKRA4Y26ZP5S", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_self_instruct", "01GZVKGS7JTYK0M35AFXHY0CD0", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_stanford_alpaca", "01GZVKGSHNPRFSJBS4K74FTRDC", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_unnatural_instructions", "01GZVKGSP9BAW8XTWB9509SPDB", None, "tuned_lm"),
-    # ("finetuned_llama1_7B_sharegpt", "01GZWDNED8KP28SAR1159WZ366", None, "tuned_lm"),
-    
-    # ("finetuned_llama1_13B_oasst1", "01GZWN5FRTGJKEZR890MQRXZZ9", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_dolly", "01GZWN5FXP2ZEKJ8HBBWHK58TZ", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_super_ni", "01GZWN5G71CT6GFC9VC6T6RT5V", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_self_instruct", "01H0JSB1QDQDYPEG8AX127XMND", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_flan_v2", "01H04RBP7F545WC5APZK5DE58T", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_sharegpt", "01GZWN5G2DVDTSM508CW34V1FT", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_cot_lumi", "01H0F09XR3PNABMPD7X95PSR8H", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_baize_lumi", "01H0F123TJG9BXZ9WT42XTSDPS", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_code_alpaca_lumi", "01H0F1SF5WX84RXWJYZFS4CBW5", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_gpt4_alpaca_lumi", "01H0F43FKA2J7YY8N3K9A0CHFD", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_stanford_alpaca_lumi", "01H0F4TWK7YNB2YRK1TG5JEXZ5", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_unnatural_instructions_lumi", "01H0F5JTDM9WMKSPDBYH141089", None, "tuned_lm"),
-
-    # ("finetuned_llama1_30B_sharegpt_lumi", "01H1SHNQXG8GSXNATQPN7GKE3T", None, "tuned_lm"),
-    # ("finetuned_llama1_65B_sharegpt_lumi", "01H1SWN595ASF1NH0RBX12X96W", None, "tuned_lm"),
-
-    # ("finetuned_llama1_7B_flanv2_cot_oasst1_dolly_lumi", "01H0K4049XMFGD8PW7BB6KVGBZ", None, "tuned_lm"),
-    # ("finetuned_llama1_13B_flanv2_cot_oasst1_dolly_lumi", "01H0KJ3ZFCDBGGV4FGS8RZXCXA", None, "tuned_lm"),
-    # ("finetuned_llama1_30B_flanv2_cot_oasst1_dolly_lumi", "01H0NF25QSBTVDWYV7JJNKDYCV", None, "tuned_lm"),
-    # ("finetuned_llama1_65B_flanv2_cot_oasst1_dolly_lumi", "01H0P3BKSC389DSK8KBPXW8JDF", None, "tuned_lm"),
-    
-    # tulu v1 models
-    # ("tulu_v1_7B", "01H0K6A8P9TC25F5D0NMN8NTG7", None, "tuned_lm"),
-    # ("tulu_v1_13B", "01H0JW5D7ETX8252T2AHKN6S94", None, "tuned_lm"),
-    # ("tulu_v1_30B", "01H0PHQSWP1CYHBYF4EG8ABX3E", None, "tuned_lm"),
-    # ("tulu_v1_65B", "01H0MHPS7Y3YTND66KCP16E4AC", None, "tuned_lm"),
-
-    # tulu v2 ablation models
-    # ("finetuned_llama2_7B_on_v1_data", "01H7ABFYB84N9TN8MYXAVSMJ68", None, "tuned_lm"),
-    # ("finetuned_llama2_7B_on_sharegpt", "01HEXQK5YHNWG6RW1RS1H32XXA", None, "tuned_lm"),
-    # ("finetuned_llama2_13B_on_v1_data", "01H7AC0KXGRDH9ACJ24WTSK7SR", None, "tuned_lm"),
-    # ("finetuned_llama2_70B_on_v1_data", "01HE9NVD58XX6G9ZYA61JZKJ7N", None, "tuned_lm"),
-    # ("finetuned_llama2_7B_on_sharegpt_dpo", "01HEXR0R515HKPKTN4TNAC408A", None, "tuned_lm"),
-
-    # tulu v2 models
-    # ("tulu_v2_7B_qlora", "01HDCNBNJS56BWKP5AHV4YNCSJ", None, "tuned_lm"),
-    # ("tulu_v2_13B_qlora", "01HDCNNENVNZP37VSYR3AZSMYT", None, "tuned_lm"),
-    # ("tulu_v2_70B_qlora", "01HDG3YXJD6TKNFW6WV19NE7A0", None, "tuned_lm"),
-    # ("tulu_v2_7B_jax", "01HBXTF305QARZ7P4T6ASXXVAM", None, "tuned_lm"),
-    # ("tulu_v2_13B_jax", "01HBWE5NHC3M30HH63339HS8BE", None, "tuned_lm"),
-    # ("tulu_v2_70B_jax", "01HCB2VZJ2T2JXZX0R1SJBRSB2", None, "tuned_lm"),
-    # ("tulu_v2_7B_dpo", "01HE8H1MBSVN09ZZ82X6K90NTF", None, "tuend_lm"),
-    # ("tulu_v2_13B_dpo", "01HE8YMBMJSTJV49QWA6TF2NTE", None, "tuend_lm"),
-    # ("tulu_v2_70B_dpo_first_epoch", "01HES1TCSJCPTPV50HQZHSN319", None, "tuend_lm"),
-    # ("tulu_v2_70B_dpo_second_epoch", "/net/nfs.cirrascale/allennlp/hamishi/EasyLM/tulu_2_70b_dpo/", None, "tuend_lm"),
-    # ("tulu_v2_70B_dpo", "01HEXKXP0MFM60PT7SY71XXSWD", None, "tuend_lm"),
-
-    # code llama models
-    # ("code_llama_7B", "01HD9Z1MJ9K3ZK494KGTVD1063", None, "vanilla_lm"),
-    # ("code_llama_13B", "01HD9Z9TNEFWS5E8MQJMDY6N0P", None, "vanilla_lm"),
-    # ("code_llama_34B", "01HD9ZQF6PRAMC0ANVPFJFEJHR", None, "vanilla_lm"),
-    # ("code_llama_instruct_7B", "01HDA0SGJ0GB2ZF6D6RXS6NREZ", None, "tuned_lm"),
-    # ("code_llama_instruct_13B", "01HDA141K4SEDPXFY749092FNZ", None, "tuned_lm"),
-    # ("code_llama_instruct_34B", "01HDA1GNSCCNDQ4FNQ2FPPRBSD", None, "tuned_lm"),
-    
-    # code tulu models
-    # ("code_tulu_7B_jax", "01HD57SA48PBKD30FKB2F55S7H", None, "tuned_lm"),
-    # ("code_tulu_13B_jax", "01HCTQG860G68C2486K1QNSY3S", None, "tuned_lm"),
-    # ("code_tulu_34B_jax", "01HD7J73FJ7299VQKPKBS8RSJB", None, "tuned_lm"),
-
 
     # other causal models
     # ("hf-opt-7B", "facebook/opt-6.7b", None, "vanilla_lm"),
-    # ("finetuned_opt_7B_flanv2_cot_oasst1_dolly_sharegpt_gpt4alpaca_codealpaca", "01H13EBXSADXXJCRERART90ZKJ", None, "tuned_lm"),
-    # ("hf-pythia-7B", "EleutherAI/pythia-6.9b", None, "vanilla_lm"),
-    # ("fintuned_pythia_7B_flanv2_cot_oasst1_dolly_sharegpt_gpt4alpaca_codealpaca", "01H1359QTQZCXFTW4KY4WVKF0C", None, "tuned_lm"),
-    # ("hf-falcon-40B", "tiiuae/falcon-40b", None, "vanilla_lm"),
-    # ("finetuned_falcon_40B_flanv2_cot_oasst1_dolly_sharegpt_gpt4alpaca_codealpaca", "01H2TRXD9TE80W61PABE26785P", None, "tuned_lm"),
-    # ("hf-falcon-7B", "tiiuae/falcon-7b", None, "vanilla_lm"),
-    # ("finetuned_falcon_7B_flanv2_cot_oasst1_dolly_sharegpt_gpt4alpaca_codealpaca", "01H356X9ZYY8HX1C7HFH6JYWNW", None, "tuned_lm"),
-    # ("hf-falcon-rw-7B", "tiiuae/falcon-rw-7b", None, "vanilla_lm"),
-    # ("finetuned_falcon_rw_7B_flanv2_cot_oasst1_dolly_sharegpt_gpt4alpaca_codealpaca", "01H37QXWFK095588W6GCMVGFKB", None, "tuned_lm"),
-    # ("zephyr-7B", "/net/nfs.cirrascale/allennlp/yizhongw/checkpoints/zephyr-7b-beta", None, "tuned_lm"),
-    # ("xwin-70B", "/net/nfs.cirrascale/allennlp/yizhongw/checkpoints/Xwin-LM-70B-V0.1", None, "tuned_lm"),
+    # ("finetuned_opt", "01H13EBXSADXXJCRERART90ZKJ", None, "tuned_lm"),
+    (args.model_name, args.location, args.beaker_subfolder, model_type),
 ]
 
 #--------------- experiments about number of supervision tasks -------------------------
@@ -408,7 +324,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
     elif "olmo" in model_info[0]:
         d['tasks'][0]['arguments'] = [d['tasks'][0]['arguments'][0].replace(
             "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format", 
-            "--chat_formatting_function eval.templates.create_prompt_with_olmo_chat_format")
+            "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format_force_bos")
         ]
         # no vllm for olmo yet
         if "--use_vllm" in d['tasks'][0]['arguments'][0]:
@@ -428,5 +344,5 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
     yaml.dump(d, file, default_flow_style=True)
     file.close()
 
-    cmd = "beaker experiment create {} --workspace ai2/yizhong_default".format(fn)
+    cmd = "beaker experiment create {} --workspace ai2/{}".format(fn, workspace)
     subprocess.Popen(cmd, shell=True)

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -324,7 +324,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
     elif "olmo" in model_info[0]:
         d['tasks'][0]['arguments'] = [d['tasks'][0]['arguments'][0].replace(
             "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format", 
-            "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format_force_bos")
+            "--chat_formatting_function eval.templates.create_prompt_with_olmo_chat_format")
         ]
         # no vllm for olmo yet
         if "--use_vllm" in d['tasks'][0]['arguments'][0]:


### PR DESCRIPTION
This PR turns the beaker script into a command-line configurable thing, making it easier for people to use it without actually reading the script and understanding what's happening. @dwadden may turn this into something more tightly integrated with beaker-py.

Additionally, I've added support for just applying the HF tokenizer in the eval chat formatting. This required a little refactoring to pass the tokenizer into the chat template. This allows us just to reuse the chat template given in an HF tokenizer (saving us time in implementing and testing any given chat format, hopefully).