### PR TITLE
Remove unused checkpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,7 @@ ENTRYPOINT ["bash", "-l"]
 WORKDIR /stage/
 
 # TODO When updating flash-attn or torch in the future, make sure to update the version in the requirements.txt file. 
+ENV HF_HUB_ENABLE_HF_TRANSFER=1
 COPY requirements.txt .
 RUN pip install --upgrade pip "setuptools<70.0.0" wheel 
 # TODO, unpin setuptools when this issue in flash attention is resolved

--- a/Dockerfile.olmo
+++ b/Dockerfile.olmo
@@ -83,6 +83,7 @@ ENTRYPOINT ["bash", "-l"]
 WORKDIR /stage/
 
 # TODO When updating flash-attn or torch in the future, make sure to update the version in the requirements.txt file. 
+ENV HF_HUB_ENABLE_HF_TRANSFER=1
 COPY requirements.txt .
 RUN pip install --upgrade pip "setuptools<70.0.0" wheel 
 # TODO, unpin setuptools when this issue in flash attention is resolved

--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -1020,6 +1020,10 @@ def main(args: FlatArguments):
             args.use_lora,
         )
 
+    # remove all checkpoints to save space
+    if accelerator.is_main_process:
+        clean_last_n_checkpoints(args.output_dir, keep_last_n_checkpoints=0)
+
     if args.push_to_hub:
         push_folder_to_hub(
             accelerator,

--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -60,10 +60,7 @@ from open_instruct.dpo_utils import (
     simpo_loss,
     wpo_loss,
 )
-from open_instruct.model_utils import (
-    push_folder_to_hub,
-    save_with_accelerate,
-)
+from open_instruct.model_utils import push_folder_to_hub, save_with_accelerate
 from open_instruct.utils import (
     ArgumentParserPlus,
     clean_last_n_checkpoints,

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -50,10 +50,7 @@ from transformers import (
     get_scheduler,
 )
 
-from open_instruct.model_utils import (
-    push_folder_to_hub,
-    save_with_accelerate,
-)
+from open_instruct.model_utils import push_folder_to_hub, save_with_accelerate
 from open_instruct.utils import (
     ArgumentParserPlus,
     clean_last_n_checkpoints,
@@ -991,7 +988,7 @@ def main(args: FlatArguments):
             args.output_dir,
             args.use_lora,
         )
-    
+
     # remove all checkpoints to save space
     if accelerator.is_main_process:
         clean_last_n_checkpoints(args.output_dir, keep_last_n_checkpoints=0)

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -991,6 +991,10 @@ def main(args: FlatArguments):
             args.output_dir,
             args.use_lora,
         )
+    
+    # remove all checkpoints to save space
+    if accelerator.is_main_process:
+        clean_last_n_checkpoints(args.output_dir, keep_last_n_checkpoints=0)
 
     if args.push_to_hub:
         push_folder_to_hub(

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -377,6 +377,7 @@ def push_folder_to_hub(
         )
         print(f"🔥 pushed to {hf_repo_url}")
 
+
 # ----------------------------------------------------------------------------
 # DeepSpeed utilities
 def get_all_parameters(sub_module, recurse=False):

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -570,7 +570,8 @@ def clean_last_n_checkpoints(output_dir: str, keep_last_n_checkpoints: int) -> N
         # find the checkpoint with the largest step
         checkpoints = sorted(folders, key=lambda x: int(x.split("_")[-1]))
         if len(checkpoints) > keep_last_n_checkpoints:
-            shutil.rmtree(os.path.join(output_dir, checkpoints[0]))
+            for checkpoint in checkpoints[:len(checkpoints) - keep_last_n_checkpoints]:
+                shutil.rmtree(os.path.join(output_dir, checkpoint))
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
This PR does two things: 

1) speed up HF model upload / download through `HF_HUB_ENABLE_HF_TRANSFER=1`

2) at the end of the training, remove the checkpoints and save only the final model checkpoints. The current model checkpoint could save up to 300GB, which seems a bit excessive. https://beaker.org/ds/01J6351Y7VZ9DAQ5ZS18MCJKHR/details