### PR TITLE
add the parameter "tokenizer_mode" when using the vllm.LLM() function

### DIFF
--- a/eval/alpaca_farm/run_eval.py
+++ b/eval/alpaca_farm/run_eval.py
@@ -33,6 +33,7 @@ def main(args):
             model = vllm.LLM(
                 model=args.model_name_or_path,
                 tokenizer=args.tokenizer_name_or_path if args.tokenizer_name_or_path is not None else args.model_name_or_path,
+                tokenizer_mode="slow" if args.use_slow_tokenizer else "auto",
                 tensor_parallel_size=torch.cuda.device_count(),
             )
             

--- a/scripts/eval/alpaca_farm.sh
+++ b/scripts/eval/alpaca_farm.sh
@@ -6,6 +6,7 @@ export IS_ALPACA_EVAL_2=False
 # use vllm for generation
 python -m eval.alpaca_farm.run_eval \
     --model_name_or_path ../checkpoints/tulu_v1_7B/ \
+    --tokenizer_name_or_path ../checkpoints/tulu_v1_7B/ \
     --save_dir results/alpaca_farm/tulu_v1_7B/ \
     --eval_batch_size 20 \
     --use_vllm \
@@ -16,6 +17,7 @@ python -m eval.alpaca_farm.run_eval \
 # use normal huggingface generation function
 python -m eval.alpaca_farm.run_eval \
     --model_name_or_path ../checkpoints/tulu_v1_7B/ \
+    --tokenizer_name_or_path ../checkpoints/tulu_v1_7B/ \
     --save_dir results/alpaca_farm/tulu_v1_7B/ \
     --eval_batch_size 20 \
     --use_chat_format \


### PR DESCRIPTION
Some tokens have different "tokenized ids" in fast and slow modes, so we need to specify the parameter "tokenizer_mode" while loading the model with vllm.