### PR TITLE
Add MBPP+ and HumanEval+

### DIFF
--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -44,7 +44,8 @@ def main(args):
         else:
             print(f"Could not find HumanEvalPack file at {args.data_file_hep}, which will result in significantly worse performance. You can download it at https://hf.co/datasets/bigcode/humanevalpack/blob/main/data/python/data/humanevalpack.jsonl")
             instructions_dict = None
-            answer = "Here is the completed function:\n\n\n"
+            answer = "Here is the completed function:\n\n\n```python\n"
+            stop_sequences.append("\n```")
 
         def apply_chat_format(tokenizer, inst, suffix):
             messages = [{"role": "user", "content": inst}]

--- a/eval/mbpp/evaluation.py
+++ b/eval/mbpp/evaluation.py
@@ -1,0 +1,92 @@
+import itertools
+import os
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import numpy as np
+from eval.mbpp.execution import check_correctness 
+
+# https://github.com/bigcode-project/bigcode-evaluation-harness/blob/main/bigcode_eval/tasks/custom_metrics/code_eval.py#L129
+
+_WARNING = """
+################################################################################
+                                  !!!WARNING!!!
+################################################################################
+The "code_eval" metric executes untrusted model-generated code in Python.
+Although it is highly unlikely that model-generated code will do something
+overtly malicious in response to this test suite, model-generated code may act
+destructively due to a lack of model capability or alignment.
+Users are strongly encouraged to sandbox this evaluation suite so that it
+does not perform destructive actions on their host or network. For more
+information on how OpenAI sandboxes its code, see the paper "Evaluating Large
+Language Models Trained on Code" (https://arxiv.org/abs/2107.03374).
+
+Once you have read this disclaimer and taken appropriate precautions,
+set the environment variable HF_ALLOW_CODE_EVAL="1". Within Python you can to this
+with:
+
+>>> import os
+>>> os.environ["HF_ALLOW_CODE_EVAL"] = "1"
+
+################################################################################\
+"""
+
+def compute_code_eval(predictions, k=[1, 10, 100], num_workers=4, timeout=3.0):
+    """Returns the scores"""
+
+    if os.getenv("HF_ALLOW_CODE_EVAL", 0) != "1":
+        raise ValueError(_WARNING)
+
+    if os.name == "nt":
+        raise NotImplementedError("This metric is currently not supported on Windows.")
+
+    with ThreadPoolExecutor(max_workers=num_workers) as executor:
+        futures = []
+        completion_id = Counter()
+        n_samples = 0
+        results = defaultdict(list)
+
+        for sample in predictions:
+            test_program = sample['completion'] + "\n" + sample['test_cases']
+            args = (test_program, timeout, sample['task_id'], completion_id[sample['task_id']])
+            future = executor.submit(check_correctness, *args)
+            futures.append(future)
+            completion_id[sample['task_id']] += 1
+            n_samples += 1
+
+        for future in as_completed(futures):
+            result = future.result()
+            results[result["task_id"]].append((result["completion_id"], result))
+    total, correct = [], []
+    for result in results.values():
+        result.sort()
+        passed = [r[1]["passed"] for r in result]
+        total.append(len(passed))
+        correct.append(sum(passed))
+    total = np.array(total)
+    correct = np.array(correct)
+
+    ks = k
+    if not isinstance(ks, (list, tuple)):
+        ks = [ks]
+    pass_at_k = {f"pass@{k}": estimate_pass_at_k(total, correct, k).mean() for k in ks if (total >= k).all()}
+
+    return pass_at_k, results
+
+
+def estimate_pass_at_k(num_samples, num_correct, k):
+    """Estimates pass@k of each problem and returns them in an array."""
+
+    def estimator(n: int, c: int, k: int) -> float:
+        """Calculates 1 - comb(n - c, k) / comb(n, k)."""
+        if n - c < k:
+            return 1.0
+        return 1.0 - np.prod(1.0 - k / np.arange(n - c + 1, n + 1))
+
+    if isinstance(num_samples, int):
+        num_samples_it = itertools.repeat(num_samples, len(num_correct))
+    else:
+        assert len(num_samples) == len(num_correct)
+        num_samples_it = iter(num_samples)
+
+    return np.array([estimator(int(n), int(c), k) for n, c in zip(num_samples_it, num_correct)])

