### PR TITLE
Add safety evaluation as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "safety-eval"]
+	path = safety-eval
+	url = https://github.com/allenai/safety-eval.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "safety-eval"]
 	path = safety-eval
-	url = https://github.com/allenai/safety-eval.git
+	url = https://github.com/nouhadziri/safety-eval-fork.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "safety-eval"]
 	path = safety-eval
-	url = https://github.com/nouhadziri/safety-eval-fork.git
+	url = git@github.com:nouhadziri/safety-eval-fork.git

--- a/docs/safety-eval/safety.md
+++ b/docs/safety-eval/safety.md
@@ -48,7 +48,7 @@ In the examples below, text within {} tags should be replaced with your own valu
 As a convenience, you can use the `evaluation/gantry_run.sh` script which includes some necessary arguments. You can use it the same way as `gantry run`, but excluding these boilerplate arguments (take a look at the script to see what it includes). Example usage:
 
 ```bash
-./evaluation/gantry_run.sh --workspace {workspace} --cluster {cluster} --gpus {n_gpus} \
+PYTHONPATH=safety-eval ./safety-eval/evaluation/gantry_run.sh --workspace {workspace} --cluster {cluster} --gpus {n_gpus} \
     --priority {priority} -- python evaluation/run_all_generation_benchmarks.py \
     --model_name_or_path allenai/tulu-2-dpo-7b \
     --model_input_template_path_or_name tulu2 \

--- a/docs/safety-eval/safety.md
+++ b/docs/safety-eval/safety.md
@@ -60,7 +60,7 @@ Here is an example using the full `gantry run` command. Use the beaker image `se
 
 **Important**: Please include all the beaker arguments exactly as in the examples unless intentionally modifying some configuration. Many of them are necessary to avoid job failures, such as `--beaker-image`, `--venv`, and `--env-secret`. Note that `openai_api_key` and `hf_token` are Beaker workspace secret names, so should *not* be replaced with actual values (see One-Time Setup).
 
