### PR TITLE
remove duplicated load_in_xbit call

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -298,7 +298,6 @@ def main():
                 args.model_name_or_path,
                 from_tf=bool(".ckpt" in args.model_name_or_path),
                 config=config,
-                load_in_4bit=True,
                 quantization_config=bnb_config,
                 device_map=device_map,
                 trust_remote_code=args.trust_remote_code,

--- a/open_instruct/merge_lora.py
+++ b/open_instruct/merge_lora.py
@@ -82,7 +82,6 @@ if __name__ == "__main__":
         )
         base_model = AutoModelForCausalLM.from_pretrained(
             args.base_model_name_or_path if args.base_model_name_or_path else peft_config.base_model_name_or_path,
-            load_in_4bit=True,
             torch_dtype=torch.bfloat16,
             quantization_config=quantization_config,
             device_map={"": 0} if torch.cuda.is_available() else None,


### PR DESCRIPTION
Newer transformers doesnt allow passing a quantization config and `load_in_4bit` together, so this is just removing the second duplicated flag.