### PR TITLE
Log beaker experiment URL

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,6 +48,7 @@ python scripts/submit_eval_jobs.py --model_name llama_31_tulu_2_8b --location 01
 
 # submit evals on a model in huggingface; note you need to 1) prepend the model name with `hf-` and 2) replace `--location` with the hf repo id
 python scripts/submit_eval_jobs.py --model_name hf-llama_31_tulu_2_8b --location allenai/llama-3-tulu-2-8b --is_tuned --workspace tulu-3-results --preemptible --use_hf_tokenizer_template --beaker_image nathanl/open_instruct_olmo_auto --upload_to_hf allenai/tulu-3-evals
+python scripts/submit_eval_jobs.py --model_name hf-llama_31_tulu_2_8b --location vwxyzjn/online_dpo_tulu_2 --is_tuned --workspace tulu-3-results --preemptible --use_hf_tokenizer_template --beaker_image nathanl/open_instruct_olmo_auto --upload_to_hf allenai/tulu-3-evals
 ```
 2. `submit_finetune_jobs.py`: **Core script** for submitting multiple and configurable instruction tuning jobs. This script works for both single- and multi-node configurations. It by default reads configs in `configs/train_configs`, but also can take in CLI arguments matching those in `open_instruct/utils.py` `FlatArguments` class. 
 Example of running this is in `scripts/submit_finetune_jobs.sh`. 
@@ -93,10 +94,10 @@ After setting it up successfully, say you are running `sh scripts/dpo_train_with
 
 ```bash
 python mason.py \
-    --cluster ai2/allennlp-cirrascale ai2/general-cirrascale-a5000 ai2/general-cirrascale-a5000 ai2/general-cirrascale-a100-80g-ib \
+    --cluster ai2/allennlp-cirrascale ai2/general-cirrascale-a5000 ai2/general-cirrascale-a5000  \
     --priority low \
     --budget ai2/allennlp \
-    --gpus 1 -- sh scripts/dpo_train_with_accelerate_config.sh 8 configs/train_configs/dpo/default.yaml
+    --gpus 8 -- sh scripts/dpo_train_with_accelerate_config.sh 8 configs/train_configs/dpo/default.yaml
 ```
 
 


### PR DESCRIPTION
This PR attempts to add the beaker experiment URL in wandb when possible, so you can directly go from wandb experiment to the beaker experiment. 


* https://wandb.ai/ai2-llm/open_instruct_internal/runs/ze11zq9p

<img width="785" alt="image" src="https://github.com/user-attachments/assets/be1cbe20-0a6c-46ac-8998-6e8dd3e6516a">

<img width="863" alt="image" src="https://github.com/user-attachments/assets/3832f41a-05a4-458e-af98-3ebde594aefd">



https://github.com/user-attachments/assets/83092032-34b8-430b-a52d-3cd973be4ad0

