### PR TITLE
Upload metadata along with model weights

### DIFF
--- a/eval/MATH/run_eval.py
+++ b/eval/MATH/run_eval.py
@@ -11,7 +11,8 @@ from eval.utils import (
     query_openai_chat_model,
     dynamic_import_function,
     load_hf_tokenizer,
-    upload_results_to_hf
+    upload_results_to_hf,
+    check_and_upload_model_metadata
 )
 from eval.MATH.examplars import EXAMPLARS as MATH_EXAMPLARS
 from eval.MATH.utilities import last_boxed_only_string, remove_boxed
@@ -213,6 +214,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/alpaca_farm/run_eval.py
+++ b/eval/alpaca_farm/run_eval.py
@@ -8,7 +8,7 @@ import torch
 import datasets
 import vllm
 from alpaca_eval import evaluate as alpaca_farm_evaluate
-from eval.utils import query_openai_chat_model, query_openai_model, generate_completions, dynamic_import_function, load_hf_lm, load_hf_tokenizer, upload_results_to_hf
+from eval.utils import query_openai_chat_model, query_openai_model, generate_completions, dynamic_import_function, load_hf_lm, load_hf_tokenizer, upload_results_to_hf, check_and_upload_model_metadata
 
 def main(args):
     random.seed(42)
@@ -158,6 +158,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
         
 

--- a/eval/bbh/run_eval.py
+++ b/eval/bbh/run_eval.py
@@ -14,7 +14,8 @@ from eval.utils import (
     query_openai_chat_model,
     dynamic_import_function,
     load_hf_tokenizer,
-    upload_results_to_hf
+    upload_results_to_hf,
+    check_and_upload_model_metadata
 )
 
 
@@ -195,6 +196,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/codex_humaneval/run_eval.py
+++ b/eval/codex_humaneval/run_eval.py
@@ -11,6 +11,7 @@ from eval.utils import (
     dynamic_import_function,
     load_hf_tokenizer,
     upload_results_to_hf,
+    check_and_upload_model_metadata,
 )
 from eval.codex_humaneval.data import write_jsonl, read_problems
 from eval.codex_humaneval.evaluation import evaluate_functional_correctness
@@ -194,6 +195,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/gsm/run_eval.py
+++ b/eval/gsm/run_eval.py
@@ -13,7 +13,8 @@ from eval.utils import (
     query_openai_chat_model,
     dynamic_import_function,
     load_hf_tokenizer,
-    upload_results_to_hf
+    upload_results_to_hf,
+    check_and_upload_model_metadata
 )
 from eval.gsm.examplars import EXAMPLARS as GSM_EXAMPLARS
 
@@ -198,6 +199,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/ifeval/run_eval.py
+++ b/eval/ifeval/run_eval.py
@@ -20,7 +20,8 @@ from eval.utils import (
     query_openai_chat_model,
     dynamic_import_function,
     load_hf_tokenizer,
-    upload_results_to_hf
+    upload_results_to_hf,
+    check_and_upload_model_metadata
 )
 from eval.ifeval import instructions_registry
 
@@ -350,6 +351,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/mbpp/run_eval.py
+++ b/eval/mbpp/run_eval.py
@@ -12,6 +12,7 @@ from eval.utils import (
     dynamic_import_function,
     load_hf_tokenizer,
     upload_results_to_hf,
+    check_and_upload_model_metadata,
 )
 from eval.codex_humaneval.data import write_jsonl
 from eval.mbpp.evaluation import compute_code_eval
@@ -206,6 +207,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/mmlu/run_eval.py
+++ b/eval/mmlu/run_eval.py
@@ -6,7 +6,7 @@ import pandas as pd
 import json
 from tqdm import tqdm
 from eval.mmlu.categories import subcategories, categories
-from eval.utils import get_next_word_predictions, load_hf_tokenizer, load_hf_lm, query_openai_chat_model, dynamic_import_function, upload_results_to_hf
+from eval.utils import get_next_word_predictions, load_hf_tokenizer, load_hf_lm, query_openai_chat_model, dynamic_import_function, upload_results_to_hf, check_and_upload_model_metadata
 
 
 choices = ["A", "B", "C", "D"]
