### PR TITLE
Add ability to upload evals to HF

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ python scripts/submit_eval_jobs.py \
       --preemptible \
       --use_hf_tokenizer_template \
       --beaker_image nathanl/open_instruct_olmo_auto \
-      --upload_to_hf allenai/tulu-3-evals//results/<model name> \
+      --upload_to_hf allenai/tulu-3-evals \
       --run_oe_eval_experiments
 ```
 Replace location with your beaker ID, and model name with your model name (note this will affect experiment naming, so make it unique and memorable!). For HF models, use a name with `hf-<model-name>` for the model_name argument, and for location give the HF path (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`). Note this assumes your model has a valid HF tokenizer chat template.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,22 @@ Evaluation scripts for different datasets are put under `./scripts`. For example
 ./scripts/eval/mmlu.sh
 ```
 
+### Ai2 Internal Evaluation
+
+We provide a script integrated with beaker for use internally at Ai2. For example, to run all the tulu 3 evals with easy uploading:
+```bash
+python scripts/submit_eval_jobs.py \
+      --model_name <model name> \
+      --location <beaker id> \
+      --is_tuned --workspace tulu-3-results \
+      --preemptible \
+      --use_hf_tokenizer_template \
+      --beaker_image nathanl/open_instruct_olmo_auto \
+      --upload_to_hf allenai/tulu-3-evals//results/<model name> \
+      --run_oe_eval_experiments
+```
+Replace location with your beaker ID, and model name with your model name (note this will affect experiment naming, so make it unique and memorable!). For HF models, use a name with `hf-<model-name>` for the model_name argument, and for location give the HF path (e.g. `meta-llama/Meta-Llama-3-8B-Instruct`). Note this assumes your model has a valid HF tokenizer chat template.
+
 ### Human evaluation
 
 We release our human evaluation interface and collected annotations in the `./human_eval` folder. Please see the corresponding [README](./human_eval/README.md) for more details.

--- a/configs/beaker_configs/default_eval.yaml
+++ b/configs/beaker_configs/default_eval.yaml
@@ -34,6 +34,8 @@ tasks:
         value: true
       - name: OPENAI_API_KEY
         secret: openai_api_key
+      - name: HF_TOKEN
+        secret: HF_TOKEN
     datasets:
       - mountPath: /data/
         source:

--- a/eval/MATH/run_eval.py
+++ b/eval/MATH/run_eval.py
@@ -10,7 +10,8 @@ from eval.utils import (
     load_hf_lm,
     query_openai_chat_model,
     dynamic_import_function,
-    load_hf_tokenizer
+    load_hf_tokenizer,
+    upload_results_to_hf
 )
 from eval.MATH.examplars import EXAMPLARS as MATH_EXAMPLARS
 from eval.MATH.utilities import last_boxed_only_string, remove_boxed
@@ -196,6 +197,20 @@ def main(args):
     with open(os.path.join(args.save_dir, "metrics.json"), "w") as fout:
         json.dump(metrics, fout, indent=4)
 
+    if args.upload_to_hf is not None:
+        # upload metrics to HF. Main metric is the accuracy
+        results = metrics
+        task_name = "oi_MATH_cot"
+        primary_score = results["accuracy"]
+        upload_results_to_hf(
+            results,
+            args.upload_to_hf,
+            args.hf_upload_name,
+            task_name=task_name,
+            primary_score=primary_score,
+            prepend_timestamp=True,
+        )
+
 
 if __name__ == "__main__":
 
@@ -305,6 +320,19 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         help="Additional stop sequences to use when generating completions. Useful for e.g. llama-3-instruct."
+    )
+    parser.add_argument(
+        "--upload_to_hf",
+        type=str,
+        default=None,
+        help="If specified, we will upload the results to Hugging Face Datasets. "
+             "This should be the name of the dataset to upload to."
+    )
+    parser.add_argument(
+        "--hf_upload_name",
+        type=str,
+        default=None,
+        help="If uploading to hf, this is the model name"
     )
     args = parser.parse_args()
 

--- a/eval/alpaca_farm/run_eval.py
+++ b/eval/alpaca_farm/run_eval.py
@@ -1,5 +1,6 @@
 import os
 import json
+import ast
 import argparse
 import logging
 import random
@@ -137,7 +138,9 @@ def main(args):
         # upload metrics to HF. Main metric is the LC winrate
         # we divide by 100 to match other metrics.
         results = df_leaderboard.to_dict()
-        if os.getenv("IS_ALPACA_EVAL_2", False) != "False":
+        # copied below from alpacaeval codebase
+        is_alpaca_eval_2 = ast.literal_eval(os.environ.get("IS_ALPACA_EVAL_2", "True"))
+        if is_alpaca_eval_2:
             task_name = "oi_alpaca_eval_2"
             # we only have one model in here, so we can just take the first value
             primary_score = [x for x in results["length_controlled_winrate"].values()][0] / 100

--- a/eval/alpaca_farm/run_eval.py
+++ b/eval/alpaca_farm/run_eval.py
@@ -7,7 +7,7 @@ import torch
 import datasets
 import vllm
 from alpaca_eval import evaluate as alpaca_farm_evaluate
-from eval.utils import query_openai_chat_model, query_openai_model, generate_completions, dynamic_import_function, load_hf_lm, load_hf_tokenizer
+from eval.utils import query_openai_chat_model, query_openai_model, generate_completions, dynamic_import_function, load_hf_lm, load_hf_tokenizer, upload_results_to_hf
 
 def main(args):
     random.seed(42)
@@ -132,6 +132,26 @@ def main(args):
     # save to json
     with open(os.path.join(args.save_dir, f"metrics.json"), "w") as fout:
         json.dump(df_leaderboard.to_dict(), fout)
+
+    if args.upload_to_hf is not None:
+        # upload metrics to HF. Main metric is the LC winrate
+        # we divide by 100 to match other metrics.
+        results = df_leaderboard.to_dict()
+        if os.getenv("IS_ALPACA_EVAL_2", False) != "False":
+            task_name = "oi_alpaca_eval_2"
+            # we only have one model in here, so we can just take the first value
+            primary_score = [x for x in results["length_controlled_winrate"].values()][0] / 100
+        else:
+            task_name = "oi_alpaca_eval"
+            primary_score = [x for x in results["discrete_win_rate"].values()][0] / 100
+        upload_results_to_hf(
+            results,
+            args.upload_to_hf,
+            args.hf_upload_name,
+            task_name=task_name,
+            primary_score=primary_score,
+            prepend_timestamp=True,
+        )
         
 
 if __name__ == "__main__":
@@ -218,6 +238,19 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         help="Additional stop sequences to use when generating completions. Useful for e.g. llama-3-instruct."
+    )
+    parser.add_argument(
+        "--upload_to_hf",
+        type=str,
+        default=None,
+        help="If specified, we will upload the results to Hugging Face Datasets. "
+             "This should be the name of the dataset to upload to."
+    )
+    parser.add_argument(
+        "--hf_upload_name",
+        type=str,
+        default=None,
+        help="If uploading to hf, this is the model name"
     )
     args = parser.parse_args()
 

--- a/eval/bbh/run_eval.py
+++ b/eval/bbh/run_eval.py
@@ -13,7 +13,8 @@ from eval.utils import (
     generate_completions,
     query_openai_chat_model,
     dynamic_import_function,
-    load_hf_tokenizer
+    load_hf_tokenizer,
+    upload_results_to_hf
 )
 
 
@@ -178,6 +179,20 @@ def main(args):
         print(f"Average EM: {performance['average_exact_match']}")
         json.dump(performance, fout, indent=4)
 
+    if args.upload_to_hf is not None:
+        # upload metrics to HF. Main metric is the accuracy
+        results = performance
+        task_name = "oi_bbh_cot"
+        primary_score = results["average_exact_match"]
+        upload_results_to_hf(
+            results,
+            args.upload_to_hf,
+            args.hf_upload_name,
+            task_name=task_name,
+            primary_score=primary_score,
+            prepend_timestamp=True,
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -268,6 +283,19 @@ if __name__ == "__main__":
         '--stop_at_double_newline',
         action="store_true",
         help="If given, we will stop generation at the first double newline. Turn on to match older eval settings."
+    )
+    parser.add_argument(
+        "--upload_to_hf",
+        type=str,
+        default=None,
+        help="If specified, we will upload the results to Hugging Face Datasets. "
+             "This should be the name of the dataset to upload to."
+    )
+    parser.add_argument(
+        "--hf_upload_name",
+        type=str,
+        default=None,
+        help="If uploading to hf, this is the model name"
     )
     args = parser.parse_args()
 

--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -10,6 +10,7 @@ from eval.utils import (
     query_openai_chat_model,
     dynamic_import_function,
     load_hf_tokenizer,
+    upload_results_to_hf,
 )
 from eval.codex_humaneval.data import write_jsonl, read_problems
 from eval.codex_humaneval.evaluation import evaluate_functional_correctness
@@ -174,6 +175,23 @@ def main(args):
     with open(os.path.join(args.save_dir, "metrics.json"), "w") as fout:
         json.dump(pass_at_k_results, fout)
 
+    if args.upload_to_hf is not None:
+        # upload metrics to HF.
+        # main metric is p@10 for temp=.8,
+        # p@1 for temp=.1, maybe default to p@10 otherwise.
+        results = pass_at_k_results
+        pass_at = 1 if args.temperature == 0.1 else 10
+        task_name = f"oi_codex_humaneval_p@{str(pass_at)}"
+        primary_score = results[f"pass@{str(pass_at)}"]
+        upload_results_to_hf(
+            results,
+            args.upload_to_hf,
+            args.hf_upload_name,
+            task_name=task_name,
+            primary_score=primary_score,
+            prepend_timestamp=True,
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -281,6 +299,19 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         help="Additional stop sequences to use when generating completions. Useful for e.g. llama-3-instruct."
+    )
+    parser.add_argument(
+        "--upload_to_hf",
+        type=str,
+        default=None,
+        help="If specified, we will upload the results to Hugging Face Datasets. "
+             "This should be the name of the dataset to upload to."
+    )
+    parser.add_argument(
+        "--hf_upload_name",
+        type=str,
+        default=None,
+        help="If uploading to hf, this is the model name"
     )
     args = parser.parse_args()
     # model_name_or_path and openai_engine cannot be both None or both not None.

--- a/eval/gsm/run_eval.py
+++ b/eval/gsm/run_eval.py
@@ -12,7 +12,8 @@ from eval.utils import (
     load_hf_lm,
     query_openai_chat_model,
     dynamic_import_function,
-    load_hf_tokenizer
+    load_hf_tokenizer,
+    upload_results_to_hf
 )
 from eval.gsm.examplars import EXAMPLARS as GSM_EXAMPLARS
 
@@ -181,6 +182,20 @@ def main(args):
             "exact_match": em_score
         }, fout, indent=4)
 
+    if args.upload_to_hf is not None:
+        # upload metrics to HF. Main metric is the accuracy
+        results = { "exact_match": em_score }
+        task_name = "oi_gsm8k_cot"
+        primary_score = results["exact_match"]
+        upload_results_to_hf(
+            results,
+            args.upload_to_hf,
+            args.hf_upload_name,
+            task_name=task_name,
+            primary_score=primary_score,
+            prepend_timestamp=True,
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -276,6 +291,19 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         help="Additional stop sequences to use when generating completions. Useful for e.g. llama-3-instruct."
+    )
+    parser.add_argument(
+        "--upload_to_hf",
+        type=str,
+        default=None,
+        help="If specified, we will upload the results to Hugging Face Datasets. "
+             "This should be the name of the dataset to upload to."
+    )
+    parser.add_argument(
+        "--hf_upload_name",
+        type=str,
+        default=None,
+        help="If uploading to hf, this is the model name"
     )
     args = parser.parse_args()
 

--- a/eval/ifeval/run_eval.py
+++ b/eval/ifeval/run_eval.py
@@ -19,7 +19,8 @@ from eval.utils import (
     generate_completions,
     query_openai_chat_model,
     dynamic_import_function,
-    load_hf_tokenizer
+    load_hf_tokenizer,
+    upload_results_to_hf
 )
 from eval.ifeval import instructions_registry
 
@@ -334,6 +335,19 @@ def main(args):
     with open(os.path.join(args.save_dir, "metrics.json"), "w") as fout:
         json.dump(results, fout, indent=4)
 
+    if args.upload_to_hf is not None:
+        # upload metrics to HF. Main metric is the loose acc.
+        task_name = "oi_ifeval"
+        primary_score = results["loose"]["Accuracy"]
+        upload_results_to_hf(
+            results,
+            args.upload_to_hf,
+            args.hf_upload_name,
+            task_name=task_name,
+            primary_score=primary_score,
+            prepend_timestamp=True,
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -414,6 +428,19 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         help="Additional stop sequences to use when generating completions. Useful for e.g. llama-3-instruct."
+    )
+    parser.add_argument(
+        "--upload_to_hf",
+        type=str,
+        default=None,
+        help="If specified, we will upload the results to Hugging Face Datasets. "
+             "This should be the name of the dataset to upload to."
+    )
+    parser.add_argument(
+        "--hf_upload_name",
+        type=str,
+        default=None,
+        help="If uploading to hf, this is the model name"
     )
     args = parser.parse_args()
 

--- a/eval/toxigen/run_eval.py
+++ b/eval/toxigen/run_eval.py
@@ -15,6 +15,7 @@ from eval.utils import (
     load_hf_lm,
     query_openai_chat_model,
     load_hf_tokenizer,
+    upload_results_to_hf,
 )
 from eval.utils import dynamic_import_function 
 
@@ -179,6 +180,21 @@ def main(args):
                 print(f"Average Toxicity for {group}: {performance[group]}")
         json.dump(performance, fout, indent=4)
 
+    if args.upload_to_hf is not None:
+        # upload metrics to HF. Main metric is the accuracy
+        results = performance
+        task_name = "oi_toxigen"
+        # invert for use in leaderboard
+        primary_score = 1 - results["overall"]
+        upload_results_to_hf(
+            results,
+            args.upload_to_hf,
+            args.hf_upload_name,
+            task_name=task_name,
+            primary_score=primary_score,
+            prepend_timestamp=True,
+        )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -268,6 +284,19 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         help="Additional stop sequences to use when generating completions. Useful for e.g. llama-3-instruct."
+    )
+    parser.add_argument(
+        "--upload_to_hf",
+        type=str,
+        default=None,
+        help="If specified, we will upload the results to Hugging Face Datasets. "
+             "This should be the name of the dataset to upload to."
+    )
+    parser.add_argument(
+        "--hf_upload_name",
+        type=str,
+        default=None,
+        help="If uploading to hf, this is the model name"
     )
     args = parser.parse_args()
 

--- a/eval/truthfulqa/run_eval.py
+++ b/eval/truthfulqa/run_eval.py
@@ -14,6 +14,7 @@ from eval.utils import (
     generate_completions,
     score_completions,
     dynamic_import_function,
+    upload_results_to_hf,
 )
 from eval.truthfulqa.utilities import (
     format_prompt,
@@ -393,6 +394,19 @@ def main(args):
     with open(os.path.join(args.save_dir, 'metrics.json'), 'w') as f:
         json.dump(results, f, indent=2)
 
+    if args.upload_to_hf is not None:
+        # upload metrics to HF. Main metric is the accuracy
+        task_name = "oi_truthfulqa"
+        primary_score = results["truth-info acc"]
+        upload_results_to_hf(
+            results,
+            args.upload_to_hf,
+            args.hf_upload_name,
+            task_name=task_name,
+            primary_score=primary_score,
+            prepend_timestamp=True,
+        )
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -499,6 +513,19 @@ if __name__ == '__main__':
         type=str,
         help='A trained HuggingFace judge model name to be used for computing the metrics for `info` if it is specified.' \
             'Either `gpt_info_model_name` or `hf_info_model_name_or_path` should be specified for computing the metric.'
+    )
+    parser.add_argument(
+        "--upload_to_hf",
+        type=str,
+        default=None,
+        help="If specified, we will upload the results to Hugging Face Datasets. "
+             "This should be the name of the dataset to upload to."
+    )
+    parser.add_argument(
+        "--hf_upload_name",
+        type=str,
+        default=None,
+        help="If uploading to hf, this is the model name"
     )
     args = parser.parse_args()
     main(args)

--- a/eval/tydiqa/run_eval.py
+++ b/eval/tydiqa/run_eval.py
@@ -12,6 +12,7 @@ from eval.utils import (
     query_openai_chat_model,
     dynamic_import_function,
     load_hf_tokenizer,
+    upload_results_to_hf,
 )
 
 
@@ -259,7 +260,20 @@ def main(args):
     
     with open(os.path.join(args.save_dir, "metrics.json"), "w") as fout:
         json.dump(eval_scores, fout, indent=4)
-    print("Done!")
+
+    if args.upload_to_hf is not None:
+        # upload metrics to HF. Main metric is the accuracy
+        results = eval_scores
+        task_name = f"oi_tydiqa_{args.n_shot}shot"
+        primary_score = results["average"]["f1"]
+        upload_results_to_hf(
+            results,
+            args.upload_to_hf,
+            args.hf_upload_name,
+            task_name=task_name,
+            primary_score=primary_score,
+            prepend_timestamp=True,
+        )
 
 
 if __name__ == "__main__":
@@ -358,6 +372,19 @@ if __name__ == "__main__":
         nargs="+",
         default=[],
         help="Additional stop sequences to use when generating completions. Useful for e.g. llama-3-instruct."
+    )
+    parser.add_argument(
+        "--upload_to_hf",
+        type=str,
+        default=None,
+        help="If specified, we will upload the results to Hugging Face Datasets. "
+             "This should be the name of the dataset to upload to."
+    )
+    parser.add_argument(
+        "--hf_upload_name",
+        type=str,
+        default=None,
+        help="If uploading to hf, this is the model name"
     )
     args = parser.parse_args()
     # model_name_or_path and openai_engine cannot be both None or both not None.

--- a/eval/tydiqa/run_eval.py
+++ b/eval/tydiqa/run_eval.py
@@ -265,7 +265,7 @@ def main(args):
         # upload metrics to HF. Main metric is the accuracy
         results = eval_scores
         task_name = f"oi_tydiqa_{args.n_shot}shot"
-        primary_score = results["average"]["f1"]
+        primary_score = results["average"]["f1"] / 100
         upload_results_to_hf(
             results,
             args.upload_to_hf,

--- a/eval/utils.py
+++ b/eval/utils.py
@@ -7,7 +7,7 @@ import os
 from importlib import import_module
 from transformers import StoppingCriteria
 from eval.dispatch_openai_requests import dispatch_openai_chat_requesets, dispatch_openai_prompt_requesets
-import warnings
+from huggingface_hub import HfApi
 
 
 class KeyWordsCriteria(StoppingCriteria):
@@ -469,3 +469,34 @@ def dynamic_import_function(function_path):
     function = getattr(module, function_name)
     return function
  
+def upload_results_to_hf(
+        results_dict,
+        hf_dataset_name,
+        hf_dataset_save_dir,
+        task_name=None,
+        primary_score=None,
+        prepend_timestamp=False,
+    ):
+    # A bunch of stuff for making the results file setup follow
+    # the oe-eval standards
+    if task_name is not None:
+        results_dict["task_name"] = task_name
+    if primary_score is not None:
+        results_dict["metrics"] = {}
+        results_dict["metrics"]["primary_score"] = primary_score
+    if prepend_timestamp:
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        hf_dataset_save_path = f"{hf_dataset_save_dir}/{timestamp}-{task_name}.json"
+    else:
+        hf_dataset_save_path = f"{hf_dataset_save_dir}/{task_name}.json"
+    # actual save and upload
+    with open("results.json", "w") as f:
+        json.dump(results_dict, f)
+    api = HfApi(token=os.getenv("HF_TOKEN", None))
+    api.upload_file(
+        path_or_fileobj="results.json",
+        path_in_repo=hf_dataset_save_path,
+        repo_id=hf_dataset_name,
+        repo_type="dataset",
+    )
+    os.remove("results.json")

--- a/requirements-olmo.txt
+++ b/requirements-olmo.txt
@@ -1,5 +1,5 @@
 # TODO When updating flash-attn or torch in the future, make sure to update the version in the Dockerfile 
-torch<=2.3.0
+torch
 scipy
 packaging
 sentencepiece
@@ -26,7 +26,7 @@ fire
 alpaca-eval==0.6.2
 # for human eval web app
 flask
-vllm>=0.4.2  # for compatibility with olmo
+vllm>=0.5.4  # for llama 3 + olmo compat.
 openpyxl
 # for ifeval
 nltk

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # A script for using oe-eval for our development!
-# to install oe-eval, check out https://github.com/allenai/oe-eval-internal
+# to use, clone oe-eval (https://github.com/allenai/oe-eval-internal) into the top level dir of this repo.
 # you'll need the current main for this to work.
 # sadly, this is internal at Ai2 for now, but we are working on making it public!
 
@@ -83,5 +83,5 @@ for TASK in "${TASKS[@]}"; do
     else
         BATCH_SIZE=$BATCH_SIZE_VLLM
     fi
-    oe-eval --model "$MODEL_NAME" --beaker-workspace "ai2/tulu-3-results" --beaker-budget ai2/oe-adapt --task "$TASK" $MODEL_TYPE --batch-size "$BATCH_SIZE" --model-args {\"model_path\":\"${MODEL_LOCATION}\"} ${HF_UPLOAD_ARG} --gpus "$GPU_COUNT"
+    python oe-eval-internal/oe_eval/launch.py --model "$MODEL_NAME" --beaker-workspace "ai2/tulu-3-results" --beaker-budget ai2/oe-adapt --task "$TASK" $MODEL_TYPE --batch-size "$BATCH_SIZE" --model-args {\"model_path\":\"${MODEL_LOCATION}\"} ${HF_UPLOAD_ARG} --gpus "$GPU_COUNT"
 done

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -568,7 +568,7 @@ if args.run_oe_eval_experiments:
     # if so, run oe-eval. We assume it is cloned in the top-level repo directory.
     oe_eval_cmd = f"scripts/eval/oe-eval.sh --model-name {model_name}"
     if args.upload_to_hf:
-        oe_eval_cmd += "--hf-upload"
+        oe_eval_cmd += " --hf-upload"
     ## model location munging: if beaker, use beaker://. If hf, just name
     if model_info[0].startswith("hf-"):
         oe_eval_cmd += f" --model-location {model_info[1]}"

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -87,7 +87,7 @@ parser.add_argument("--gsm_stop_at_double_newline", action="store_true", help="S
 parser.add_argument("--no-nfs", action="store_true", help="Don't mount the NFS.")
 parser.add_argument("--add_stop_sequence", type=str, nargs="+", default=[], help="Additional stop sequences to use when generating completions.") # e.g. \"<|eot_id|>\" for llama 3
 parser.add_argument("--upload_to_hf", type=str, default=None, help="If given, upload the eval results to the Hugging Face model hub. Provide the HF dataset and path in form <hf dataset>//<hf path>.")
-parser.add_argument("hf_upload_experiments", type=str, nargs="*", default=None, help="Upload given experiment to the Hugging Face model hub.")
+parser.add_argument("--hf_upload_experiments", type=str, nargs="*", default=None, help="Upload given experiment to the Hugging Face model hub.")
 args = parser.parse_args()
 
 

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -86,6 +86,7 @@ parser.add_argument("--gpu_multiplier", type=int, default=None, help="Multiply t
 parser.add_argument("--gsm_stop_at_double_newline", action="store_true", help="Stop GSM generation at the first double newline.")
 parser.add_argument("--no-nfs", action="store_true", help="Don't mount the NFS.")
 parser.add_argument("--add_stop_sequence", type=str, nargs="+", default=[], help="Additional stop sequences to use when generating completions.") # e.g. \"<|eot_id|>\" for llama 3
+parser.add_argument("--upload_to_hf", type=str, default=None, help="If given, upload the eval results to the Hugging Face model hub. Provide the HF dataset and path in form <hf dataset>//<hf path>.")
 args = parser.parse_args()
 
 
@@ -522,6 +523,12 @@ for experiment_group in experiment_groups:
     tasks_without_addition_stop = ["mmlu_0shot", "mmlu_5shot", "trutufulqa"]
     if args.add_stop_sequence and experiment_group not in tasks_without_addition_stop:
         task_spec['arguments'] = [task_spec['arguments'][0] + " --additional_stop_sequence " + " ".join(args.add_stop_sequence)]
+
+    # add HF hub upload if specified
+    if args.upload_to_hf:
+        hf_dataset = args.upload_to_hf.split("//")[0]
+        hf_path = args.upload_to_hf.split("//")[1]
+        task_spec['arguments'] = [task_spec['arguments'][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name {hf_path}"]
 
     eval_task_specs.append(task_spec)
 

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -541,9 +541,9 @@ for experiment_group in experiment_groups:
         if experiment_group not in args.hf_upload_experiments:
             print(f"Skipping HF upload for {experiment_group}")
         else:
-            hf_dataset = args.upload_to_hf.split("//")[0]
-            hf_path = args.upload_to_hf.split("//")[1]
-            task_spec['arguments'] = [task_spec['arguments'][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name {hf_path}"]
+            hf_dataset = args.upload_to_hf
+            # to match the way oe-eval script works.
+            task_spec['arguments'] = [task_spec['arguments'][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name results/{model_name}"]
 
     eval_task_specs.append(task_spec)
 

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -87,6 +87,7 @@ parser.add_argument("--gsm_stop_at_double_newline", action="store_true", help="S
 parser.add_argument("--no-nfs", action="store_true", help="Don't mount the NFS.")
 parser.add_argument("--add_stop_sequence", type=str, nargs="+", default=[], help="Additional stop sequences to use when generating completions.") # e.g. \"<|eot_id|>\" for llama 3
 parser.add_argument("--upload_to_hf", type=str, default=None, help="If given, upload the eval results to the Hugging Face model hub. Provide the HF dataset and path in form <hf dataset>//<hf path>.")
+parser.add_argument("hf_upload_experiments", type=str, nargs="*", default=None, help="Upload given experiment to the Hugging Face model hub.")
 args = parser.parse_args()
 
 
@@ -526,9 +527,22 @@ for experiment_group in experiment_groups:
 
     # add HF hub upload if specified
     if args.upload_to_hf:
-        hf_dataset = args.upload_to_hf.split("//")[0]
-        hf_path = args.upload_to_hf.split("//")[1]
-        task_spec['arguments'] = [task_spec['arguments'][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name {hf_path}"]
+        if args.hf_upload_experiments is None or len(args.hf_upload_experiments) == 0:
+            # use defaults for tulu dev evals.
+            args.hf_upload_experiments = [
+                "MATH_cot",
+                "bbh_cot",
+                "trutufulqa",
+                "xstest",
+                "alpaca_eval",
+                "alpaca_eval_2",
+            ]
+        if experiment_group not in args.hf_upload_experiments:
+            print(f"Skipping HF upload for {experiment_group}")
+        else:
+            hf_dataset = args.upload_to_hf.split("//")[0]
+            hf_path = args.upload_to_hf.split("//")[1]
+            task_spec['arguments'] = [task_spec['arguments'][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name {hf_path}"]
 
     eval_task_specs.append(task_spec)
 


### PR DESCRIPTION
Adding the ability to upload eval results to HF. Currently dumps the output file to a given location and adds some tags to match our oe-eval tool. I've tested this works with the leaderboard. All eval names get prepended with 'oi_' to make it clear its coming from open-instruct.

The submit_eval script also sets this using the `--upload_to_hf` flag. For example, to eval llama 3 tulu 2 and upload to the tulu-3 eval database:
`python scripts/submit_eval_jobs.py --model_name llama_31_tulu_2_8b --location 01J4MGRSS3FM1J4E6XSH3459DK --is_tuned --workspace tulu-3-results --preemptible --use_hf_tokenizer_template --beaker_image hamishivi/open-instruct-hf-upload-testing --upload_to_hf allenai/tulu-3-evals//results/testing_oi_hf`

The flag takes `<hf_dataset_name>//<hf_dataset_path>`, similar to the oe-eval tool. By default, it only uploads some experiments (those not in oe-eval), but you can configure yourself with `--hf_upload_experiments`. 