### PR TITLE
Patch checkpointing step

### DIFF
--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -828,6 +828,7 @@ def main(args: FlatArguments):
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 
     # Figure out how many steps we should save the Accelerator states
+    checkpointing_steps = args.checkpointing_steps
     if checkpointing_steps is not None and str(checkpointing_steps).lower() != "epoch":
         checkpointing_steps = int(checkpointing_steps)
 

--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -828,8 +828,7 @@ def main(args: FlatArguments):
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 
     # Figure out how many steps we should save the Accelerator states
-    checkpointing_steps = str(args.checkpointing_steps)
-    if checkpointing_steps is not None and checkpointing_steps.lower() != "epoch":
+    if checkpointing_steps is not None and str(checkpointing_steps).lower() != "epoch":
         checkpointing_steps = int(checkpointing_steps)
 
     # We need to initialize the trackers we use, and also store our configuration.

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -826,8 +826,7 @@ def main(args: FlatArguments):
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 
     # Figure out how many steps we should save the Accelerator states
-    checkpointing_steps = str(args.checkpointing_steps)
-    if checkpointing_steps is not None and checkpointing_steps.lower() != "epoch":
+    if checkpointing_steps is not None and str(checkpointing_steps).lower() != "epoch":
         checkpointing_steps = int(checkpointing_steps)
 
     # We need to initialize the trackers we use, and also store our configuration.

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -826,6 +826,7 @@ def main(args: FlatArguments):
     args.num_train_epochs = math.ceil(args.max_train_steps / num_update_steps_per_epoch)
 
     # Figure out how many steps we should save the Accelerator states
+    checkpointing_steps = args.checkpointing_steps
     if checkpointing_steps is not None and str(checkpointing_steps).lower() != "epoch":
         checkpointing_steps = int(checkpointing_steps)
 


### PR DESCRIPTION
https://github.com/allenai/open-instruct/pull/274#discussion_r1721912975 added a conversion to string that meant `checkpointing_steps` was `"None"` not `None`, so when checkpointing steps was not specified we would get errors.
This fixes that.