### PR TITLE
Bump transformers to 4.43.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ bitsandbytes>=0.41.1
 evaluate>=0.4.0
 tokenizers==0.19.1
 protobuf
-transformers==4.43.0
+transformers==4.43.1
 openai>=1.0.0
 tiktoken
 rouge_score

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ bitsandbytes>=0.41.1
 evaluate>=0.4.0
 tokenizers==0.19.1
 protobuf
-transformers==4.40.2
+transformers==4.43.0
 openai>=1.0.0
 tiktoken
 rouge_score

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ bitsandbytes>=0.41.1
 evaluate>=0.4.0
 tokenizers==0.19.1
 protobuf
-transformers==4.43.3
+transformers==4.43.4
 openai>=1.0.0
 tiktoken
 rouge_score

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ bitsandbytes>=0.41.1
 evaluate>=0.4.0
 tokenizers==0.19.1
 protobuf
-transformers==4.43.2
+transformers==4.43.3
 openai>=1.0.0
 tiktoken
 rouge_score

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ bitsandbytes>=0.41.1
 evaluate>=0.4.0
 tokenizers==0.19.1
 protobuf
-transformers==4.43.1
+transformers==4.43.2
 openai>=1.0.0
 tiktoken
 rouge_score


### PR DESCRIPTION
We need to bump the version to support llama 3.1
The main breaking changes from 4.40 shouldnt affect us:
- tokenizer behaviour in TextGenerationPipeline (4.42 -> 4.43)
- ConversationalPipeline, FLAVA, idefics, timm, quantization tests (4.41 -> 4.42)
Some minor llama tokenizer changes (https://github.com/huggingface/transformers/pull/28881) but nothing that seems crazy.