--- a/eval/mbpp/execution.py
+++ b/eval/mbpp/execution.py
@@ -1,0 +1,236 @@
+# Copyright 2020 The HuggingFace Datasets Authors and the current dataset script contributor.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This code is adapted from OpenAI's release
+# https://github.com/openai/human-eval/blob/master/human_eval/execution.py
+
+import contextlib
+import faulthandler
+import io
+import multiprocessing
+import os
+import platform
+import signal
+import tempfile
+
+
+def check_correctness(check_program, timeout, task_id, completion_id):
+    """
+    Evaluates the functional correctness of a completion by running the test
+    suite provided in the problem.
+
+    :param completion_id: an optional completion ID so we can match
+        the results later even if execution finishes asynchronously.
+    """
+    manager = multiprocessing.Manager()
+    result = manager.list()
+
+    p = multiprocessing.Process(target=unsafe_execute, args=(check_program, result, timeout))
+    p.start()
+    p.join(timeout=timeout + 1)
+    if p.is_alive():
+        p.kill()
+
+    if not result:
+        result.append("timed out")
+
+    return dict(
+        task_id=task_id,
+        passed=result[0] == "passed",
+        result=result[0],
+        completion_id=completion_id,
+    )
+
+
+def unsafe_execute(check_program, result, timeout):
+
+    with create_tempdir():
+
+        # These system calls are needed when cleaning up tempdir.
+        import os
+        import shutil
+
+        rmtree = shutil.rmtree
+        rmdir = os.rmdir
+        chdir = os.chdir
+
+        # Disable functionalities that can make destructive changes to the test.
+        reliability_guard()
+
+        # Run program.
+        try:
+            exec_globals = {}
+            with swallow_io():
+                with time_limit(timeout):
+                    exec(check_program, exec_globals)
+            result.append("passed")
+        except TimeoutException:
+            result.append("timed out")
+        except BaseException as e:
+            result.append(f"failed: {e}")
+
+        # Needed for cleaning up.
+        shutil.rmtree = rmtree
+        os.rmdir = rmdir
+        os.chdir = chdir
+
+
+@contextlib.contextmanager
+def time_limit(seconds):
+    def signal_handler(signum, frame):
+        raise TimeoutException("Timed out!")
+
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+    signal.signal(signal.SIGALRM, signal_handler)
+    try:
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+
+
+@contextlib.contextmanager
+def swallow_io():
+    stream = WriteOnlyStringIO()
+    with contextlib.redirect_stdout(stream):
+        with contextlib.redirect_stderr(stream):
+            with redirect_stdin(stream):
+                yield
+
+
+@contextlib.contextmanager
+def create_tempdir():
+    with tempfile.TemporaryDirectory() as dirname:
+        with chdir(dirname):
+            yield dirname
+
+
+class TimeoutException(Exception):
+    pass
+
+
+class WriteOnlyStringIO(io.StringIO):
+    """StringIO that throws an exception when it's read from"""
+
+    def read(self, *args, **kwargs):
+        raise OSError
+
+    def readline(self, *args, **kwargs):
+        raise OSError
+
+    def readlines(self, *args, **kwargs):
+        raise OSError
+
+    def readable(self, *args, **kwargs):
+        """Returns True if the IO object can be read."""
+        return False
+
+
+class redirect_stdin(contextlib._RedirectStream):  # type: ignore
+    _stream = "stdin"
+
+
+@contextlib.contextmanager
+def chdir(root):
+    if root == ".":
+        yield
+        return
+    cwd = os.getcwd()
+    os.chdir(root)
+    try:
+        yield
+    except BaseException as exc:
+        raise exc
+    finally:
+        os.chdir(cwd)
+
+
+def reliability_guard(maximum_memory_bytes=None):
+    """
+    This disables various destructive functions and prevents the generated code
+    from interfering with the test (e.g. fork bomb, killing other processes,
+    removing filesystem files, etc.)
+
+    WARNING
+    This function is NOT a security sandbox. Untrusted code, including, model-
+    generated code, should not be blindly executed outside of one. See the
+    Codex paper for more information about OpenAI's code sandbox, and proceed
+    with caution.
+    """
+
+    if maximum_memory_bytes is not None:
+        import resource
+
+        resource.setrlimit(resource.RLIMIT_AS, (maximum_memory_bytes, maximum_memory_bytes))
+        resource.setrlimit(resource.RLIMIT_DATA, (maximum_memory_bytes, maximum_memory_bytes))
+        if not platform.uname().system == "Darwin":
+            resource.setrlimit(resource.RLIMIT_STACK, (maximum_memory_bytes, maximum_memory_bytes))
+
+    faulthandler.disable()
+
+    import builtins
+
+    builtins.exit = None
+    builtins.quit = None
+
+    import os
+
+    os.environ["OMP_NUM_THREADS"] = "1"
+
+    os.kill = None
+    os.system = None
+    os.putenv = None
+    os.remove = None
+    os.removedirs = None
+    os.rmdir = None
+    os.fchdir = None
+    os.setuid = None
+    os.fork = None
+    os.forkpty = None
+    os.killpg = None
+    os.rename = None
+    os.renames = None
+    os.truncate = None
+    os.replace = None
+    os.unlink = None
+    os.fchmod = None
+    os.fchown = None
+    os.chmod = None
+    os.chown = None
+    os.chroot = None
+    os.fchdir = None
+    os.lchflags = None
+    os.lchmod = None
+    os.lchown = None
+    os.getcwd = None
+    os.chdir = None
+
+    import shutil
+
+    shutil.rmtree = None
+    shutil.move = None
+    shutil.chown = None
+
+    import subprocess
+
+    subprocess.Popen = None  # type: ignore
+
+    __builtins__["help"] = None
+
+    import sys
+
+    sys.modules["ipdb"] = None
+    sys.modules["joblib"] = None
+    sys.modules["resource"] = None
+    sys.modules["psutil"] = None
+    sys.modules["tkinter"] = None

