### PR TITLE
Add option to specify tokenizer revision.

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -66,17 +66,17 @@ def parse_args():
         required=False,
     )
     parser.add_argument(
-        "--model_revision",
-        help="""If given, specifies a model revision (for HuggingFace models). This will 
-        be applied to all model components, including config and tokenizer.""",
-        default="main",
-        required=False,
-    )
-    parser.add_argument(
         "--config_name",
         type=str,
         default=None,
         help="Pretrained config name or path if not the same as model_name",
+    )
+    parser.add_argument(
+        "--model_revision",
+        help="""If given, specifies a model revision (for HuggingFace models). This will 
+        be applied to both the `model_name_or_path` and `config_name` args.""",
+        default="main",
+        required=False,
     )
     parser.add_argument(
         "--use_lora",
@@ -111,6 +111,15 @@ def parse_args():
         type=str,
         default=None,
         help="Pretrained tokenizer name or path if not the same as model_name",
+    )
+    parser.add_argument(
+        "--tokenizer_revision",
+        help="""Specifies a revision for the tokenizer. If not given, defaults
+             to the value of the `model_revision` arg. In most cases, the tokenizer
+             revision should be the same as the model revision and this flag shouldn't
+             be needed.""",
+        default=None,
+        required=False,
     )
     parser.add_argument(
         "--use_slow_tokenizer",
@@ -459,19 +468,32 @@ def main():
             "You are instantiating a new config instance from scratch. This is not supported by this script."
         )
 
+    tokenizer_revision = (
+        args.model_revision
+        if args.tokenizer_revision is None
+        else args.tokenizer_revision
+    )
+
+    if tokenizer_revision != args.model_revision:
+        # Warn user if tokenizer and model use different revisions; this is an unusual
+        # use case.
+        warning = f"""Requested tokenizer revision `{tokenizer_revision}` is different
+                   from the model revision `{args.model_revision}`."""
+        logger.warn(warning)
+
     if args.tokenizer_name:
         tokenizer = AutoTokenizer.from_pretrained(
             args.tokenizer_name,
             trust_remote_code=args.trust_remote_code,
             use_fast=not args.use_slow_tokenizer,
-            revision=args.model_revision,
+            revision=tokenizer_revision
         )
     elif args.model_name_or_path:
         tokenizer = AutoTokenizer.from_pretrained(
             args.model_name_or_path,
             trust_remote_code=args.trust_remote_code,
             use_fast=not args.use_slow_tokenizer,
-            revision=args.model_revision,
+            revision=tokenizer_revision
         )
     else:
         raise ValueError(


### PR DESCRIPTION
Per @hamishivi [comment](https://github.com/allenai/open-instruct/pull/121#issuecomment-1962050213) on PR #121, add an option to specify a separate `tokenizer_revision` if requested. This seems like an unusual use case, so the code throws a warning if the model and tokenizer have different revisions.