### PR TITLE
Add hf-transfer to olmo image

### DIFF
--- a/requirements-olmo.txt
+++ b/requirements-olmo.txt
@@ -37,3 +37,5 @@ black
 flake8
 isort
 autoflake
+hf_transfer
+beaker-py


### PR DESCRIPTION
Otherwise the eval image is gonna get 

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/4c34099d-85ab-46da-950d-3855bfe3befd">