--- a/eval/mbpp/mbpp.py
+++ b/eval/mbpp/mbpp.py
@@ -1,0 +1,211 @@
+from abc import ABC, abstractmethod
+from warnings import warn
+import os
+
+from datasets import load_dataset
+
+from evaluation import compute_code_eval
+
+class Task(ABC):
+    """A task represents an entire benchmark including its dataset, problems,
+    answers, generation settings and evaluation methods.
+    """
+
+    # The name of the `Task` benchmark as denoted in the HuggingFace datasets Hub
+    DATASET_PATH: str = None
+
+    # The name of a subset within `DATASET_PATH`.
+    DATASET_NAME: str = None
+
+    def __init__(self, stop_words=None, requires_execution=True):
+        """
+        :param stop_words: list
+            list of stop words if the generation uses a stopping criteria during generation
+        :param requires_execution: bool
+            wheter the task requires code execution during evaluation or not
+        """
+        self.stop_words = stop_words
+        self.requires_execution = requires_execution
+        try:
+            self.dataset = load_dataset(path=self.DATASET_PATH, name=self.DATASET_NAME)
+        except Exception as e:
+            warn(
+                f"Loading the dataset failed with {str(e)}. This task will use a locally downloaded dataset, not from the HF hub. \
+                This is expected behavior for the DS-1000 benchmark but not for other benchmarks!"
+            )
+
+    @abstractmethod
+    def get_dataset(self):
+        """Returns dataset for the task or an iterable of any object, that get_prompt can handle"""
+        return []
+
+    def fewshot_examples(self):
+        """Loads and returns the few-shot examples for the task if they exist."""
+        pass
+
+    @abstractmethod
+    def get_prompt(self, doc):
+        """Builds the prompt for the LM to generate from.
+        :param doc: dict[str: str]
+            sample from the test dataset
+        """
+        pass
+
+    @abstractmethod
+    def get_reference(self, doc):
+        """Builds the reference solution for the doc.
+        :param doc: dict[str: str]
+            sample from the test dataset
+        """
+        pass
+
+    @abstractmethod
+    def postprocess_generation(self, generation, idx):
+        """Defines the postprocessing for a LM generation.
+        :param generation: str
+            code generation from LM
+        :param idx: int
+            index of doc in the dataset to which the generation belongs
+        """
+        pass
+
+    @abstractmethod
+    def process_results(self, generations, references):
+        """Takes the list of LM generations and evaluates them against ground truth references,
+        returning the metric for the generations as in {"metric_name": result}.
+        :param generations: list(list(str))
+            list of lists containing generations
+        :param references: list(str)
+            list of str containing refrences
+        :return: dict[str: float]
+        """
+        pass
+
+    @staticmethod
+    def _stop_at_stop_token(decoded_string, stop_tokens):
+        """
+        Produces the prefix of decoded_string that ends at the first occurrence of
+        a stop_token.
+        WARNING: the decoded_string *must not* include the prompt, which may have stop tokens
+        itself.
+        """
+        min_stop_index = len(decoded_string)
+        for stop_token in stop_tokens:
+            stop_index = decoded_string.find(stop_token)
+            if stop_index != -1 and stop_index < min_stop_index:
+                min_stop_index = stop_index
+        return decoded_string[:min_stop_index]
+
+
+class MBPP(Task):
+    """A task represents an entire benchmark including its dataset, problems,
+    answers, generation settings and evaluation methods.
+    """
+
+    DATASET_PATH = "mbpp"
+
+    def __init__(self):
+        super().__init__(
+            stop_words=["\nclass", "\nassert", '\n"""', "\nprint", "\nif", "\n<|/", "\n```"],
+            requires_execution=True,
+        )
+
+    def get_dataset(self):
+        """Returns dataset for the task or an iterable of any object, that get_prompt can handle"""
+        dataset = self.dataset["test"]
+        # the wrong split of mbpp can be loaded with old datasets cache
+        assert (
+            len(dataset) == 500
+        ), "please ensure you have the latest version of MBPP dataset, try deleting its old cache"
+        return dataset
+
+    def get_prompt(self, doc):
+        """Builds the prompt for the LM to generate from.
+        MBPP prompt is built following to InCoder (Fried et al.) approach
+        prompt = docstring that includes one test
+        """
+        description = doc["text"]
+        test_example = doc["test_list"][0]
+        prompt = f'"""\n{description}\n{test_example}\n"""\n'
+        return prompt
+
+    def get_reference(self, doc):
+        """Builds the reference solution for the doc (sample from the test dataset)."""
+        return "\n".join(doc["test_list"])
+
+
+    def postprocess_generation(self, generation, idx):
+        """Defines the postprocessing for a LM generation.
+        :param generation: str
+            code generation from LM
+        :param idx: int
+            index of doc in the dataset to which the generation belongs
+        """
+        prompt = self.get_prompt(self.dataset["test"][idx])
+        generation = generation[len(prompt) :]
+        return prompt + self._stop_at_stop_token(generation, self.stop_words)
+
+    def process_results(self, generations, references):
+        """Takes the list of LM generations and evaluates them against ground truth references,
+        returning the metric for the generations.
+        :param generations: list(list(str))
+            list of lists containing generations
+        :param references: list(str)
+            list of str containing refrences
+        """
+        results, _ = compute_code_eval(
+            references=references,
+            predictions=generations,
+        )
+        return results
+
+
+class MBPPPlus(MBPP):
+    """A task represents an entire benchmark including its dataset, problems,
+    answers, generation settings and evaluation methods.
+    """
+
+    DATASET_PATH = "evalplus/mbppplus"
+
+    def get_prompt(self, doc):
+        """Builds the prompt for the LM to generate from.
+        MBPP prompt is built following to InCoder (Fried et al.) approach
+        prompt = docstring that includes one test
+        """
+        description = doc["prompt"]  # sanitized testset use "prompt" instead of "text"
+        test_example = doc["test_list"][0]
+        prompt = f'"""\n{description}\n{test_example}\n"""\n'
+        return prompt
+
+    # NOTE(@ganler): MBPP+ extends the original MBPP jsonl data with a "test" field which
+    #                includes the testing code ready for execution. Note the "test" field
+    #                is different from HumanEval(+) which further requires a `check` func
+    def get_reference(self, doc):
+        """Builds the reference solution for the doc (sample from the test dataset)."""
+        use_mbpp_tests = os.getenv("MBBPPLUS_USE_MBPP_TESTS", "0")
+        if use_mbpp_tests == "1":
+            return "\n".join(doc["test_list"])
+        return "\n" + doc["test"]
+
+    def get_dataset(self):
+        """Returns dataset for the task or an iterable of any object, that get_prompt can handle"""
+        dataset = self.dataset["test"]
+        assert (
+            len(dataset) == 399
+        ), "MBPP+ only has 399 problems. Please retry by deleting its old cache"
+        return dataset
+
+    def process_results(self, generations, references):
+        """Takes the list of LM generations and evaluates them against ground truth references,
+        returning the metric for the generations.
+        :param generations: list(list(str))
+            list of lists containing generations
+        :param references: list(str)
+            list of str containing refrences
+        """
+        results, _ = compute_code_eval(
+            references=references,
+            predictions=generations,
+            timeout=10.0,  # 10s timeout
+        )
+        return results