@@ -269,6 +269,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/toxigen/run_eval.py
+++ b/eval/toxigen/run_eval.py
@@ -16,6 +16,7 @@ from eval.utils import (
     query_openai_chat_model,
     load_hf_tokenizer,
     upload_results_to_hf,
+    check_and_upload_model_metadata,
 )
 from eval.utils import dynamic_import_function 
 
@@ -197,6 +198,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/truthfulqa/run_eval.py
+++ b/eval/truthfulqa/run_eval.py
@@ -15,6 +15,7 @@ from eval.utils import (
     score_completions,
     dynamic_import_function,
     upload_results_to_hf,
+    check_and_upload_model_metadata,
 )
 from eval.truthfulqa.utilities import (
     format_prompt,
@@ -407,6 +408,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/tydiqa/run_eval.py
+++ b/eval/tydiqa/run_eval.py
@@ -13,6 +13,7 @@ from eval.utils import (
     dynamic_import_function,
     load_hf_tokenizer,
     upload_results_to_hf,
+    check_and_upload_model_metadata,
 )
 
 
@@ -277,6 +278,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/eval/utils.py
+++ b/eval/utils.py
@@ -510,6 +510,7 @@ def upload_results_to_hf(
     os.remove("results.json")
 
 
+@retry_on_exception
 def check_and_upload_model_metadata(model_name_or_path, hf_dataset_name, hf_dataset_save_dir, hf_revision=None):
     # if metadata.json exists in the model directory, upload it to the dataset
     api = HfApi()

--- a/eval/utils.py
+++ b/eval/utils.py
@@ -500,7 +500,7 @@ def upload_results_to_hf(
     # actual save and upload
     with open("results.json", "w") as f:
         json.dump(results_dict, f)
-    api = HfApi(token=os.getenv("HF_TOKEN", None))
+    api = HfApi()
     api.upload_file(
         path_or_fileobj="results.json",
         path_in_repo=hf_dataset_save_path,
@@ -508,3 +508,36 @@ def upload_results_to_hf(
         repo_type="dataset",
     )
     os.remove("results.json")
+
+
+def check_and_upload_model_metadata(model_name_or_path, hf_dataset_name, hf_dataset_save_dir, hf_revision=None):
+    # if metadata.json exists in the model directory, upload it to the dataset
+    api = HfApi()
+    if os.path.exists(f"{model_name_or_path}/metadata.json"):
+        api.upload_file(
+            path_or_fileobj=f"{model_name_or_path}/metadata.json",
+            path_in_repo=f"{hf_dataset_save_dir}/metadata.json",
+            repo_id=hf_dataset_name,
+            repo_type="dataset",
+        )
+    else:
+        # assume its a HF model and try to download the metadata
+        try:
+            from huggingface_hub import hf_hub_download
+            hf_hub_download(
+                model_name_or_path,
+                filename="metadata.json",
+                local_dir=".",
+                revision=hf_revision,
+            )
+        except Exception as e:
+            print(f"Failed to download metadata.json from {model_name_or_path}")
+            print(e)
+            return
+        api.upload_file(
+            path_or_fileobj=f"metadata.json",
+            path_in_repo=f"{hf_dataset_save_dir}/metadata.json",
+            repo_id=hf_dataset_name,
+            repo_type="dataset",
+        )
+    

--- a/eval/xstest/run_eval.py
+++ b/eval/xstest/run_eval.py
@@ -17,7 +17,8 @@ from eval.utils import (
     query_openai_chat_model,
     dynamic_import_function,
     load_hf_tokenizer,
-    upload_results_to_hf
+    upload_results_to_hf,
+    check_and_upload_model_metadata
 )
 from eval.xstest.classify_refusal import classify_refusals_w_gpt4, classify_outputs_w_strmatch
 
@@ -174,6 +175,9 @@ def main(args):
             task_name=task_name,
             primary_score=primary_score,
             prepend_timestamp=True,
+        )
+        check_and_upload_model_metadata(
+            args.model_name_or_path, args.upload_to_hf, args.hf_upload_name, hf_revision=args.hf_revision
         )
 
 

--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -1046,6 +1046,15 @@ def main(args: FlatArguments):
         clean_last_n_checkpoints(args.output_dir, keep_last_n_checkpoints=0)
 
     if is_beaker_job() and accelerator.is_main_process:
+        # dpo script only supports these two options right now for datasets
+        if args.dataset_mixer:
+            dataset_list = args.dataset_mixer.keys()
+        elif args.dataset_mixer_list:
+            dataset_list = args.dataset_mixer_list[::2]  # even indices
+        elif args.dataset_name:
+            dataset_list = [args.dataset_name]
+        else:
+            dataset_list = [args.train_file]
         # mainly just focussing here on what would be useful for the leaderboard.
         # wandb will have even more useful information.
         metadata_blob = {
@@ -1060,17 +1069,8 @@ def main(args: FlatArguments):
         # save in the output directory
         with open(os.path.join(args.output_dir, "metadata.json"), "w") as f:
             json.dump(metadata_blob, f)
-        
+
         if args.hf_metadata_dataset:
-            # dpo script only supports these two options right now for datasets
-            if args.dataset_mixer:
-                dataset_list = args.dataset_mixer.keys()
-            elif args.dataset_mixer_list:
-                dataset_list = args.dataset_mixer_list[::2]  # even indices
-            elif args.dataset_name:
-                dataset_list = [args.dataset_name]
-            else:
-                dataset_list = [args.train_file]
             upload_metadata_to_hf(
                 metadata_blob,
                 "metadata.json",

--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -23,6 +23,7 @@ import os
 import random
 import subprocess
 import time
+import json
 from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -1045,6 +1046,21 @@ def main(args: FlatArguments):
         clean_last_n_checkpoints(args.output_dir, keep_last_n_checkpoints=0)
 
     if is_beaker_job() and accelerator.is_main_process:
+        # mainly just focussing here on what would be useful for the leaderboard.
+        # wandb will have even more useful information.
+        metadata_blob = {
+            "model_name": args.exp_name,
+            "model_type": "sft",
+            "datasets": dataset_list,
+            "base_model": args.model_name_or_path,
+            "wandb_path": wandb_tracker.run.get_url(),
+            "beaker_experiment": beaker_config.beaker_experiment_url,
+            "beaker_datasets": beaker_config.beaker_dataset_id_urls,
+        }
+        # save in the output directory
+        with open(os.path.join(args.output_dir, "metadata.json"), "w") as f:
+            json.dump(metadata_blob, f)
+        
         if args.hf_metadata_dataset:
             # dpo script only supports these two options right now for datasets
             if args.dataset_mixer:
@@ -1055,17 +1071,6 @@ def main(args: FlatArguments):
                 dataset_list = [args.dataset_name]
             else:
                 dataset_list = [args.train_file]
-            # mainly just focussing here on what would be useful for the leaderboard.
-            # wandb will have even more useful information.
-            metadata_blob = {
-                "model_name": args.exp_name,
-                "model_type": "sft",
-                "datasets": dataset_list,
-                "base_model": args.model_name_or_path,
-                "wandb_path": wandb_tracker.run.get_url(),
-                "beaker_experiment": beaker_config.beaker_experiment_url,
-                "beaker_datasets": beaker_config.beaker_dataset_id_urls,
-            }
             upload_metadata_to_hf(
                 metadata_blob,
                 "metadata.json",

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -1006,32 +1006,32 @@ def main(args: FlatArguments):
         clean_last_n_checkpoints(args.output_dir, keep_last_n_checkpoints=0)
 
     if is_beaker_job() and accelerator.is_main_process:
+        # dpo script only supports these two options right now for datasets
+        if args.dataset_mixer:
+            dataset_list = args.dataset_mixer.keys()
+        elif args.dataset_mixer_list:
+            dataset_list = args.dataset_mixer_list[::2]  # even indices
+        elif args.dataset_name:
+            dataset_list = [args.dataset_name]
+        else:
+            dataset_list = [args.train_file]
         # mainly just focussing here on what would be useful for the leaderboard.
         # wandb will have even more useful information.
         metadata_blob = {
-                "model_name": args.exp_name,
-                "model_type": "sft",
-                "datasets": dataset_list,
-                "base_model": args.model_name_or_path,
-                "wandb_path": wandb_tracker.run.get_url(),
-                "beaker_experiment": beaker_config.beaker_experiment_url,
-                "beaker_datasets": beaker_config.beaker_dataset_id_urls,
-            }
+            "model_name": args.exp_name,
+            "model_type": "sft",
+            "datasets": dataset_list,
+            "base_model": args.model_name_or_path,
+            "wandb_path": wandb_tracker.run.get_url(),
+            "beaker_experiment": beaker_config.beaker_experiment_url,
+            "beaker_datasets": beaker_config.beaker_dataset_id_urls,
+        }
         # save metadata to the output directory. then it should also get pushed to HF.
         with open(os.path.join(args.output_dir, "metadata.json"), "w") as f:
             json.dump(metadata_blob, f)
 
         # upload metadata to the dataset if set
         if args.hf_metadata_dataset:
-            # dpo script only supports these two options right now for datasets
-            if args.dataset_mixer:
-                dataset_list = args.dataset_mixer.keys()
-            elif args.dataset_mixer_list:
-                dataset_list = args.dataset_mixer_list[::2]  # even indices
-            elif args.dataset_name:
-                dataset_list = [args.dataset_name]
-            else:
-                dataset_list = [args.train_file]
             upload_metadata_to_hf(
                 metadata_blob,
                 "metadata.json",

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -20,6 +20,7 @@ import os
 import random
 import subprocess
 import time
+import json
 from dataclasses import dataclass, field
 from datetime import timedelta
 from functools import partial
@@ -1005,6 +1006,22 @@ def main(args: FlatArguments):
         clean_last_n_checkpoints(args.output_dir, keep_last_n_checkpoints=0)
 
     if is_beaker_job() and accelerator.is_main_process:
+        # mainly just focussing here on what would be useful for the leaderboard.
+        # wandb will have even more useful information.
+        metadata_blob = {
+                "model_name": args.exp_name,
+                "model_type": "sft",
+                "datasets": dataset_list,
+                "base_model": args.model_name_or_path,
+                "wandb_path": wandb_tracker.run.get_url(),
+                "beaker_experiment": beaker_config.beaker_experiment_url,
+                "beaker_datasets": beaker_config.beaker_dataset_id_urls,
+            }
+        # save metadata to the output directory. then it should also get pushed to HF.
+        with open(os.path.join(args.output_dir, "metadata.json"), "w") as f:
+            json.dump(metadata_blob, f)
+
+        # upload metadata to the dataset if set
         if args.hf_metadata_dataset:
             # dpo script only supports these two options right now for datasets
             if args.dataset_mixer:
@@ -1015,17 +1032,6 @@ def main(args: FlatArguments):
                 dataset_list = [args.dataset_name]
             else:
                 dataset_list = [args.train_file]
-            # mainly just focussing here on what would be useful for the leaderboard.
-            # wandb will have even more useful information.
-            metadata_blob = {
-                "model_name": args.exp_name,
-                "model_type": "sft",
-                "datasets": dataset_list,
-                "base_model": args.model_name_or_path,
-                "wandb_path": wandb_tracker.run.get_url(),
-                "beaker_experiment": beaker_config.beaker_experiment_url,
-                "beaker_datasets": beaker_config.beaker_dataset_id_urls,
-            }
             upload_metadata_to_hf(
                 metadata_blob,
                 "metadata.json",


### PR DESCRIPTION
I previously made an upload thing that was mainly targeted to auto-eval setup. This PR now adds:
- the metadata blob is included with the model weights, making it easier to persist through evals
- if metadata is present in the model directory (local or HF) when running an open-instruct eval, the code uploads the metadata alongside the results. This would be nice if we weren't sort of moving on from the open-instruct evals.

Tested and appears to work:
- https://huggingface.co/datasets/allenai/tulu-3-evals/tree/main/results/finetune__EleutherAI_pythia-14m__42__1725401265
- https://beaker.org/ex/01J6WZDT868FAPYSSM5GEP4HJE/tasks/01J6WZDV152RNECVX5V9GCZHG1/job/01J6WZDV7C0KY5K3SN57YY6F0S

Somewhat annoyingly, this doesnt affect the oe-evals and safety evals we are going to swap to use soon, but I figure its a useful update anyway.