### PR TITLE
RS: save config and raw scores

### DIFF
--- a/docs/algorithms/rejection_sampling.md
+++ b/docs/algorithms/rejection_sampling.md
@@ -52,7 +52,8 @@ python open_instruct/rejection_sampling/rejection_sampling.py \
     --num_gpus 1 \
 
 # 2.3 tokenize them and run a combination of reward models / llm as a judge
-# Here is an example created dataset: https://huggingface.co/datasets/vwxyzjn/rejection_sampling_1723745582
+# Here is an example created dataset: https://huggingface.co/datasets/vwxyzjn/rejection_sampling_1724273702
+# Here is an example created dataset for raw scores: https://huggingface.co/datasets/vwxyzjn/rejection_sampling_scores_1724273702
 python open_instruct/rejection_sampling/rejection_sampling.py \
     --input_filename output/completions.jsonl \
     --model_names_or_paths allenai/llama-3-tulu-2-8b-uf-mean-rm gpt-4o-mini gpt-4-turbo \

--- a/docs/algorithms/rejection_sampling.md
+++ b/docs/algorithms/rejection_sampling.md
@@ -17,6 +17,7 @@ python open_instruct/rejection_sampling/generation.py \
     --num_completions 3 \
     --save_filename output/completions.jsonl \
     --sanity_check \
+    --push_to_hub 
 ```
 
 ### Scoring completions

--- a/docs/algorithms/rejection_sampling.md
+++ b/docs/algorithms/rejection_sampling.md
@@ -8,9 +8,10 @@ different number of completions per prompt.
 # Debug run (use an interactive session)
 
 This code supports HF models, local models and also API-based models (e.g., `gpt-4`). For generating completions, the code now accepts one model at a time, but we're working on adding an ensemble of models. Stay tuned. 
+
 ```bash
-## tulu v3 recipe
 # 1. first sample a bunch of completions given prompts
+# Here is an example created dataset: https://huggingface.co/datasets/vwxyzjn/generation_1724272894
 python open_instruct/rejection_sampling/generation.py \
     --dataset_name allenai/tulu-v2-sft-mixture \
     --model_name_or_path allenai/llama-3-tulu-2-8b \