--- a/eval/mbpp/run_eval.py
+++ b/eval/mbpp/run_eval.py
@@ -50,7 +50,7 @@ def main(args):
     else:
         prompts = [example["prompt"] + example['code'].split(":")[0] for example in test_data]
     
-    stop_sequences = ['```']
+    stop_sequences = ['```'] + args.additional_stop_sequence
         
     if not args.results_file:
         if args.model_name_or_path:
@@ -259,6 +259,13 @@ if __name__ == "__main__":
         type=str, 
         default="minimal_multitask.eval.templates.create_prompt_with_tulu_chat_format", 
         help="The function to use to create the chat format. This function will be dynamically imported. Please see examples in `eval/templates.py`."
+    )
+    parser.add_argument(
+        '--additional_stop_sequence',
+        type=str,
+        nargs="+",
+        default=[],
+        help="Additional stop sequences to use when generating completions. Useful for e.g. llama-3-instruct."
     )
     parser.add_argument("--results_file", type=str)
     args = parser.parse_args()

--- a/eval/mbpp/run_eval.py
+++ b/eval/mbpp/run_eval.py
@@ -1,0 +1,268 @@
+import argparse
+import os
+import json
+import random
+import torch
+import vllm
+from datasets import load_dataset
+from eval.utils import (
+    generate_completions, 
+    load_hf_lm, 
+    query_openai_chat_model,
+    dynamic_import_function,
+    load_hf_tokenizer,
+)
+from eval.codex_humaneval.data import write_jsonl
+from eval.mbpp.evaluation import compute_code_eval
+
+
+def main(args):
+    random.seed(42)
+
+    if not os.path.exists(args.save_dir):
+        os.makedirs(args.save_dir, exist_ok=True)
+
+    dataset = load_dataset("evalplus/mbppplus")['test']
+    dataset.shuffle(seed=42)
+    # Always head-out first 100 examples
+    if args.max_num_examples is None:
+        args.max_num_examples = len(dataset) - 100
+    if args.max_num_examples > len(dataset) - 100:
+        Warning("The number of examples is larger than the test set size. Will use the maximum number of examples.")
+        args.max_num_examples = len(dataset) - 100
+    test_data = dataset.select(range(100, min(100+args.max_num_examples, len(dataset))))
+    print("Number of examples:", len(test_data))
+    
+    if args.use_chat_format:
+        prompts = []
+        chat_formatting_function = dynamic_import_function(args.chat_formatting_function)
+        answer = "Here is the completed function:\n\n\n```python\n"
+
+        def apply_chat_format(tokenizer, inst, suffix):
+            messages = [{"role": "user", "content": inst}]
+            prompt = chat_formatting_function(messages, tokenizer, add_bos=False)
+            prefix = "" if prompt[-1] in ["\n", " "] else " "
+            return prompt + prefix + suffix
+            
+        instruction = "Complete the following python function.\n\n\n"
+        for example in test_data:
+            prompts.append((instruction + example["prompt"] + example['code'].split(":")[0], answer))   
+    else:
+        prompts = [example["prompt"] + example['code'].split(":")[0] for example in test_data]
+    
+    stop_sequences = ['```']
+        
+    if not args.results_file:
+        if args.model_name_or_path:
+            tokenizer = load_hf_tokenizer(
+                model_name_or_path=args.model_name_or_path,
+                tokenizer_name_or_path=args.tokenizer_name_or_path if args.tokenizer_name_or_path else args.model_name_or_path,
+                use_fast_tokenizer=not args.use_slow_tokenizer,
+            )
+            if args.use_vllm:
+                model = vllm.LLM(
+                    model=args.model_name_or_path,
+                    tokenizer=args.tokenizer_name_or_path if args.tokenizer_name_or_path else args.model_name_or_path,
+                    tokenizer_mode="slow" if args.use_slow_tokenizer else "auto",
+                    tensor_parallel_size=torch.cuda.device_count(),
+                )
+                sampling_params = vllm.SamplingParams(
+                    n=args.unbiased_sampling_size_n,
+                    temperature=args.temperature,
+                    max_tokens=512,
+                    stop=stop_sequences,
+                )
+                if args.use_chat_format:
+                    prompts = [apply_chat_format(tokenizer, inst, suffix) for (inst, suffix) in prompts]
+                generations = model.generate(prompts, sampling_params)
+                outputs = [output.text for it in generations for output in it.outputs]
+                # Note: early vllm might ignore the first space in the generation, because the processing of _token.
+                # This is not a problem for chat, but for codex, we need to keep the first space.
+                # Be careful here!
+                outputs = [output for output in outputs]
+            else:
+                print("Loading model and tokenizer...")
+                model = load_hf_lm(
+                    model_name_or_path=args.model_name_or_path, 
+                    load_in_8bit=args.load_in_8bit, 
+                    # device map is determined by the number of gpus available.
+                    device_map="balanced_low_0" if torch.cuda.device_count() > 1 else "auto",
+                    gptq_model=args.gptq,
+                )
+                from transformers import GPTNeoXForCausalLM, OPTForCausalLM
+                if isinstance(model, GPTNeoXForCausalLM) or isinstance(model, OPTForCausalLM):
+                    tokenizer.model_max_length = model.config.max_position_embeddings
+                    print("Set tokenizer.model_max_length to model.config.max_position_embeddings: {}".format(model.config.max_position_embeddings))
+                
+                if args.use_chat_format:
+                    prompts = [apply_chat_format(tokenizer, inst, suffix) for (inst, suffix) in prompts]
+
+                # Because many tokenizers will treat the word after space differently from the original word alone, 
+                # to be consistent, we add a space before tokenization and remove it after tokenization.
+                stop_sequences = [tokenizer.encode(" " + x, add_special_tokens=False)[1:] for x in stop_sequences]
+                outputs_per_sampling_iter = []
+                for sampling_iter in range(args.unbiased_sampling_size_n):
+                    print(f"Sampling iter: {sampling_iter} / {args.unbiased_sampling_size_n}")
+                    sampling_outputs = generate_completions(
+                        model=model,
+                        tokenizer=tokenizer,
+                        prompts=prompts,
+                        max_new_tokens=512,
+                        batch_size=args.eval_batch_size,
+                        stop_id_sequences=stop_sequences,
+                        num_return_sequences=1,  # we don't use the hf num_return_sequences, because otherwise the real batch size will be multiplied by it and often cause oom.
+                        do_sample=True,  # if only pass@1 is evaluated, we do greedy decoding.
+                        temperature=args.temperature,
+                    )
+                    outputs_per_sampling_iter.append(sampling_outputs)
+                # regroup the outputs to match the number of test data.
+                outputs = []
+                for i in range(len(prompts)):
+                    for j in range(args.unbiased_sampling_size_n):
+                        outputs.append(outputs_per_sampling_iter[j][i])
+        else:
+            instances = [{
+                "id": examle["task_id"], 
+                "prompt": "Complete the following python function. Please only output the code for the completed function.\n\n\n" + prompt,
+            } for examle, prompt in zip(test_data, prompts)]
+            results = query_openai_chat_model(
+                engine=args.openai_engine,
+                instances=instances,
+                output_path=os.path.join(args.save_dir, "openai_query_results.jsonl"),
+                batch_size=args.eval_batch_size,
+                top_p=0.95,
+                temperature=args.temperature,
+                n=args.unbiased_sampling_size_n,
+            )
+            outputs = []
+            for result in results:
+                for choice in result["response_metadata"]["choices"]:
+                    outputs.append(choice["message"]["content"])
+    else:
+        with open(args.results_file, "r") as f:
+            outputs = [json.loads(line)['completion'] for line in f]
+
+    # duplicates test data to match the number of outputs.
+    duplicate_test_data = [
+        example for example in test_data for _ in range(args.unbiased_sampling_size_n)
+    ]
+    duplicate_prompts = [
+        prompt for prompt in prompts for _ in range(args.unbiased_sampling_size_n)
+    ]
+    # assert len(duplicate_test_data) == len(outputs)
+    predictions = [{"task_id": example["task_id"], "prompt": prompt, "completion": output, "test_cases": example['test']} 
+                   for example, prompt, output in zip(duplicate_test_data, duplicate_prompts, outputs)]
+    predictions_noresult = [{"task_id":pred["task_id"], "prompt":pred['prompt'], "completion": pred['completion']} for pred in predictions]
+    if args.use_chat_format:
+        prediction_save_path = os.path.join(args.save_dir, "mbpp_chat_predictions.jsonl")
+    else:
+        prediction_save_path = os.path.join(args.save_dir, "mbpp_predictions.jsonl")
+    write_jsonl(prediction_save_path, predictions_noresult)
+    pass_at_k_results, results = compute_code_eval(
+        predictions=predictions,
+        k=args.eval_pass_at_ks,
+        num_workers=64,
+        timeout=10.0
+    )
+
+    print(pass_at_k_results)
+    if args.use_chat_format:
+        with open(os.path.join(args.save_dir, "metrics.json"), "w") as fout:
+            json.dump(pass_at_k_results, fout)
+    else:
+        with open(os.path.join(args.save_dir, "metrics.json"), "w") as fout:
+            json.dump(pass_at_k_results, fout)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--model_name_or_path", 
+        type=str, 
+        default=None, 
+        help="If specified, we will load the model to generate the predictions."
+    )
+    parser.add_argument(
+        "--tokenizer_name_or_path", 
+        type=str, 
+        default=None, 
+        help="If specified, we will load the tokenizer from here."
+    )
+    parser.add_argument(
+        "--use_slow_tokenizer",
+        action="store_true",
+        help="If given, we will use the slow tokenizer."
+    )
+    parser.add_argument(
+        "--openai_engine", 
+        type=str, 
+        default=None, 
+        help="If specified, we will use the OpenAI API to generate the predictions."
+    )
+    parser.add_argument(
+        "--save_dir", 
+        type=str, 
+        default="results/codex_eval", 
+        help="Directory to save the results."
+    )
+    parser.add_argument(
+        "--max_num_examples",
+        type=int,
+    )
+    parser.add_argument(
+        "--eval_batch_size", 
+        type=int, 
+        default=1, 
+        help="Batch size for evaluation."
+    )
+    parser.add_argument(
+        "--eval_pass_at_ks", 
+        nargs="+", 
+        type=int, 
+        default=[1], 
+        help="Multiple k's that we will report pass@k."
+    )
+    parser.add_argument(
+        "--unbiased_sampling_size_n", 
+        type=int, 
+        default=20,
+        help="Codex HumanEval requires `n` sampled generations per prompt, to estimate the unbiased pass@k. "
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.1,
+        help="Temperature for sampling. This is should be low for evaluating smaller pass@k, and high for larger pass@k."
+    )
+    parser.add_argument(
+        "--load_in_8bit", 
+        action="store_true", 
+        help="Load model in 8bit mode, which will reduce memory and speed up inference."
+    )
+    parser.add_argument(
+        "--gptq", 
+        action="store_true", 
+        help="If given, we're evaluating a 4-bit quantized GPTQ model."
+    )
+    parser.add_argument(
+        "--use_vllm",
+        action="store_true", 
+        help="If given, we will use the vllm library, which will likely increase the inference throughput."
+    )
+    parser.add_argument(
+        "--use_chat_format", 
+        action="store_true", 
+        help="If given, we will use the chat format for the prompts."
+    )
+    parser.add_argument(
+        "--chat_formatting_function", 
+        type=str, 
+        default="minimal_multitask.eval.templates.create_prompt_with_tulu_chat_format", 
+        help="The function to use to create the chat format. This function will be dynamically imported. Please see examples in `eval/templates.py`."
+    )
+    parser.add_argument("--results_file", type=str)
+    args = parser.parse_args()
+    # model_name_or_path and openai_engine cannot be both None or both not None.
+    assert (args.model_name_or_path is None) != (args.openai_engine is None), "Either model_name_or_path or openai_engine should be specified."
+    assert args.unbiased_sampling_size_n >= max(args.eval_pass_at_ks), "n should be larger than the largest k in eval_pass_at_ks."
+    main(args)

