### PR TITLE
Upload training metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ COPY open_instruct open_instruct
 # install the package in editable mode
 COPY pyproject.toml .
 RUN pip install -e .
-COPY .git .
+COPY .git/ ./.git/
 
 COPY eval eval
 COPY configs configs

--- a/Dockerfile.olmo
+++ b/Dockerfile.olmo
@@ -103,7 +103,7 @@ COPY open_instruct open_instruct
 # install the package in editable mode
 COPY pyproject.toml .
 RUN pip install -e .
-COPY .git .
+COPY .git/ ./.git/
 
 COPY eval eval
 COPY configs configs

--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -350,10 +350,8 @@ class FlatArguments:
     """The url of the saved model in the Hugging Face Hub (will be autoset)"""
     try_launch_beaker_eval_jobs: bool = True
     """Whether to launch beaker evaluation jobs after training"""
-    upload_hf_metadata: bool = True
-    """Whether to upload metadata about run to HF or not"""
     hf_metadata_dataset: Optional[str] = None
-    """What dataset to upload the metadata to"""
+    """What dataset to upload the metadata to. If unset, don't upload metadata"""
 
     def __post_init__(self):
         if self.reduce_loss not in ["mean", "sum"]:
@@ -1040,7 +1038,7 @@ def main(args: FlatArguments):
                 location=args.hf_repo_id,
                 hf_repo_revision=args.hf_repo_revision,
             )
-    if args.upload_hf_metadata:
+    if args.hf_metadata_dataset:
         # dpo script only supports these two options right now for datasets
         dataset_name = args.dataset_name if args.dataset_name else args.train_file
         beaker_config = maybe_get_beaker_config()

--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -71,6 +71,7 @@ from open_instruct.utils import (
     maybe_use_ai2_hf_entity,
     maybe_use_ai2_wandb_entity,
     submit_beaker_eval_jobs,
+    upload_metadata_to_hf,
 )
 
 logger = get_logger(__name__)
@@ -850,7 +851,6 @@ def main(args: FlatArguments):
             init_kwargs={"wandb": {"entity": args.wandb_entity, "tags": [args.exp_name] + get_wandb_tags()}},
         )
         wandb_tracker = accelerator.get_tracker("wandb")
-
 
     # Train!
     total_batch_size = args.per_device_train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps

--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -1038,10 +1038,9 @@ def main(args: FlatArguments):
                 location=args.hf_repo_id,
                 hf_repo_revision=args.hf_repo_revision,
             )
-    if args.hf_metadata_dataset:
+    if args.hf_metadata_dataset and accelerator.is_main_process and is_beaker_job():
         # dpo script only supports these two options right now for datasets
         dataset_name = args.dataset_name if args.dataset_name else args.train_file
-        beaker_config = maybe_get_beaker_config()
         # mainly just focussing here on what would be useful for the leaderboard.
         # wandb will have even more useful information.
         metadata_blob = {

--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -350,6 +350,10 @@ class FlatArguments:
     """The url of the saved model in the Hugging Face Hub (will be autoset)"""
     try_launch_beaker_eval_jobs: bool = True
     """Whether to launch beaker evaluation jobs after training"""
+    upload_hf_metadata: bool = True
+    """Whether to upload metadata about run to HF or not"""
+    hf_metadata_dataset: Optional[str] = None
+    """What dataset to upload the metadata to"""
 
     def __post_init__(self):
         if self.reduce_loss not in ["mean", "sum"]:
@@ -1034,6 +1038,22 @@ def main(args: FlatArguments):
                 location=args.hf_repo_id,
                 hf_repo_revision=args.hf_repo_revision,
             )
+    if args.upload_hf_metadata:
+        # dpo script only supports these two options right now for datasets
+        dataset_name = args.dataset_name if args.dataset_name else args.train_file
+        metadata_blob = {
+            "model_name": args.exp_name,
+            "model_type": "dpo",
+            "dpo_type": args.dpo_loss_type,
+            "datasets": [dataset_name],
+            "base_model": args.model_name_or_path
+        }
+        upload_metadata_to_hf(
+            metadata_blob,
+            "metadata.json",
+            args.hf_metadata_dataset,
+            args.exp_name,
+        )
 
     accelerator.wait_for_everyone()
     if args.with_tracking:

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -319,10 +319,8 @@ class FlatArguments:
     """The url of the saved model in the Hugging Face Hub (will be autoset)"""
     try_launch_beaker_eval_jobs: bool = True
     """Whether to launch beaker evaluation jobs after training"""
