### PR TITLE
Remove HF tag

### DIFF
--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -543,6 +543,9 @@ for experiment_group in experiment_groups:
         else:
             hf_dataset = args.upload_to_hf
             # to match the way oe-eval script works.
+            # if we prepended hf- to the model name, remove it.
+            if model_name.startswith("hf-"):
+                model_name = model_name[3:]
             task_spec['arguments'] = [task_spec['arguments'][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name results/{model_name}"]
 
     eval_task_specs.append(task_spec)


### PR DESCRIPTION
Really small change - remove the `hf-` tag in front of the model name in the hf script for uploading to the leaderboard. This is useful to have more flexible naming in the leaderboard.