-Note that the `--` divides the gantry command from the evaluation command - you can edit the second part to run whatever eval suite you want from the `eval.py` script, or any other script in the OE-Safety repo. Any additional Beaker arguments such as a dataset mount to use a model from a Beaker dataset or adding a priority tag can be added before the `--`.
+Note that the `--` divides the gantry command from the evaluation command - you can edit the second part to run whatever eval suite you want from the `eval.py` script. Any additional Beaker arguments such as a dataset mount to use a model from a Beaker dataset or adding a priority tag can be added before the `--`.
 
 You can also run all generator evaluations parallelized across the GPUs allocated to your batch job, like so:
 ```bash

--- a/docs/safety-eval/safety.md
+++ b/docs/safety-eval/safety.md
@@ -1,0 +1,114 @@
+
+## Running on an interactive session
+
+Run the following command from the main project dir `open-instruct`.
+### Safety benchmarks
+
+For all benchmarks requiring safety classification unless noted otherwise, as a default, we use the [WildGuard](https://github.com/allenai/wildguard) classifier to evaluate the safety of model outputs.
+
+- [WildGuardTest](https://arxiv.org/abs/2406.18495)
+- [Harmbench](https://arxiv.org/abs/2402.04249)
+- [ToxiGen](https://arxiv.org/abs/2203.09509)
+- [XSTest](https://arxiv.org/abs/2308.01263)
+- [JailbreakTrigger (in TrustLLM)](https://arxiv.org/abs/2401.05561)
+- [Do-anything-now](https://arxiv.org/abs/2308.03825)
+- [WildJailbreak](https://arxiv.org/abs/2406.18510) (both harmful and benign contrast sets)
+
+```commandline
+PYTHONPATH=safety-eval python safety-eval/evaluation/run_all_generation_benchmarks.py    \
+ --model_name_or_path allenai/tulu-2-dpo-7b     --model_input_template_path_or_name tulu2    \
+  --report_output_path ./generation_results/metrics.json     --save_individual_results_path ./generation_results/all.json \
+  --hf_upload_name {HF upload name} --upload_to_hf {HF repo ID}
+```
+
+**Changing classifiers for safety benchmarks**:
+
+You can change the safety classifier used for evaluation by specifying the `classifier_model_name` in the yaml file.
+For example, when you want to use the HarmBench's classifiers for evaluation on HarmBench, you can use `HarmbenchClassifier` as the `classifier_model_name`. Please check out the `evaluation/tasks/generation/harmbench/default.yaml` and `evaluation/tasks/classification/harmbench/harmbench_classsifier.yaml` to see the classifier's specification.
+
+
+
+
+## Running on a Beaker Batch Job
+
+The recommended way to run evaluation on Beaker is through [beaker-gantry](https://github.com/allenai/beaker-gantry). The basic format of a gantry command is `gantry run {beaker arguments} -- python {script path from repo root} {python script arguments}`. 
+
+**Important**: Before you run any command with gantry, make sure you *commit and push*, since gantry will attempt to clone the repo with your local latest commit hash.
+
+See the "One-Time Setup" section below before running commands. To test your setup, run the following command -- if this job succeeds, then you're ready to run evaluations with gantry.
+
+```bash
+gantry run --workspace {workspace} --budget ai2/oe-adapt --beaker-image kavelr/oe-safety --venv base --cluster ai2/mosaic-cirrascale --env-secret OPENAI_API_KEY=openai_api_key --env-secret HF_TOKEN=hf_token -- python -c 'print("Hello world")'
+```
+
+You can freely add any additional arguments to give to Beaker, such as a `--priority` tag which can be set to preemptible, normal, high, or urgent. AI2 policies may restrict the priorities that are available to users on certain clusters.
+
+In the examples below, text within {} tags should be replaced with your own values. 
+
+As a convenience, you can use the `evaluation/gantry_run.sh` script which includes some necessary arguments. You can use it the same way as `gantry run`, but excluding these boilerplate arguments (take a look at the script to see what it includes). Example usage:
+
+```bash
+./evaluation/gantry_run.sh --workspace {workspace} --cluster {cluster} --gpus {n_gpus} \
+    --priority {priority} -- python evaluation/run_all_generation_benchmarks.py \
+    --model_name_or_path allenai/tulu-2-dpo-7b \
+    --model_input_template_path_or_name tulu2 \
+    --report_output_path /results/metrics.json
+```
+
+
+Here is an example using the full `gantry run` command. Use the beaker image `seungjuh/oe-safety-support-olmo17`
+
+**Important**: Please include all the beaker arguments exactly as in the examples unless intentionally modifying some configuration. Many of them are necessary to avoid job failures, such as `--beaker-image`, `--venv`, and `--env-secret`. Note that `openai_api_key` and `hf_token` are Beaker workspace secret names, so should *not* be replaced with actual values (see One-Time Setup).
+
+```bash
+gantry run --workspace {your_workspace} --cluster {cluster} --gpus {n_gpus} \
+    --name {beaker_experiment_name} --task-name {beaker_task_name} --beaker-image seungjuh/oe-safety-support-olmo17 --venv base \
+    --env-secret OPENAI_API_KEY=openai_api_key \
+    --env-secret HF_TOKEN=hf_token \
+    --budget {budget} -- python evaluation/eval.py generators \
+    --use_vllm \
+    --model_name_or_path allenai/tulu-2-dpo-7b \
+    --model_input_template_path_or_name tulu2 \
+    --tasks harmbench,harmbench:vanilla_ai2_refusal_classifier,toxigen:tiny,trustllm:xstest \
+    --report_output_path /results/metrics.json --save_individual_results_path /results/all.json
+```
+
+Note that the `--` divides the gantry command from the evaluation command - you can edit the second part to run whatever eval suite you want from the `eval.py` script, or any other script in the OE-Safety repo. Any additional Beaker arguments such as a dataset mount to use a model from a Beaker dataset or adding a priority tag can be added before the `--`.
+
+You can also run all generator evaluations parallelized across the GPUs allocated to your batch job, like so:
+```bash
+gantry run --workspace {your_workspace} --cluster {cluster} --gpus {n_gpus} \
+    --name {beaker_experiment_name} --task-name {beaker_task_name} --beaker-image seungjuh/oe-safety-support-olmo17 --venv base \
+    --env-secret OPENAI_API_KEY=openai_api_key \
+    --env-secret HF_TOKEN=hf_token \
+    --budget {budget} -- python evaluation/run_all_generation_benchmarks.py \
+    --model_name_or_path allenai/tulu-2-dpo-7b \
+    --model_input_template_path_or_name tulu2 \
+    --report_output_path /results/metrics.json --save_individual_results_path /results/all.json
+```
+
+Because the `--report_output_path` argument is set to `/results/metrics.json`, the output will automatically get logged to Beaker metrics in the experiment page ([example](https://beaker.org/ex/01HW8NKZ458MA1PSB1X4YQTH94/tasks/01HW8NKZ4DTDA8FEFDGWA7Q8XX/job/01HW8NM2QR5AYB53PYP32J2VAA)).
+
+### Gantry One-Time Setup
+
+Before you can use gantry, there are a couple of things to set up. For the workspace you use, ensure it is owned by the `ai2` organization, or gantry won't be able to create the experiments.
+
+1. Run `pip install beaker-gantry beaker-py`
+2. Create a [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) with "repo" scope
+3. Go to https://github.com/settings/tokens and authorize your token to configure SSO access to the allenai organization
+4. Run `gantry config set-gh-token` and paste the token created above when prompted
+5. Create a [HuggingFace access token](https://huggingface.co/settings/tokens) with "read" scope (this is used to authenticate for using restricted models like Llama series)
+6. Run `beaker secret write --workspace {your_workspace} hf_token {your_token}`
+7. Obtain an OpenAI API key and run `beaker secret write --workspace {your_workspace} openai_api_key {your_api_key}
+
+Doing these steps once will set up your workspace to use gantry.
+
+
+### Common Gotchas
+
+If you're experiencing job failures, here are some things to check:
+
+- Make sure your local changes are committed,  pushed, and up to date with the remote
+- Make sure you have `--beaker-image seungjuh/oe-safety-support-olmo17` and `--venv base` in your `gantry run` command
+- Check your GitHub personal access token is authorized to access the allenai organization
+- Make sure the openai_api_key and hf_token secrets exist in your Beaker workspace