--- a/scripts/eval/codex_humaneval.sh
+++ b/scripts/eval/codex_humaneval.sh
@@ -31,6 +31,33 @@ python -m eval.codex_humaneval.run_eval \
     --data_file data/eval/codex_humaneval/HumanEval.jsonl.gz  \
     --data_file_hep data/eval/codex_humaneval/humanevalpack.jsonl  \
     --use_chat_format \
+    --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
+    --eval_pass_at_ks 1 5 10 20 \
+    --unbiased_sampling_size_n 20 \
+    --temperature 0.1 \
+    --save_dir results/codex_humaneval/tulu_7B_temp_0_1 \
+    --model ../checkpoints/tulu_7B/ \
+    --tokenizer ../checkpoints/tulu_7B/ \
+    --use_vllm
+
+# Evaluating tulu 7B model using temperature 0.1 to get the pass@1 score with chat format via HumanEvalPack
+# And use the HumanEval+ data for more rigorous evaluation.
+python -m eval.codex_humaneval.run_eval \
+    --data_file data/eval/codex_humaneval/HumanEvalPlus-OriginFmt.jsonl.gz  \
+    --data_file_hep data/eval/codex_humaneval/humanevalpack.jsonl  \
+    --use_chat_format \
+    --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
+    --eval_pass_at_ks 1 5 10 20 \
+    --unbiased_sampling_size_n 20 \
+    --temperature 0.1 \
+    --save_dir results/codex_humaneval/tulu_7B_temp_0_1 \
+    --model ../checkpoints/tulu_7B/ \
+    --tokenizer ../checkpoints/tulu_7B/ \
+    --use_vllm
+
+# you can also use humaneval+ without the HumanEvalPack data
+python -m eval.codex_humaneval.run_eval \
+    --data_file data/eval/codex_humaneval/HumanEvalPlus-OriginFmt.jsonl.gz  \
     --eval_pass_at_ks 1 5 10 20 \
     --unbiased_sampling_size_n 20 \
     --temperature 0.1 \

