### PR TITLE
flash-attn needs data type of bfloat16 or float16

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -530,6 +530,7 @@ def main():
                 config=config,
                 trust_remote_code=args.trust_remote_code,
                 low_cpu_mem_usage=args.low_cpu_mem_usage,
+                torch_dtype=torch.bfloat16,
                 use_flash_attention_2=True if args.use_flash_attn else False,
                 revision=args.model_revision
             )


### PR DESCRIPTION
HI, I tried to fine-tune the llama2 model, and I want to use flash-attn, it seems like flash-attn only supports `float16` or `bfloat16`, you guys may need to check this.