@@ -25,10 +26,12 @@ You can use either a single RM to score responses or a list of RMs. In the latte
 
 ```bash
 # 2.1 tokenize them and run a reward model to filter them
-# Here is an example created dataset: https://huggingface.co/datasets/vwxyzjn/rejection_sampling_1723742650
+# Here is an example created dataset: https://huggingface.co/datasets/vwxyzjn/rejection_sampling_1724273165
+# Here is an example created dataset for raw scores: https://huggingface.co/datasets/vwxyzjn/rejection_sampling_scores_1724273165
 python open_instruct/rejection_sampling/rejection_sampling.py \
     --input_filename output/completions.jsonl \
     --model_names_or_paths allenai/llama-3-tulu-2-8b-uf-mean-rm \
+    --save_filename_scores output/completions_scores.jsonl \
     --save_filename output/rejection_sampled_completions.jsonl \
     --num_completions 3 \
     --push_to_hub \
@@ -37,10 +40,12 @@ python open_instruct/rejection_sampling/rejection_sampling.py \
 # 2.2 tokenize them and run llm as a judge
 # Note then when using LLM as a judge, it's possible that llm api failed to produce a score in our expected
 # format, so score extraction failed and we simply mark the score -1.
-# Here is an example created dataset: https://huggingface.co/datasets/vwxyzjn/rejection_sampling_1723745040
+# Here is an example created dataset: https://huggingface.co/datasets/vwxyzjn/rejection_sampling_1724273303
+# Here is an example created dataset for raw scores: https://huggingface.co/datasets/vwxyzjn/rejection_sampling_scores_1724273303
 python open_instruct/rejection_sampling/rejection_sampling.py \
     --input_filename output/completions.jsonl \
     --model_names_or_paths gpt-4o-mini  \
+    --save_filename_scores output/completions_scores.jsonl \
     --save_filename output/rejection_sampled_completions.jsonl \
     --num_completions 3 \
     --push_to_hub \
@@ -51,6 +56,7 @@ python open_instruct/rejection_sampling/rejection_sampling.py \
 python open_instruct/rejection_sampling/rejection_sampling.py \
     --input_filename output/completions.jsonl \
     --model_names_or_paths allenai/llama-3-tulu-2-8b-uf-mean-rm gpt-4o-mini gpt-4-turbo \
+    --save_filename_scores output/completions_scores.jsonl \
     --save_filename output/rejection_sampled_completions.jsonl \
     --num_completions 3 \
     --push_to_hub \

--- a/scripts/rejection_sampling_tulu_docker.bash
+++ b/scripts/rejection_sampling_tulu_docker.bash
@@ -4,14 +4,17 @@ mkdir -p output/shards
 num_prompts=1000
 num_shards=4
 prompts_per_shard=$((num_prompts / num_shards))
-shared_hf_repo_id=rejection_sampling_$RANDOM 
+timestamp=$RANDOM
+shared_generation_hf_repo_id=generation_$timestamp
+shared_rs_hf_repo_id=rejection_sampling_$timestamp
+shared_scores_hf_repo_id=scores_$timestamp
 num_completions=5
 generation_model=allenai/llama-3-tulu-2-8b
 reward_model=allenai/llama-3-tulu-2-8b-uf-mean-rm
 sft_dataset=allenai/tulu-v2-sft-mixture
 on_jupyter=true
 num_gpus=1
-mkdir -p output/shards/$shared_hf_repo_id
+mkdir -p output/shards/$timestamp
 
 # Prepare the command string
 command=""
@@ -34,13 +37,18 @@ do
     --model_name_or_path $generation_model \
     --dataset_start_idx $start_idx \
     --dataset_end_idx $end_idx \
-    --save_filename output/shards/$shared_hf_repo_id/$i.jsonl \
+    --save_filename output/shards/$timestamp/$i.jsonl \
+    --hf_repo_id $shared_generation_hf_repo_id \
+    --no_add_timestamp \
+    --push_to_hub \
     --num_completions $num_completions --tensor_parallel_size $num_gpus && \
     python open_instruct/rejection_sampling/rejection_sampling.py \
-    --input_filename output/shards/$shared_hf_repo_id/$i.jsonl \
+    --input_filename output/shards/$timestamp/$i.jsonl \
     --model_names_or_paths $reward_model \
-    --save_filename output/shards/$shared_hf_repo_id/scores_$i.jsonl \
-    --hf_repo_id $shared_hf_repo_id \
+    --save_filename output/shards/$timestamp/rs_$i.jsonl \
+    --save_filename_scores output/shards/$timestamp/scores_$i.jsonl \
+    --hf_repo_id $shared_rs_hf_repo_id \
+    --hf_repo_id_scores $shared_scores_hf_repo_id \
     --no_add_timestamp \
     --num_completions $num_completions \
     --push_to_hub \
@@ -64,7 +72,7 @@ echo "Submitting all shards in one command"
 if [ "$on_jupyter" = true ]; then
     python mason.py \
         --cluster ai2/jupiter-cirrascale-2 \
-        --image costah/open_instruct \
+        --image costah/open_instruct_rs \
         --pure_docker_mode \
         --priority low \
         --preemptible \
@@ -75,7 +83,7 @@ else
     echo "Running on Mason"
     python mason.py \
     --cluster ai2/allennlp-cirrascale ai2/pluto-cirrascale ai2/prior-cirrascale ai2/s2-cirrascale \
-    --image costah/open_instruct \
+    --image costah/open_instruct_rs \
     --pure_docker_mode \
     --priority low \
     --preemptible \


### PR DESCRIPTION
UPDATE: docker works, too! https://beaker.org/ex/01J5VCT8W19KYE1F0NSS2AG29C/tasks/01J5VCT8W6VRKWFBB3QA1EA8E0/job/01J5VCT91EXX29AWW9ED8B0A8R

You can expect to get 3 datasets

<img width="858" alt="image" src="https://github.com/user-attachments/assets/6181427f-d8a1-4229-80cf-36224d147575">


This PR save the config in HF dataset. Like https://huggingface.co/datasets/vwxyzjn/rejection_sampling_1724273303 or the following

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/5b97e4c7-865f-46bf-9e7f-78085c62126a">

It also saves the raw scores of the completions from reward models in https://huggingface.co/datasets/vwxyzjn/rejection_sampling_scores_1724273303


<img width="976" alt="image" src="https://github.com/user-attachments/assets/09f82deb-562c-4b0f-a644-c206c466c041">
