### PR TITLE
Fix NLTK punkt download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ RUN pip install -r requirements.txt
 
 # NLTK download
 RUN python -m nltk.downloader punkt
+RUN python -m nltk.downloader punkt_tab
 
 COPY open_instruct open_instruct
 COPY eval eval

--- a/Dockerfile.olmo
+++ b/Dockerfile.olmo
@@ -58,6 +58,7 @@ RUN pip install -r requirements-olmo.txt
 
 # NLTK download
 RUN python -m nltk.downloader punkt
+RUN python -m nltk.downloader punkt_tab
 
 COPY open_instruct open_instruct
 COPY eval eval


### PR DESCRIPTION
NLTK recently updated and added breaking change with punkt (https://github.com/nltk/nltk/issues/3293) that means we no longer download the required package for IFEval. This fixes that.