--- a/scripts/eval/mbpp.sh
+++ b/scripts/eval/mbpp.sh
@@ -1,5 +1,7 @@
 # Here we use 1 GPU for demonstration, but you can use multiple GPUs and larger eval_batch_size to speed up the evaluation.
 export CUDA_VISIBLE_DEVICES=0
+# you need to set the below to say you are okay with running llm-generated code on your machine...
+export HF_ALLOW_CODE_EVAL=1
 
 # Evaluating tulu 7B model using temperature 0.1 to get the pass@1 score
 python -m eval.mbpp.run_eval \

--- a/scripts/eval/mbpp.sh
+++ b/scripts/eval/mbpp.sh
@@ -1,0 +1,66 @@
+# Here we use 1 GPU for demonstration, but you can use multiple GPUs and larger eval_batch_size to speed up the evaluation.
+export CUDA_VISIBLE_DEVICES=0
+
+# Evaluating tulu 7B model using temperature 0.1 to get the pass@1 score
+python -m eval.mbpp.run_eval \
+    --use_chat_format \
+    --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
+    --eval_pass_at_ks 1 5 10 20 \
+    --unbiased_sampling_size_n 20 \
+    --temperature 0.1 \
+    --save_dir results/mbpp/tulu_7B_temp_0_1_nochat \
+    --model ../checkpoints/tulu_7B/ \
+    --tokenizer ../checkpoints/tulu_7B/ \
+    --use_vllm
+
+
+# Evaluating tulu 7B model using temperature 0.8 to get the pass@10 score
+python -m eval.mbpp.run_eval \
+    --use_chat_format \
+    --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
+    --eval_pass_at_ks 10 \
+    --unbiased_sampling_size_n 20 \
+    --temperature 0.8 \
+    --save_dir results/mbpp/tulu_7B_temp_0_8_nochat \
+    --model ../checkpoints/tulu_7B/ \
+    --tokenizer ../checkpoints/tulu_7B/ \
+    --use_vllm
+
+# Evaluating chatgpt using temperature 0.1 to get the pass@1 score
+python -m eval.mbpp.run_eval \
+    --eval_pass_at_ks 1 5 10 20 \
+    --unbiased_sampling_size_n 20 \
+    --temperature 0.1 \
+    --openai_engine "gpt-3.5-turbo-0301" \
+    --save_dir results/mbpp/chatgpt_temp_0.1/ \
+    --eval_batch_size 10
+
+
+# Evaluating chatgpt using temperature 0.8 to get the pass@10 score
+python -m eval.mbpp.run_eval \
+    --eval_pass_at_ks 1 5 10 20 \
+    --unbiased_sampling_size_n 20 \
+    --temperature 0.8 \
+    --openai_engine "gpt-3.5-turbo-0301" \
+    --save_dir results/mbpp/chatgpt_temp_0.8/ \
+    --eval_batch_size 10
+
+
+# Evaluating gpt4 using temperature 0.1 to get the pass@1 score
+python -m eval.mbpp.run_eval \
+    --eval_pass_at_ks 1 5 10 20 \
+    --unbiased_sampling_size_n 20 \
+    --temperature 0.1 \
+    --openai_engine "gpt-4-0314" \
+    --save_dir results/mbpp/gpt4_temp_0.1 \
+    --eval_batch_size 1
+
+
+# Evaluating gpt4 using temperature 0.8 to get the pass@10 score
+python -m eval.mbpp.run_eval \
+    --eval_pass_at_ks 1 5 10 20 \
+    --unbiased_sampling_size_n 20 \
+    --temperature 0.8 \
+    --openai_engine "gpt-4-0314" \
+    --save_dir results/mbpp/gpt4_temp_0.8 \
+    --eval_batch_size 1