-    upload_hf_metadata: bool = True
-    """Whether to upload metadata about run to HF or not"""
     hf_metadata_dataset: Optional[str] = None
-    """What dataset to upload the metadata to"""
+    """What dataset to upload the metadata to. If unset, don't upload metadata"""
 
     def __post_init__(self):
         if self.reduce_loss not in ["mean", "sum"]:
@@ -1012,7 +1010,7 @@ def main(args: FlatArguments):
                 location=args.hf_repo_id,
                 hf_repo_revision=args.hf_repo_revision,
             )
-    if args.upload_hf_metadata:
+    if args.hf_metadata_dataset:
         # dpo script only supports these two options right now for datasets
         if args.dataset_mixer:
             dataset_list = args.dataset_mixer.keys()

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -625,7 +625,7 @@ def get_beaker_whoami() -> Optional[str]:
 
 
 def maybe_get_beaker_config():
-    beaker_dataset_ids = [get_beaker_dataset_ids(os.environ["BEAKER_WORKLOAD_ID"])]
+    beaker_dataset_ids = get_beaker_dataset_ids(os.environ["BEAKER_WORKLOAD_ID"])
     beaker_dataset_id_urls = [f"https://beaker.org/ds/{dataset_id}" for dataset_id in beaker_dataset_ids]
     return BeakerRuntimeConfig(
         beaker_workload_id=os.environ["BEAKER_WORKLOAD_ID"],

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -691,12 +691,13 @@ def submit_beaker_eval_jobs(
     logger.error(f"Beaker evaluation jobs: Stderr:\n{stderr.decode()}")
     logger.info(f"Beaker evaluation jobs: process return code: {process.returncode}")
 
+
 def upload_metadata_to_hf(
         metadata_dict,
         filename,
         hf_dataset_name,
         hf_dataset_save_dir,
-    ):
+):
     # upload a random dict to HF. Originally for uploading metadata to HF
     # about a model for leaderboard displays.
     with open("tmp.json", "w") as f:

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -690,3 +690,22 @@ def submit_beaker_eval_jobs(
     logger.info(f"Beaker evaluation jobs: Stdout:\n{stdout.decode()}")
     logger.error(f"Beaker evaluation jobs: Stderr:\n{stderr.decode()}")
     logger.info(f"Beaker evaluation jobs: process return code: {process.returncode}")
+
+def upload_metadata_to_hf(
+        metadata_dict,
+        filename,
+        hf_dataset_name,
+        hf_dataset_save_dir,
+    ):
+    # upload a random dict to HF. Originally for uploading metadata to HF
+    # about a model for leaderboard displays.
+    with open("tmp.json", "w") as f:
+        json.dump(metadata_dict, f)
+    api = HfApi(token=os.getenv("HF_TOKEN", None))
+    api.upload_file(
+        path_or_fileobj="tmp.json",
+        path_in_repo=f"{hf_dataset_save_dir}/{filename}",
+        repo_id=hf_dataset_name,
+        repo_type="dataset",
+    )
+    os.remove("tmp.json")


### PR DESCRIPTION
Gives the ability to upload training metadata when `hf_metadata_dataset` is set. This uploads a file called `metadata.json` to the location provided with the following info:
```bash
{
            "model_name": args.exp_name,
            "model_type": "sft",
            "datasets": dataset_list,
            "base_model": args.model_name_or_path,
            "wandb_path": wandb_tracker.run.get_url(),
            "beaker_experiment": beaker_config.beaker_experiment_url,
            "beaker_datasets": beaker_config.beaker_dataset_id_urls
        }
```

For now, I'll leave this not with any defaults set, but once we setup leaderboard 2.0 we can use this information to make it nicer. It's setup to try and make it to match up with the auto-evals naming scheme, with timestamps and stuff.

Additionally, fixed a small bug with beaker dataset urls (`maybe_get_beaker_config` wrapped the return of `get_beaker_dataset_ids` in a list, but `get_beaker_dataset_ids` already returns a list), and fixed a dockerfile issue with .git.