### PR TITLE
Push rejection sampling dataset to beaker dataset as well.

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -179,7 +179,7 @@ def make_task_spec(args, command, i):
         image=beaker.ImageSource(beaker=args.image),
         command=command,
         arguments=[fully_command],
-        result=beaker.ResultSpec(path="/unused"),
+        result=beaker.ResultSpec(path="/output"),
         datasets=get_datasets(args.beaker_datasets, args.no_mount_nfs),
         context=beaker.TaskContext(priority=beaker.Priority(args.priority),
                                    preemptible=args.preemptible),

--- a/scripts/rejection_sampling_tulu_docker.bash
+++ b/scripts/rejection_sampling_tulu_docker.bash
@@ -37,16 +37,16 @@ do
     --model_name_or_path $generation_model \
     --dataset_start_idx $start_idx \
     --dataset_end_idx $end_idx \
-    --save_filename output/shards/$timestamp/$i.jsonl \
+    --save_filename /output/shards/$timestamp/$i.jsonl \
     --hf_repo_id $shared_generation_hf_repo_id \
     --no_add_timestamp \
     --push_to_hub \
     --num_completions $num_completions --tensor_parallel_size $num_gpus && \
     python open_instruct/rejection_sampling/rejection_sampling.py \
-    --input_filename output/shards/$timestamp/$i.jsonl \
+    --input_filename /output/shards/$timestamp/$i.jsonl \
     --model_names_or_paths $reward_model \
-    --save_filename output/shards/$timestamp/rs_$i.jsonl \
-    --save_filename_scores output/shards/$timestamp/scores_$i.jsonl \
+    --save_filename /output/shards/$timestamp/rs_$i.jsonl \
+    --save_filename_scores /output/shards/$timestamp/scores_$i.jsonl \
     --hf_repo_id $shared_rs_hf_repo_id \
     --hf_repo_id_scores $shared_scores_hf_repo_id \
     --no_add_timestamp \


### PR DESCRIPTION
This PR puts the generated rejection sampling jsonls to beaker dataset as well. Maybe helpful to @fabrahman.


Example beaker job:

https://beaker.org/ex/01J6D0428H68FT8GN1ENWQ2QPH

<img width="668" alt="image" src="https://github.com/user-attachments/assets/8bd6a1ae-7dc9-4aed-8784-1c4d3e731612">