--- a/scripts/prepare_eval_data.sh
+++ b/scripts/prepare_eval_data.sh
@@ -29,6 +29,9 @@ wget -P data/eval/gsm/ https://github.com/openai/grade-school-math/raw/master/gr
 wget -P data/eval/codex_humaneval https://github.com/openai/human-eval/raw/master/data/HumanEval.jsonl.gz
 wget -P data/eval/codex_humaneval https://huggingface.co/datasets/bigcode/humanevalpack/raw/main/data/python/data/humanevalpack.jsonl
 
+# HumanEval+
+wget -P data/eval/codex_humaneval https://github.com/evalplus/humanevalplus_release/releases/download/v0.1.9/HumanEvalPlus-OriginFmt.jsonl.gz
+
 # Alpaca Farm reference
 wget -P data/eval/alpaca_farm https://huggingface.co/datasets/hamishivi/alpaca-farm-davinci-003-2048-token/resolve/main/davinci_003_outputs.json
 

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -248,7 +248,7 @@ for experiment_group in experiment_groups:
         '''
     elif experiment_group == "mbpp_evalplus_temp_0.1":
         task_spec['arguments'][0] = '''
-            python -m eval.mbpp.run_eval \
+            HF_ALLOW_CODE_EVAL=1 python -m eval.mbpp.run_eval \
             --eval_pass_at_ks 1 5 10 20 \
             --unbiased_sampling_size_n 20 \
             --temperature 0.1 \
