### PR TITLE
Reorder final save items to fix olmo saving

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -836,14 +836,14 @@ def main():
                 output_dir = os.path.join(args.output_dir, output_dir)
             save_with_accelerate(accelerator, model, tokenizer, output_dir, args)
 
-    if args.with_tracking:
-        accelerator.end_training()
-
     if args.output_dir is not None:
-        accelerator.wait_for_everyone()
         if accelerator.is_main_process:
             tokenizer.save_pretrained(args.output_dir)
         save_with_accelerate(accelerator, model, tokenizer, args.output_dir, args)
+
+    accelerator.wait_for_everyone()
+    if args.with_tracking:
+        accelerator.end_training()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I did a little messing around and this seemed to make olmo saving work. Not sure why because I was unable to trace the processes to see the locations of hangs (this is a beaker issue, see https://github.com/allenai/reconfig/issues/2337). 

I tested and this didn't break llama 2 7b saving.

Should fix #123.