### PR TITLE
Fix resumption when dataset mixer is present

### DIFF
--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -520,8 +520,6 @@ def main(args: FlatArguments):
 
     # Figure out how many steps we should save the Accelerator states
     checkpointing_steps = args.checkpointing_steps
-    if checkpointing_steps is not None:
-        checkpointing_steps = int(checkpointing_steps)
 
     # We need to initialize the trackers we use, and also store our configuration.
     # The trackers initializes automatically on the main process.

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -553,8 +553,6 @@ def main(args: FlatArguments):
 
     # Figure out how many steps we should save the Accelerator states
     checkpointing_steps = args.checkpointing_steps
-    if checkpointing_steps is not None:
-        checkpointing_steps = int(checkpointing_steps)
 
     # We need to initialize the trackers we use, and also store our configuration.
     # The trackers initializes automatically on the main process.

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -838,6 +838,7 @@ def clean_last_n_checkpoints(output_dir: str, keep_last_n_checkpoints: int) -> N
     # remove the last checkpoint to save space
     if keep_last_n_checkpoints > 0:
         folders = [f for f in os.listdir(output_dir) if is_checkpoint_folder(output_dir, f)]
+        # find the checkpoint with the largest step
         checkpoints = sorted(folders, key=lambda x: int(x.split("_")[-1]))
         if len(checkpoints) > keep_last_n_checkpoints:
             shutil.rmtree(os.path.join(output_dir, checkpoints[0]))

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -830,9 +830,14 @@ def get_last_checkpoint_path(args: FlatArguments, incomplete: bool = False) -> s
     return last_checkpoint_path
 
 
+def is_checkpoint_folder(dir: str, folder: str) -> bool:
+    return (folder.startswith("step_") or folder.startswith("epoch_")) and os.path.isdir(os.path.join(dir, folder))
+
+
 def clean_last_n_checkpoints(output_dir: str, keep_last_n_checkpoints: int) -> None:
     # remove the last checkpoint to save space
     if keep_last_n_checkpoints > 0:
-        checkpoints = sorted(os.listdir(output_dir), key=lambda x: int(x.split("_")[-1]))
+        folders = [f for f in os.listdir(output_dir) if is_checkpoint_folder(output_dir, f)]
+        checkpoints = sorted(folders, key=lambda x: int(x.split("_")[-1]))
         if len(checkpoints) > keep_last_n_checkpoints:
             shutil.rmtree(os.path.join(output_dir, checkpoints[0]))


### PR DESCRIPTION
When the dataset mixer is present, the presence of the output file mucked up my logic for cleaning older checkpoints. This should fix it.