### PR TITLE
Refactor GPU and batch size adjustment code.

### DIFF
--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -92,9 +92,8 @@ parser.add_argument(
     "--gpu_multiplier",
     default=None,
     type=int,
-    help="""Increase number of GPU's by this factor relative ot the default. If using 
-    80GB A100's or similar, set this to 2 for 30B or larger models. If not given, a 
-    reasonable default will be selected based on the model name.""",
+    help="""Increase number of GPU's by this factor relative to the default. If not 
+    given, a reasonable default will be selected based on the model name.""",
 )
 args = parser.parse_args()
 

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -6,6 +6,65 @@ import itertools
 from datetime import date
 import argparse
 
+
+########################################
+
+# Helper functions.
+
+def adjust_batch_size(task_spec, model_name, batch_size_reduction):
+    "Adjust batch size using heuristics that are good for A100-size GPUs."
+    reduce_by_2 = ["13B"]
+    reduce_by_4 = ["30B", "34B", "40B", "65B", "70B"]
+    # If not given, choose a value based on the model name.
+    if batch_size_reduction is None:
+        if any([pattern in model_name for pattern in reduce_by_2]):
+            batch_size_reduction = 2
+        elif any([pattern in model_name for pattern in reduce_by_4]):
+            batch_size_reduction = 4
+        else:
+            batch_size_reduction = 1
+
+    # Reduce accordingly.
+    if "--eval_batch_size" in task_spec['arguments'][0]:
+        original_batch_size = re.search("--eval_batch_size (\d+)", task_spec['arguments'][0]).group(1)
+        new_batch_size = max(1, int(original_batch_size) // batch_size_reduction)
+        task_spec['arguments'] = [task_spec['arguments'][0].replace("--eval_batch_size {}".format(original_batch_size), "--eval_batch_size {}".format(new_batch_size))]
+
+    return task_spec
+
+
+def adjust_gpus(task_spec, experiment_group, model_name, gpu_multiplier):
+    "Adjust GPU count using heuristics that are good for A100-size GPUs."
+    medium = ["30B", "34B"]
+    large = ["40B", "65B", "70B"]
+    # If not given, choose a value based on model name. 
+    if gpu_multiplier is None:
+        if any([pattern in model_name for pattern in medium]):
+            default_multiplier = 1
+            codex_multiplier = 2
+        elif any([pattern in model_name for pattern in large]):
+            default_multiplier = 2
+            codex_multiplier = 4
+        else:
+            default_multiplier = codex_multiplier = 1
+    else:
+        default_multiplier = gpu_multiplier
+        # If a gpu multiplier is given, double the gpus for Codex.
+        codex_multiplier = 2 * gpu_multiplier
+
+    # Increase accordingly. 
+    if "codex_eval" in experiment_group:
+        task_spec['resources']['gpuCount'] = codex_multiplier * task_spec['resources']['gpuCount']
+    else:
+        task_spec['resources']['gpuCount'] = default_multiplier * task_spec['resources']['gpuCount']
+
+    return task_spec
+
+    
+########################################
+
+# Launcher
+
 today = date.today().strftime("%m%d%Y")
 
 parser = argparse.ArgumentParser()
@@ -21,6 +80,22 @@ parser.add_argument("--priority", type=str, default="preemptible")
 parser.add_argument("--olmo", action="store_true", help="Pass this flag if evaluating an OLMo model and `olmo` isn't in the model name.")
 parser.add_argument("--experiments", type=str, nargs="+", default=None, help="Experiments to run, e.g., '--experiments mmlu_5shot gsm_cot'")
 parser.add_argument("--gsm_stop_at_double_newline", action="store_true", help="If given, stop generation at double newline for GSM8k.")
+parser.add_argument(
+    "--batch_size_reduction",
+    default=None,
+    type=int,
+    help="""Reduce batch size by this factor relative to the default. Setting 
+    this to 2 for 13B models and 4 for anything bigger is generally good. If not given,
+    a reasonable default will be selected based on the model name.""",
+)
+parser.add_argument(
+    "--gpu_multiplier",
+    default=None,
+    type=int,
+    help="""Increase number of GPU's by this factor relative ot the default. If using 
+    80GB A100's or similar, set this to 2 for 30B or larger models. If not given, a 
+    reasonable default will be selected based on the model name.""",
+)
 args = parser.parse_args()
 
 
@@ -66,7 +141,7 @@ experiment_groups = args.experiments or experiment_groups_default
 # or: name, path, None, tuned or base
 model_info = (args.model_name, args.location, args.beaker_subfolder, model_type)
 
-#--------------- experiments about number of supervision tasks -------------------------
+# --------------- experiments about number of supervision tasks -------------------------
 
 # for experiment_group, model_info in itertools.product(experiment_groups, models):
 
@@ -301,7 +376,7 @@ for experiment_group in experiment_groups:
     if model_info[2] is not None:
         # extract existing model path
         model_name_or_path = re.search("--model_name_or_path (\S+)", task_spec['arguments'][0]).group(1)
-        # replace the model path with the checkpoint subfolder. 
+        # replace the model path with the checkpoint subfolder.
         task_spec['arguments'] = [task_spec['arguments'][0].replace(model_name_or_path, model_name_or_path+"/"+model_info[2], 1)]
         # NOTE: We don't change the tokenizer subfolder, because by default the
         # tokenizer is only saved to the top-level output dir. That's why we call
@@ -311,38 +386,18 @@ for experiment_group in experiment_groups:
     if model_info[3] == "vanilla_lm":
         task_spec['arguments'] = [task_spec['arguments'][0].replace("--use_chat_format", "")]
 
-    if "13B" in model_info[0]:
-        # find the batch size argument, and reduce by 4x
-        if "--eval_batch_size" in task_spec['arguments'][0]:
-            original_batch_size = re.search("--eval_batch_size (\d+)", task_spec['arguments'][0]).group(1)
-            new_batch_size = max(1, int(original_batch_size) // 2)
-            task_spec['arguments'] = [task_spec['arguments'][0].replace("--eval_batch_size {}".format(original_batch_size), "--eval_batch_size {}".format(new_batch_size))]
-
-
-    if "30B" in model_info[0] or "34B" in model_info[0]:
-        # find the batch size argument, and reduce by 4x
-        if "--eval_batch_size" in task_spec['arguments'][0]:
-            original_batch_size = re.search("--eval_batch_size (\d+)", task_spec['arguments'][0]).group(1)
-            new_batch_size = max(1, int(original_batch_size) // 4)
-            task_spec['arguments'] = [task_spec['arguments'][0].replace("--eval_batch_size {}".format(original_batch_size), "--eval_batch_size {}".format(new_batch_size))]
-
-        if "codex_eval" in experiment_group:
-            # request 2x more GPUs
-            task_spec['resources']['gpuCount'] = 2 * task_spec['resources']['gpuCount']
-    
-    elif "70B" in model_info[0] or "65B" in model_info[0] or "40B" in model_info[0]:
-        # find the batch size argument, and reduce by 4x
-        if "--eval_batch_size" in task_spec['arguments'][0]:
-            original_batch_size = re.search("--eval_batch_size (\d+)", task_spec['arguments'][0]).group(1)
-            new_batch_size = max(1, int(original_batch_size) // 4)
-            task_spec['arguments'] = [task_spec['arguments'][0].replace("--eval_batch_size {}".format(original_batch_size), "--eval_batch_size {}".format(new_batch_size))]
-
-        if "codex_eval" in experiment_group:
-            # request 4x more GPUs
-            task_spec['resources']['gpuCount'] = 4 * task_spec['resources']['gpuCount']
-        else:
-            # request 2x more GPUs
-            task_spec['resources']['gpuCount'] = 2 * task_spec['resources']['gpuCount']
+    # Adjust batch size and gpus.
+    task_spec = adjust_batch_size(
+        task_spec=task_spec,
+        model_name=model_info[0],
+        batch_size_reduction=args.batch_size_reduction,
+    )
+    task_spec = adjust_gpus(
+        task_spec=task_spec,
+        experiment_group=experiment_group,
+        model_name=model_info[0],
+        gpu_multiplier=args.gpu_multiplier,
+    )
 
     # if using huggingface tokenizer template, replace the chat formatting function with hf tokenizer one
     if args.use_hf_tokenizer_template:
@@ -379,7 +434,6 @@ for experiment_group in experiment_groups:
         if "--use_vllm" in task_spec['arguments'][0]:
             print(f"Removing --use_vllm for {model_info[0]}")
             task_spec['arguments'] = [task_spec['arguments'][0].replace("--use_vllm", "")] 
-
 
     if any([x in model_info[0] for x in ["opt", "pythia", "falcon"]]):
         if "--use_vllm" in task_spec['arguments'][0]:


### PR DESCRIPTION
I refactored out the logic to adjust the batch size and number of GPU's into their own functions. It reproduces the logic we had before and also coves the case where the user explicitly passes a `--batch_size_reduction` or `--gpu_multiplier` flag. I did some spot-checks that the auto-generated configs don't change for models with the name `7B`, `13B`, `30B`, `65B`. 