--- a/docs/safety-eval/safety.md
+++ b/docs/safety-eval/safety.md
@@ -55,23 +55,10 @@ As a convenience, you can use the `evaluation/gantry_run.sh` script which includ
     --report_output_path /results/metrics.json
 ```
 
-
+### Extra Beaker Commands
 Here is an example using the full `gantry run` command. Use the beaker image `seungjuh/oe-safety-support-olmo17`
 
 **Important**: Please include all the beaker arguments exactly as in the examples unless intentionally modifying some configuration. Many of them are necessary to avoid job failures, such as `--beaker-image`, `--venv`, and `--env-secret`. Note that `openai_api_key` and `hf_token` are Beaker workspace secret names, so should *not* be replaced with actual values (see One-Time Setup).
-
-```bash
-gantry run --workspace {your_workspace} --cluster {cluster} --gpus {n_gpus} \
-    --name {beaker_experiment_name} --task-name {beaker_task_name} --beaker-image seungjuh/oe-safety-support-olmo17 --venv base \
-    --env-secret OPENAI_API_KEY=openai_api_key \
-    --env-secret HF_TOKEN=hf_token \
-    --budget {budget} -- python evaluation/eval.py generators \
-    --use_vllm \
-    --model_name_or_path allenai/tulu-2-dpo-7b \
-    --model_input_template_path_or_name tulu2 \
-    --tasks harmbench,harmbench:vanilla_ai2_refusal_classifier,toxigen:tiny,trustllm:xstest \
-    --report_output_path /results/metrics.json --save_individual_results_path /results/all.json
-```
 
 Note that the `--` divides the gantry command from the evaluation command - you can edit the second part to run whatever eval suite you want from the `eval.py` script, or any other script in the OE-Safety repo. Any additional Beaker arguments such as a dataset mount to use a model from a Beaker dataset or adding a priority tag can be added before the `--`.
 

--- a/docs/safety-eval/safety.md
+++ b/docs/safety-eval/safety.md
@@ -4,7 +4,7 @@
 Run the following command from the main project dir `open-instruct`.
 ### Safety benchmarks
 
-For all benchmarks requiring safety classification unless noted otherwise, as a default, we use the [WildGuard](https://github.com/allenai/wildguard) classifier to evaluate the safety of model outputs.
+For all benchmarks requiring safety evaluation unless noted otherwise, as a default, we use the [WildGuard](https://github.com/allenai/wildguard) classifier to evaluate the safety of model outputs.
 
 - [WildGuardTest](https://arxiv.org/abs/2406.18495)
 - [Harmbench](https://arxiv.org/abs/2402.04249)

--- a/requirements-olmo.txt
+++ b/requirements-olmo.txt
@@ -37,3 +37,5 @@ black
 flake8
 isort
 autoflake
+tenacity==8.4.1
+fastchat==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,3 +49,5 @@ autoflake
 pytest
 hf_transfer
 beaker-py
+tenacity==8.4.1
+fastchat==0.1.0


### PR DESCRIPTION
Added [safety-eval](https://github.com/allenai/safety-eval) repo as a submodule. Running the evaluation is straightforward. I've included a README under `open-instruct/docs/safety-eval` ([safety.md](https://github.com/allenai/open-instruct/blob/safety-eval/docs/safety-eval/safety.md)) that details how to run the scripts both in an interactive session and on Beaker. The submodule supports evaluation on 7 different benchmarks.

Currently, the submodule points to a fork of [safety-eval](https://github.com/allenai/safety-eval). If you’d like to make changes to the safety evaluation scripts, let me know, and I can add you to the fork.

Why a Submodule?
- Generally, I prefer not to use submodules, but this is a temporary solution to quickly integrate safety evaluation.
- Rewriting the code in the open-instruct evaluation logic would be time-consuming and may not be worthwhile, especially since Oyvind mentioned (on friday) that safety evaluation will be integrated into oe-eval within the next two weeks.

Are results added to the leaderboard?
- I'm missing info on how to add them properly, currently the code is uploading scores into a table in HF repo but doesn't look nice, you can look [here](https://github.com/nouhadziri/safety-eval-fork/blob/0291617446f4edf32297c313389dd0b0ae1e4cff/evaluation/run_all_generation_benchmarks.py#L149-L168) to make changes: 