@@ -261,7 +261,7 @@ for experiment_group in experiment_groups:
         '''
     elif experiment_group == "mbpp_evalplus_temp_0.8":
         task_spec['arguments'][0] = '''
-            python -m eval.mbpp.run_eval \
+            HF_ALLOW_CODE_EVAL=1 python -m eval.mbpp.run_eval \
             --eval_pass_at_ks 1 5 10 20 \
             --unbiased_sampling_size_n 20 \
             --temperature 0.8 \

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -53,6 +53,10 @@ experiment_groups_default = [
     "tydiqa_no_context_1shot",
     "codex_eval_temp_0.1",
     "codex_eval_temp_0.8",
+    "codex_evalplus_temp_0.1",
+    "codex_evalplus_temp_0.8",
+    "mbpp_evalplus_temp_0.1",
+    "mbpp_evalplus_temp_0.8",
     "ifeval",
     "trutufulqa",
     "toxigen",
@@ -212,6 +216,61 @@ for experiment_group in experiment_groups:
             --use_vllm \
             --model_name_or_path /model \
             --tokenizer_name_or_path /model
+        '''
+    elif experiment_group == "codex_evalplus_temp_0.1":
+        task_spec['arguments'][0] = '''
+            python -m eval.codex_humaneval.run_eval \
+            --data_file /data/codex_humaneval/HumanEvalPlus-OriginFmt.jsonl.gz \
+            --eval_pass_at_ks 1 5 10 20 \
+            --unbiased_sampling_size_n 20 \
+            --temperature 0.1 \
+            --save_dir /output/ \
+            --use_vllm \
+            --model_name_or_path /model \
+            --tokenizer_name_or_path /model \
+            --use_chat_format \
+            --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
+        '''
+    elif experiment_group == "codex_evalplus_temp_0.8":
+        task_spec['arguments'][0] = '''
+            python -m eval.codex_humaneval.run_eval \
+            --data_file /data/codex_humaneval/HumanEvalPlus-OriginFmt.jsonl.gz \
+            --data_file_hep data/eval/codex_humaneval/humanevalpack.jsonl  \
+            --eval_pass_at_ks 1 5 10 20 \
+            --unbiased_sampling_size_n 20 \
+            --temperature 0.8 \
+            --save_dir /output/ \
+            --use_vllm \
+            --model_name_or_path /model \
+            --tokenizer_name_or_path /model \
+            --use_chat_format \
+            --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
+        '''
+    elif experiment_group == "mbpp_evalplus_temp_0.1":
+        task_spec['arguments'][0] = '''
+            python -m eval.mbpp.run_eval \
+            --eval_pass_at_ks 1 5 10 20 \
+            --unbiased_sampling_size_n 20 \
+            --temperature 0.1 \
+            --save_dir /output/ \
+            --use_vllm \
+            --model_name_or_path /model \
+            --tokenizer_name_or_path /model \
+            --use_chat_format \
+            --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
+        '''
+    elif experiment_group == "mbpp_evalplus_temp_0.8":
+        task_spec['arguments'][0] = '''
+            python -m eval.mbpp.run_eval \
+            --eval_pass_at_ks 1 5 10 20 \
+            --unbiased_sampling_size_n 20 \
+            --temperature 0.8 \
+            --save_dir /output/ \
+            --use_vllm \
+            --model_name_or_path /model \
+            --tokenizer_name_or_path /model \
+            --use_chat_format \
+            --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
         '''
     elif experiment_group == "ifeval":
         task_spec['arguments'][0] = '''


### PR DESCRIPTION
Adds humaneval+ data and mbpp+ eval from the [evalplus project](https://github.com/evalplus/evalplus), to give us some more rigorous code evaluations.

Thanks to @Nanami18 (Muru) for writing most of this, I just tweaked it for open instruct. Currently a draft until I properly test this. 

HumanEval plus is easy - just swap out the data source to the HumanEval+ released data, and it should work! It even works nicely with HumanEvalPack for better evaluation of instruction-tuned models. MBPP+ uses data from huggingface, so it has a slightly different setup.