### PR TITLE
Trust HF OLMo models.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ If you just want the dependencies for the weight diff script, use:
 pip install -r weight-diff-requirements.txt
 ```
 
+If you'd like to experiment with AI2's [OLMo](https://huggingface.co/allenai/OLMo-7B) models, you should also install:
+
+```bash
+pip install ai2-olmo
+```
+
 ## Training
 
 ### Dataset preparation

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ alpaca-eval==0.3.1
 flask
 vllm 
 openpyxl
-hf_olmo       # Needed to work with HF OLMo models.
+ai2-olmo       # Needed to work with HF OLMo models.

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ alpaca-eval==0.3.1
 flask
 vllm 
 openpyxl
+hf_olmo       # Needed to work with HF OLMo models.

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,3 @@ alpaca-eval==0.3.1
 flask
 vllm 
 openpyxl
-ai2-olmo       # Needed to work with HF OLMo models.


### PR DESCRIPTION
Previously, attempting to load OLMo models in a Beaker job raised an error because these models run custom code. This fixes it by setting `trust_remote_code=True` for OLMo models.

At some point we should just unify the command line parsers for the different eval tasks and allow the user to pass `--trust_remote_code` as a command line flag; this will take a bit of a refactor.