### PR TITLE
Add model revision flag for finetuning

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -67,7 +67,8 @@ def parse_args():
     )
     parser.add_argument(
         "--model_revision",
-        help="If given, specifies a model revision. This will be applied to the config and tokenizer as well as the model.",
+        help="""If given, specifies a model revision (for HuggingFace models). This will 
+        be applied to all model components, including config and tokenizer.""",
         default="main",
         required=False,
     )
@@ -495,7 +496,6 @@ def main():
     else:
         logger.info("Training new model from scratch")
         model = AutoModelForCausalLM.from_config(config)
-
 
     # no default pad token for llama!
     # here we add all special tokens again, because the default ones are not in the special_tokens_map

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -443,18 +443,36 @@ def main():
 
     # Load pretrained model and tokenizer
     if args.config_name:
-        config = AutoConfig.from_pretrained(args.config_name, trust_remote_code=args.trust_remote_code, revision=args.model_revision)
+        config = AutoConfig.from_pretrained(
+            args.config_name,
+            trust_remote_code=args.trust_remote_code,
+            revision=args.model_revision,
+        )
     elif args.model_name_or_path:
-        config = AutoConfig.from_pretrained(args.model_name_or_path, trust_remote_code=args.trust_remote_code, revision=args.model_revision)
+        config = AutoConfig.from_pretrained(
+            args.model_name_or_path,
+            trust_remote_code=args.trust_remote_code,
+            revision=args.model_revision,
+        )
     else:
         raise ValueError(
             "You are instantiating a new config instance from scratch. This is not supported by this script."
         )
 
     if args.tokenizer_name:
-        tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_name, trust_remote_code=args.trust_remote_code, use_fast=not args.use_slow_tokenizer, revision=args.model_revision)
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.tokenizer_name,
+            trust_remote_code=args.trust_remote_code,
+            use_fast=not args.use_slow_tokenizer,
+            revision=args.model_revision,
+        )
     elif args.model_name_or_path:
-        tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, trust_remote_code=args.trust_remote_code, use_fast=not args.use_slow_tokenizer, revision=args.model_revision)
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.model_name_or_path,
+            trust_remote_code=args.trust_remote_code,
+            use_fast=not args.use_slow_tokenizer,
+            revision=args.model_revision,
+        )
     else:
         raise ValueError(
             "You are instantiating a new tokenizer from scratch. This is not supported by this script."


### PR DESCRIPTION
Makes it possible finetune different checkpoints of the same HF model; this is useful for experimentation with OLMo.

I think I found all the places where the revision flag would need to be added but it's probably good for @yizhongw or @hamishivi to double-check.