### PR TITLE
Remove oe-eval in docker image

### DIFF
--- a/.github/workflows/push-image-olmo.yml
+++ b/.github/workflows/push-image-olmo.yml
@@ -45,12 +45,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/checkout@v3
-        with:
-          repository: vwxyzjn/learn-fsdp2 # dummy private repo to test out deploy keys
-          path: './oe-eval-internal'
-          ssh-key: ${{ secrets.OE_EVAL_GIT_CLONE_ACCESS_PRIVATE_SSH_DEPLOY_KEY }}
-
       - name: Setup environment
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -45,12 +45,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/checkout@v3
-        with:
-          repository: vwxyzjn/learn-fsdp2 # dummy private repo to test out deploy keys
-          path: './oe-eval-internal'
-          ssh-key: ${{ secrets.OE_EVAL_GIT_CLONE_ACCESS_PRIVATE_SSH_DEPLOY_KEY }}
-
       - name: Setup environment
         uses: ./.github/actions/setup
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,6 @@ RUN pip install -r requirements.txt
 
 # NLTK download
 RUN python -m nltk.downloader punkt
-COPY oe-eval-internal oe-eval-internal
 COPY open_instruct open_instruct
 
 # install the package in editable mode

--- a/Dockerfile.olmo
+++ b/Dockerfile.olmo
@@ -97,7 +97,6 @@ RUN pip install -r requirements-olmo.txt
 
 # NLTK download
 RUN python -m nltk.downloader punkt
-COPY oe-eval-internal oe-eval-internal
 COPY open_instruct open_instruct
 
 # install the package in editable mode

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -565,13 +565,12 @@ def is_checkpoint_folder(dir: str, folder: str) -> bool:
 
 def clean_last_n_checkpoints(output_dir: str, keep_last_n_checkpoints: int) -> None:
     # remove the last checkpoint to save space
-    if keep_last_n_checkpoints > 0:
-        folders = [f for f in os.listdir(output_dir) if is_checkpoint_folder(output_dir, f)]
-        # find the checkpoint with the largest step
-        checkpoints = sorted(folders, key=lambda x: int(x.split("_")[-1]))
-        if len(checkpoints) > keep_last_n_checkpoints:
-            for checkpoint in checkpoints[:len(checkpoints) - keep_last_n_checkpoints]:
-                shutil.rmtree(os.path.join(output_dir, checkpoint))
+    folders = [f for f in os.listdir(output_dir) if is_checkpoint_folder(output_dir, f)]
+    # find the checkpoint with the largest step
+    checkpoints = sorted(folders, key=lambda x: int(x.split("_")[-1]))
+    if len(checkpoints) > keep_last_n_checkpoints:
+        for checkpoint in checkpoints[:len(checkpoints) - keep_last_n_checkpoints]:
+            shutil.rmtree(os.path.join(output_dir, checkpoint))
 
 
 # ----------------------------------------------------------------------------

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -675,7 +675,6 @@ def submit_beaker_eval_jobs(
         --workspace {workspace} \
         --preemptible \
         --use_hf_tokenizer_template \
-        --run_oe_eval_experiments \
         --beaker_image {beaker_image} \
     """
     if len(hf_repo_revision) > 0:


### PR DESCRIPTION
The oe-eval was blocked by https://github.com/allenai/oe-eval-internal/issues/214. Unfortunately it seems to be related to upstream issues in https://github.com/EleutherAI/lm-evaluation-harness. So the fix might be more difficult than expected.

To avoid blocking the current effort, let's revert to including the oe-eval in the image.