### PR TITLE
Subfolder evaluation

### DIFF
--- a/beaker_configs/default_eval.yaml
+++ b/beaker_configs/default_eval.yaml
@@ -12,8 +12,8 @@ tasks:
       --ntrain 5
       --data_dir /data/mmlu/
       --save_dir /output/
-      --model /model
-      --tokenizer /model
+      --model_name_or_path /model
+      --tokenizer_name_or_path /model
       --eval_batch_size 4
       --load_in_8bit
       --use_chat_format

--- a/eval/utils.py
+++ b/eval/utils.py
@@ -7,6 +7,7 @@ import os
 from importlib import import_module
 from transformers import StoppingCriteria
 from eval.dispatch_openai_requests import dispatch_openai_chat_requesets, dispatch_openai_prompt_requesets
+import warnings
 
 
 class KeyWordsCriteria(StoppingCriteria):
@@ -275,6 +276,13 @@ def load_hf_tokenizer(
         token=os.getenv("HF_TOKEN", None),
     ):
         from transformers import AutoTokenizer
+
+        # Need to explicitly import the olmo tokenizer.
+        try:
+            from hf_olmo import OLMoTokenizerFast
+        except ImportError:
+            warnings.warn("OLMo not installed. Ignore if using a different model.")
+
         if not tokenizer_name_or_path:
             tokenizer_name_or_path = model_name_or_path
         try:

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -107,7 +107,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
             --data_dir /data/bbh \
             --save_dir /output/ \
             --use_vllm \
-            --model /model \
+            --model_name_or_path /model \
             --tokenizer_name_or_path /model \
             --max_num_examples_per_task 40 \
             --no_cot \
@@ -120,7 +120,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
             --data_dir /data/bbh \
             --save_dir /output/ \
             --use_vllm \
-            --model /model \
+            --model_name_or_path /model \
             --tokenizer_name_or_path /model \
             --max_num_examples_per_task 40 \
             --use_chat_format \
@@ -133,7 +133,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
             --max_num_examples 200 \
             --save_dir /output/ \
             --use_vllm \
-            --model /model \
+            --model_name_or_path /model \
             --tokenizer_name_or_path /model \
             --n_shot 8 \
             --no_cot \
@@ -147,7 +147,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
             --max_num_examples 200 \
             --save_dir /output/ \
             --use_vllm \
-            --model /model \
+            --model_name_or_path /model \
             --tokenizer_name_or_path /model \
             --n_shot 8 \
             --use_chat_format \
@@ -162,7 +162,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
             --max_context_length 512 \
             --save_dir /output/ \
             --use_vllm \
-            --model /model \
+            --model_name_or_path /model \
             --tokenizer_name_or_path /model \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
@@ -177,7 +177,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
             --max_context_length 512 \
             --save_dir /output/ \
             --use_vllm \
-            --model /model \
+            --model_name_or_path /model \
             --tokenizer_name_or_path /model \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
@@ -191,7 +191,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
             --temperature 0.1 \
             --save_dir /output/ \
             --use_vllm \
-            --model /model \
+            --model_name_or_path /model \
             --tokenizer_name_or_path /model
         '''
     elif experiment_group == "codex_eval_temp_0.8":
@@ -203,7 +203,7 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
             --temperature 0.8 \
             --save_dir /output/ \
             --use_vllm \
-            --model /model \
+            --model_name_or_path /model \
             --tokenizer_name_or_path /model
         '''
     elif experiment_group == "trutufulqa":
@@ -260,10 +260,11 @@ for model_info, experiment_group in itertools.product(models, experiment_groups)
     if model_info[2] is not None:
         # extract existing model path
         model_name_or_path = re.search("--model_name_or_path (\S+)", d['tasks'][0]['arguments'][0]).group(1)
-        # replace the model path with the checkpoint subfolder
-        d['tasks'][0]['arguments'] = [d['tasks'][0]['arguments'][0].replace(model_name_or_path, model_name_or_path+"/"+model_info[2])]
-        # replace the tokenizer path with the checkpoint subfolder
-        tokenizer_name_or_path = re.search("--tokenizer_name_or_path (\S+)", d['tasks'][0]['arguments'][0]).group(1)
+        # replace the model path with the checkpoint subfolder. 
+        d['tasks'][0]['arguments'] = [d['tasks'][0]['arguments'][0].replace(model_name_or_path, model_name_or_path+"/"+model_info[2], 1)]
+        # NOTE: We don't change the tokenizer subfolder, because by default the
+        # tokenizer is only saved to the top-level output dir. That's why we call
+        # `str.replace(..., 1)` above; this only replaces the first match.
 
     # for vanilla_lm, remove the chat formatting function
     if model_info[3] == "vanilla_lm":

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -12,6 +12,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--workspace", type=str, default="hamishivi")
 parser.add_argument("--model_name", type=str, default="hf-opt-7B")
 parser.add_argument("--location", type=str, default=None)
+parser.add_argument("--beaker_image", type=str, default=None, help="If given, use this Beaker image.")
 parser.add_argument("--beaker_subfolder", type=str, default=None)
 parser.add_argument("--cluster", nargs='+', default=["ai2/allennlp-cirrascale", "ai2/general-cirrascale", "ai2/general-cirrascale-a100-80g-ib", "ai2/mosaic-cirrascale-a100", "ai2/s2-cirrascale-l40"])
 parser.add_argument("--is_tuned", action="store_true")
@@ -33,6 +34,10 @@ if cluster[0] == "all":
 d1['tasks'][0]['constraints']['cluster'] = cluster
 d1['tasks'][0]['context']['priority'] = args.priority
 d1['tasks'][0]['resources']['gpuCount'] = 1
+
+# Use a different image if requested.
+if args.beaker_image is not None:
+    d1['tasks'][0]['image']['beaker'] = args.beaker_image
 
 # modify here for different set of experiments
 experiment_groups = [


### PR DESCRIPTION
Fixes some bugs to enable evaluation of models stored in subfolders. Changes are as follows:

- Fixes inconsistency between `model_name_or_path` vs. `model` as a command line arg, and similarly for `tokenizer_name_or_path` vs. `tokenizer`; the `_name_or_path` version are used in the actual eval scripts, but in the `yaml` template and and at some places in the `submit_eval_jobs` script, `model` and `tokenizer` are used instead. I made it consistent to always use `model_name_or_path`, and `tokenizer_name_or_path`. Previously, some of the code attempted to change `model` to a subdirectory, which caused an error.
- Makes it so that passing a subdirectory changes the `model_name_or_path` but not `tokenizer_name_or_path`. We want this because the training code by default doesn't dump a separate tokenizer for each subdirectory, it only saves one to the top level. The current behavior caused an error because it couldn't find the tokenizer.
- Explicitly imports `OlmoTokenizerFast` in `utils.py`. Without this import, HF can't find the OLMo tokenizer and throws an error.

As far as I can tell things work now; I ran some evals and the code seems to properly find model subdirectories and is able to evaluate.