### PR TITLE
Support mixing dataset for reward modeling

### DIFF
--- a/docs/algorithms/reward_modeling.md
+++ b/docs/algorithms/reward_modeling.md
@@ -28,29 +28,7 @@ python open_instruct/reward_modeling.py \
     --push_to_hub \
 ```
 
-You would typically get a track run like https://wandb.ai/ai2-llm/open-instruct/runs/ztgnw64l
-
-
-You can also mix datasets by specifying `--dataset_mixer` and `--dataset_train_splits`
-```bash
-python open_instruct/reward_modeling.py \
-    --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0, "ai2-adapt-dev/summarize_from_feedback_small": 1.0}' \
-    --dataset_train_splits train train \
-    --dataset_eval_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
-    --dataset_eval_splits test \
-    --model_name_or_path EleutherAI/pythia-1b-deduped \
-    --chat_template simple_concat_with_space \
-    --learning_rate 3e-6 \
-    --per_device_train_batch_size 64 \
-    --per_device_eval_batch_size 64 \
-    --gradient_accumulation_steps 1 \
-    --max_token_length 1024 \
-    --max_prompt_token_lenth 1024 \
-    --num_train_epochs 1 \
-    --output_dir models/rm/rm_sentiment_1b \
-    --with_tracking \
-    --push_to_hub \
-```
+You would typically get a track run like https://wandb.ai/ai2-llm/open-instruct/runs/ztgnw64l You can also mix datasets by specifying `--dataset_mixer` and `--dataset_train_splits`
 
 ### Quality of life tools
 
@@ -138,9 +116,33 @@ python open_instruct/reward_modeling.py \
     --with_tracking \
     --push_to_hub \
 ```
+* Tracked experiment: https://wandb.ai/ai2-llm/open_instruct_internal/runs/091a0tix
+* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1725461002
 
-* Tracked experiment: https://wandb.ai/ai2-llm/open-instruct/runs/ztgnw64l
-* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1722961506
+
+```bash
+# LEVEL 1.1: single GPU model training; test dataset mixing
+python open_instruct/reward_modeling.py \
+    --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0, "ai2-adapt-dev/summarize_from_feedback_small": 1.0}' \
+    --dataset_train_splits train train \
+    --dataset_eval_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
+    --dataset_eval_splits test \
+    --model_name_or_path EleutherAI/pythia-1b-deduped \
+    --chat_template simple_concat_with_space \
+    --learning_rate 3e-6 \
+    --per_device_train_batch_size 8 \
+    --per_device_eval_batch_size 8 \
+    --gradient_accumulation_steps 8 \
+    --max_token_length 1024 \
+    --max_prompt_token_lenth 512 \
+    --num_train_epochs 1 \
+    --output_dir models/rm/rm_sentiment_1b \
+    --with_tracking \
+    --push_to_hub
+```
+
+* Tracked experiment: https://wandb.ai/ai2-llm/open_instruct_internal/runs/hop8gzww
+* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1725459456
 
 
 
@@ -166,8 +168,8 @@ accelerate launch  --config_file configs/ds_configs/deepspeed_zero2.yaml \
     --push_to_hub
 ```
 
-* Tracked experiment: https://wandb.ai/ai2-llm/open-instruct/runs/etfpvan2
-* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1722961863
+* Tracked experiment: https://wandb.ai/ai2-llm/open_instruct_internal/runs/mlycj9qb
+* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1725460477
 
 ```bash
 # LEVEL 2: multi-gpu training using DS2 with the anthropic HH dataset
@@ -191,8 +193,8 @@ accelerate launch --config_file configs/ds_configs/deepspeed_zero2.yaml \
     --push_to_hub 
 ```
 
-* Tracked experiment: https://wandb.ai/ai2-llm/open-instruct/runs/0uwj4pmt
-* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1722962876
+* Tracked experiment: https://wandb.ai/ai2-llm/open_instruct_internal/runs/h02kp2ua
+* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1725459462
 
 
 
@@ -215,8 +217,8 @@ accelerate launch --config_file examples/accelerate_configs/deepspeed_zero2.yaml
     --bf16 \
     --output_dir models/rm/rm_zephyr_7b \
 ```
-* Tracked experiment: https://wandb.ai/ai2-llm/open_instruct_internal/runs/iucronh8
-* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__allenai_llama-3-tulu-2-8b/tree/reward_modeling__1__1723404196
+* Tracked experiment: https://wandb.ai/ai2-llm/open_instruct_internal/runs/di1f6p0b
+* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__allenai_llama-3-tulu-2-8b/tree/reward_modeling__1__1725459452
 
 ## Implementation details
 

--- a/docs/algorithms/reward_modeling.md
+++ b/docs/algorithms/reward_modeling.md
@@ -80,6 +80,7 @@ To debug you can run the command with `--sanity_check`, this way it will only de
 python -i open_instruct/reward_modeling.py \
     --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
     --dataset_train_splits train \
+    --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
     --dataset_eval_splits test \
     --model_name_or_path EleutherAI/pythia-14m \
     --chat_template simple_concat_with_space \

--- a/docs/algorithms/reward_modeling.md
+++ b/docs/algorithms/reward_modeling.md
@@ -10,14 +10,15 @@ Here is a command to train a simple reward model on the sentiment dataset taken 
 
 ```bash
 python open_instruct/reward_modeling.py \
-    --dataset_name trl-internal-testing/sentiment-trl-style \
-    --dataset_train_split train \
-    --dataset_eval_split test \
+    --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
+    --dataset_train_splits train \
+    --dataset_eval_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
+    --dataset_eval_splits test \
     --model_name_or_path EleutherAI/pythia-1b-deduped \
     --chat_template simple_concat_with_space \
     --learning_rate 3e-6 \
-    --per_device_train_batch_size 32 \
-    --per_device_eval_batch_size 32 \
+    --per_device_train_batch_size 64 \
+    --per_device_eval_batch_size 64 \
     --gradient_accumulation_steps 1 \
     --max_token_length 1024 \
     --max_prompt_token_lenth 1024 \
@@ -57,9 +58,9 @@ To debug you can run the command with `--sanity_check`, this way it will only de
 
 ```bash
 python -i open_instruct/reward_modeling.py \
-    --dataset_name trl-internal-testing/sentiment-trl-style \
-    --dataset_train_split train \
-    --dataset_eval_split test \
+    --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
+    --dataset_train_splits train \
+    --dataset_eval_splits test \
     --model_name_or_path EleutherAI/pythia-14m \
     --chat_template simple_concat_with_space \
     --learning_rate 3e-6 \
@@ -73,6 +74,137 @@ python -i open_instruct/reward_modeling.py \
     --sanity_check \
     --push_to_hub
 ```
+
+
+## Explanation of the logged metrics
+
+
+* `episode`: the global episode number training has gone through (e.g., `3000` means we have trained on 3000 data points already)
+* `epoch`: the fraction or multiple of the epoch (e.g., `2.7` means we have trained on the dataset for 2 epochs and 70% of the third epoch)
+* `train/rm/accuracy`: the training accuracy of the training batch
+* `train/rm/loss`: the logsigmoid loss of the reward modeling of the training batch
+* `train/rm/chosen_reward`: the reward of the chosen responses of the training batch
+* `train/rm/rejected_reward`: the reward of the rejected responses of the training batch
+* `train/rm/reward_margin`: the reward margin (chosen_reward - rejected_reward) of the training batch
+* `train/rm/lr`: the training learning rate
+
+
+We also have `eval/rm/accuracy`, `eval/rm/loss`, `eval/rm/chosen_rewards`, `eval/rm/rejected_rewards`, `eval/rm/reward_margin` for the evalation dataset.
+
+
+## Experiment results
+
+
+
+```bash
+# LEVEL 1: single GPU model training; adjust your `per_device_train_batch_size` and
+# `gradient_accumulation_steps` accordingly
+# you can also use the `trl-internal-testing/descriptiveness-trl-style` dataset
+python open_instruct/reward_modeling.py \
+    --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
+    --dataset_train_splits train \
+    --dataset_eval_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
+    --dataset_eval_splits test \
+    --model_name_or_path EleutherAI/pythia-1b-deduped \
+    --chat_template simple_concat_with_space \
+    --learning_rate 3e-6 \
+    --per_device_train_batch_size 32 \
+    --per_device_eval_batch_size 32 \
+    --gradient_accumulation_steps 1 \
+    --max_token_length 1024 \
+    --max_prompt_token_lenth 1024 \
+    --num_train_epochs 1 \
+    --output_dir models/rm/rm_sentiment_1b \
+    --with_tracking \
+    --push_to_hub \
+```
+
+* Tracked experiment: https://wandb.ai/ai2-llm/open-instruct/runs/ztgnw64l
+* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1722961506
+
+
+
+```bash
+# LEVEL 2: multi-gpu training using DS2 with the TL;DR summarization dataset
+accelerate launch  --config_file configs/ds_configs/deepspeed_zero2.yaml \
+    open_instruct/reward_modeling.py \
+    --dataset_mixer '{"trl-internal-testing/tldr-preference-trl-style": 1.0}' \
+    --dataset_train_splits train \
+    --dataset_eval_mixer '{"trl-internal-testing/tldr-preference-trl-style": 1.0}' \
+    --dataset_eval_splits validation \
+    --model_name_or_path EleutherAI/pythia-1b-deduped \
+    --chat_template simple_concat_with_space \
+    --learning_rate 3e-6 \
+    --per_device_train_batch_size 32 \
+    --per_device_eval_batch_size 32 \
+    --gradient_accumulation_steps 1 \
+    --max_token_length 1024 \
+    --max_prompt_token_lenth 512 \
+    --num_train_epochs 1 \
+    --output_dir models/rm/rm_tldr_1b \
+    --with_tracking \
+    --push_to_hub
+```
+
+* Tracked experiment: https://wandb.ai/ai2-llm/open-instruct/runs/etfpvan2
+* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1722961863
+
+```bash
+# LEVEL 2: multi-gpu training using DS2 with the anthropic HH dataset
+accelerate launch --config_file configs/ds_configs/deepspeed_zero2.yaml \
+    open_instruct/reward_modeling.py \
+    --dataset_mixer '{"trl-internal-testing/hh-rlhf-trl-style": 1.0}' \
+    --dataset_train_splits train \
+    --dataset_eval_mixer '{"trl-internal-testing/hh-rlhf-trl-style": 1.0}' \
+    --dataset_eval_splits test \
+    --model_name_or_path EleutherAI/pythia-1b-deduped \
+    --chat_template simple_chat \
+    --learning_rate 3e-6 \
+    --per_device_train_batch_size 8 \
+    --per_device_eval_batch_size 8 \
+    --gradient_accumulation_steps 4 \
+    --max_token_length 2048 \
+    --max_prompt_token_lenth 1024 \
+    --num_train_epochs 1 \
+    --output_dir models/rm/rm_hh_1b \
+    --with_tracking \
+    --push_to_hub 
+```
+
+* Tracked experiment: https://wandb.ai/ai2-llm/open-instruct/runs/0uwj4pmt
+* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1722962876
+
+
+
+```bash
+# LEVEL 3: multi-gpu training using DS2 with the ultrafeedback dataset
+accelerate launch --config_file examples/accelerate_configs/deepspeed_zero2.yaml \
+    open_instruct/rm_zephyr.py \
+    --dataset_mixer '{"HuggingFaceH4/ultrafeedback_binarized": 1.0}' \
+    --dataset_train_splits train_prefs \
+    --dataset_eval_mixer '{"HuggingFaceH4/ultrafeedback_binarized": 1.0}' \
+    --dataset_eval_splits test_prefs \
+    --chat_template zephyr \
+    --learning_rate 3e-6 \
+    --per_device_train_batch_size 1 \
+    --per_device_eval_batch_size 1 \
+    --gradient_accumulation_steps 32 \
+    --max_token_length 1024 \
+    --max_prompt_token_lenth 1024 \
+    --num_train_epochs 1 \
+    --bf16 \
+    --output_dir models/rm/rm_zephyr_7b \
+```
+* Tracked experiment: https://wandb.ai/ai2-llm/open_instruct_internal/runs/iucronh8
+* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__allenai_llama-3-tulu-2-8b/tree/reward_modeling__1__1723404196
+
+## Implementation details
+
+These are relevant implementation details on reward modeling:
+
+1. The tokenizer pads from the right: when the length of the data points differ, the tokenizer pads from the right
+1. Disable dropout in the model: this is actually an implementation detail in PPO training, but for consistency we also disable dropout in the reward model training (see p.3. in https://arxiv.org/pdf/1909.08593)
+1. Layer initialization: we initialize the score's weight according to `std=1 / np.sqrt(model.config.hidden_size + 1)` (see p. 11 in https://arxiv.org/abs/2009.01325)
 
 
 ## How does it work?
@@ -247,130 +379,3 @@ The `dataset_processor.get_token_length_visualization` will output the visualiza
 ### Model training
 
 Then given the tokenized datasets, we train on those using the logsigmoid loss. Namely `loss = -F.logsigmoid(chosen_rewards - rejected_rewards).mean()`. 
-
-
-## Explanation of the logged metrics
-
-
-* `episode`: the global episode number training has gone through (e.g., `3000` means we have trained on 3000 data points already)
-* `epoch`: the fraction or multiple of the epoch (e.g., `2.7` means we have trained on the dataset for 2 epochs and 70% of the third epoch)
-* `train/rm/accuracy`: the training accuracy of the training batch
-* `train/rm/loss`: the logsigmoid loss of the reward modeling of the training batch
-* `train/rm/chosen_reward`: the reward of the chosen responses of the training batch
-* `train/rm/rejected_reward`: the reward of the rejected responses of the training batch
-* `train/rm/reward_margin`: the reward margin (chosen_reward - rejected_reward) of the training batch
-* `train/rm/lr`: the training learning rate
-
-
-We also have `eval/rm/accuracy`, `eval/rm/loss`, `eval/rm/chosen_rewards`, `eval/rm/rejected_rewards`, `eval/rm/reward_margin` for the evalation dataset.
-
-
-## Implementation details
-
-These are relevant implementation details on reward modeling:
-
-1. The tokenizer pads from the right: when the length of the data points differ, the tokenizer pads from the right
-1. Disable dropout in the model: this is actually an implementation detail in PPO training, but for consistency we also disable dropout in the reward model training (see p.3. in https://arxiv.org/pdf/1909.08593)
-1. Layer initialization: we initialize the score's weight according to `std=1 / np.sqrt(model.config.hidden_size + 1)` (see p. 11 in https://arxiv.org/abs/2009.01325)
-
-
-## Experiment results
-
-
-
-```bash
-# LEVEL 1: single GPU model training; adjust your `per_device_train_batch_size` and
-# `gradient_accumulation_steps` accordingly
-# you can also use the `trl-internal-testing/descriptiveness-trl-style` dataset
-python open_instruct/reward_modeling.py \
-    --dataset_name trl-internal-testing/sentiment-trl-style \
-    --dataset_train_split train \
-    --dataset_eval_split test \
-    --model_name_or_path EleutherAI/pythia-1b-deduped \
-    --chat_template simple_concat_with_space \
-    --learning_rate 3e-6 \
-    --per_device_train_batch_size 32 \
-    --per_device_eval_batch_size 32 \
-    --gradient_accumulation_steps 1 \
-    --max_token_length 1024 \
-    --max_prompt_token_lenth 1024 \
-    --num_train_epochs 1 \
-    --output_dir models/rm/rm_sentiment_1b \
-    --with_tracking \
-    --push_to_hub \
-```
-
-* Tracked experiment: https://wandb.ai/ai2-llm/open-instruct/runs/ztgnw64l
-* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1722961506
-
-
-
-```bash
-# LEVEL 2: multi-gpu training using DS2 with the TL;DR summarization dataset
-accelerate launch  --config_file configs/ds_configs/deepspeed_zero2.yaml \
-    open_instruct/reward_modeling.py \
-    --dataset_name trl-internal-testing/tldr-preference-trl-style \
-    --dataset_train_split train \
-    --dataset_eval_split validation \
-    --model_name_or_path EleutherAI/pythia-1b-deduped \
-    --chat_template simple_concat_with_space \
-    --learning_rate 3e-6 \
-    --per_device_train_batch_size 32 \
-    --per_device_eval_batch_size 32 \
-    --gradient_accumulation_steps 1 \
-    --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
-    --num_train_epochs 1 \
-    --output_dir models/rm/rm_tldr_1b \
-    --with_tracking \
-    --push_to_hub
-```
-
-* Tracked experiment: https://wandb.ai/ai2-llm/open-instruct/runs/etfpvan2
-* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1722961863
-
-```bash
-# LEVEL 2: multi-gpu training using DS2 with the anthropic HH dataset
-accelerate launch --config_file configs/ds_configs/deepspeed_zero2.yaml \
-    open_instruct/reward_modeling.py \
-    --dataset_name trl-internal-testing/hh-rlhf-trl-style \
-    --dataset_train_split train \
-    --dataset_eval_split test \
-    --model_name_or_path EleutherAI/pythia-1b-deduped \
-    --chat_template simple_chat \
-    --learning_rate 3e-6 \
-    --per_device_train_batch_size 8 \
-    --per_device_eval_batch_size 8 \
-    --gradient_accumulation_steps 4 \
-    --max_token_length 2048 \
-    --max_prompt_token_lenth 1024 \
-    --num_train_epochs 1 \
-    --output_dir models/rm/rm_hh_1b \
-    --with_tracking \
-    --push_to_hub 
-```
-
-* Tracked experiment: https://wandb.ai/ai2-llm/open-instruct/runs/0uwj4pmt
-* Trained model: https://huggingface.co/vwxyzjn/reward_modeling__EleutherAI_pythia-1b-deduped/tree/reward_modeling__1__1722962876
-
-
-
-```bash
-# TODO (Costa): to be tested
-# LEVEL 3: multi-gpu training using DS2 with the ultrafeedback dataset
-accelerate launch --config_file examples/accelerate_configs/deepspeed_zero2.yaml \
-    open_instruct/rm_zephyr.py \
-    --dataset_name HuggingFaceH4/ultrafeedback_binarized \
-    --dataset_train_split train_prefs \
-    --dataset_eval_split test_prefs \
-    --chat_template zephyr \
-    --learning_rate 3e-6 \
-    --per_device_train_batch_size 1 \
-    --per_device_eval_batch_size 1 \
-    --gradient_accumulation_steps 32 \
-    --max_token_length 1024 \
-    --max_prompt_token_lenth 1024 \
-    --num_train_epochs 1 \
-    --bf16 \
-    --output_dir models/rm/rm_zephyr_7b \
-```

--- a/docs/algorithms/reward_modeling.md
+++ b/docs/algorithms/reward_modeling.md
@@ -31,6 +31,26 @@ python open_instruct/reward_modeling.py \
 You would typically get a track run like https://wandb.ai/ai2-llm/open-instruct/runs/ztgnw64l
 
 
+You can also mix datasets by specifying `--dataset_mixer` and `--dataset_train_splits`
+```bash
+python open_instruct/reward_modeling.py \
+    --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0, "ai2-adapt-dev/summarize_from_feedback_small": 1.0}' \
+    --dataset_train_splits train train \
+    --dataset_eval_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
+    --dataset_eval_splits test \
+    --model_name_or_path EleutherAI/pythia-1b-deduped \
+    --chat_template simple_concat_with_space \
+    --learning_rate 3e-6 \
+    --per_device_train_batch_size 64 \
+    --per_device_eval_batch_size 64 \
+    --gradient_accumulation_steps 1 \
+    --max_token_length 1024 \
+    --max_prompt_token_lenth 1024 \
+    --num_train_epochs 1 \
+    --output_dir models/rm/rm_sentiment_1b \
+    --with_tracking \
+    --push_to_hub \
+```
 
 ### Quality of life tools
 

--- a/mason.py
+++ b/mason.py
@@ -174,6 +174,12 @@ def get_datasets(beaker_datasets, no_mount_nfs):
 
 
 def make_task_spec(args, command, i, beaker_secrets, whoami):
+    # special logic to deal with escape like
+    # python mason.py ... -- python x.py --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}'
+    # we need to wrap the json string with single quote
+    for idx in range(len(command)):
+        if "{" in command[idx]:
+            command[idx] = "'" + command[idx] + "'"
     full_command = command
     command = ['/bin/bash', '-c']
     setup_commands = (

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 
-from collections import defaultdict
 import itertools
+from collections import defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import List, Literal, Optional, Tuple, Union
@@ -35,8 +35,8 @@ from accelerate.state import AcceleratorState
 from huggingface_hub import HfApi
 from rich import print as rprint
 from rich.console import Console
-from rich.table import Table
 from rich.panel import Panel
+from rich.table import Table
 from torch.nn.parallel.distributed import DistributedDataParallel
 from transformers import PreTrainedModel, PreTrainedTokenizer
 
@@ -514,26 +514,26 @@ def print_rich_single_line_metrics(metrics):
     table = Table(show_header=False, box=None)
     table.add_column("Category", style="cyan")
     table.add_column("Values", style="magenta")
-    
+
     # Group metrics by their prefix
     grouped_metrics = defaultdict(list)
     for key, value in metrics.items():
-        category = key.split('/')[0] if '/' in key else 'other'
+        category = key.split("/")[0] if "/" in key else "other"
         grouped_metrics[category].append((key, value))
-    
+
     # Sort groups by category name
     for category in sorted(grouped_metrics.keys()):
         values = grouped_metrics[category]
         value_strings = []
         for key, value in values:
             # Use the last part of the key as the display name
-            display_name = key.split('/')[-1]
+            display_name = key.split("/")[-1]
             value_strings.append(f"{display_name}: {format_value(value)}")
-        
+
         # Join all values for this category into a single string
         values_str = " | ".join(value_strings)
         table.add_row(category, values_str)
-    
+
     # Create a panel with the table
     panel = Panel(
         table,
@@ -541,7 +541,7 @@ def print_rich_single_line_metrics(metrics):
         expand=False,
         border_style="bold green",
     )
-    
+
     # Print the panel
     rprint(panel)
 

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -56,7 +56,7 @@ class ModelConfig:
     you must install this manually by running `pip install flash-attn --no-build-isolation`"""
     use_cache: Optional[bool] = None
     """Whether to use cache in the model."""
-    gradient_checkpointing: Optional[bool] = None
+    gradient_checkpointing: bool = False
     """Whether to use gradient checkpointing in the model."""
 
     # PEFT-related args

--- a/open_instruct/reward_modeling.py
+++ b/open_instruct/reward_modeling.py
@@ -3,7 +3,7 @@ import os
 import random
 import time
 from dataclasses import asdict, dataclass
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -139,8 +139,20 @@ class Args:
     """Where to save the model"""
 
     def __post_init__(self):
-        self.dataset_mixer_dict = json.loads(self.dataset_mixer)
-        self.dataset_eval_mixer_dict = json.loads(self.dataset_eval_mixer)
+        self.dataset_mixer_dict, self.dataset_mixer = process_dataset_mixer(self.dataset_mixer)
+        if self.dataset_eval_mixer is not None:
+            self.dataset_eval_mixer_dict, self.dataset_eval_mixer = process_dataset_mixer(self.dataset_eval_mixer)
+
+
+def process_dataset_mixer(value) -> Tuple[Optional[dict], Optional[str]]:
+    # if passed through cli: convert the dataset mixers to dictionaries
+    if isinstance(value, str):
+        return json.loads(value), value
+    # if passed through yaml: convert the dataset mixers to strings
+    elif isinstance(value, dict):
+        return value, json.dumps(value)
+    else:
+        raise ValueError("Input must be either a string or a dictionary")
 
 
 def calculate_runtime_args_and_accelerator(args: Args, model_config: ModelConfig) -> Accelerator:
@@ -178,6 +190,7 @@ def layer_init(layer: nn.Module, std: float):
 def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
     accelerator = calculate_runtime_args_and_accelerator(args, model_config)
     local_seed = args.seed + accelerator.process_index
+    breakpoint()
 
     # set up experiment tracking and seeds
     if accelerator.is_main_process:

--- a/open_instruct/reward_modeling.py
+++ b/open_instruct/reward_modeling.py
@@ -87,6 +87,8 @@ class Args:
     """Which scheduler to use"""
     warm_up_steps: int = 0
     """Number of warm up steps for the scheduler"""
+    gradient_checkpointing: bool = True
+    """Whether to use gradient checkpointing"""
 
     # various batch sizes
     num_train_epochs: int = 1
@@ -256,6 +258,8 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
     model: PreTrainedModel = AutoModelForSequenceClassification.from_pretrained(
         model_config.model_name_or_path, num_labels=1
     )
+    if args.gradient_checkpointing:
+        model.gradient_checkpointing_enable()
     disable_dropout_in_model(model)  # see p.3. in https://arxiv.org/pdf/1909.08593
     layer_init(
         model.score, std=1 / np.sqrt(model.config.hidden_size + 1)

--- a/open_instruct/reward_modeling.py
+++ b/open_instruct/reward_modeling.py
@@ -256,7 +256,7 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
     model: PreTrainedModel = AutoModelForSequenceClassification.from_pretrained(
         model_config.model_name_or_path, num_labels=1
     )
-    if args.gradient_checkpointing:
+    if model_config.gradient_checkpointing:
         model.gradient_checkpointing_enable()
     disable_dropout_in_model(model)  # see p.3. in https://arxiv.org/pdf/1909.08593
     layer_init(

--- a/open_instruct/reward_modeling.py
+++ b/open_instruct/reward_modeling.py
@@ -185,9 +185,9 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
         if is_beaker_job():
             beaker_config = maybe_get_beaker_config()
             # try saving to the beaker `/output`, which will be uploaded to the beaker dataset
-            if len(beaker_config.beaker_dataset_ids) > 0:
+            if len(beaker_config.beaker_dataset_id_urls) > 0:
                 args.output_dir = "/output"
-            all_configs.update(beaker_config)
+            all_configs.update(vars(beaker_config))
 
         if args.with_tracking:
             import wandb

--- a/open_instruct/reward_modeling.py
+++ b/open_instruct/reward_modeling.py
@@ -87,8 +87,6 @@ class Args:
     """Which scheduler to use"""
     warm_up_steps: int = 0
     """Number of warm up steps for the scheduler"""
-    gradient_checkpointing: bool = True
-    """Whether to use gradient checkpointing"""
 
     # various batch sizes
     num_train_epochs: int = 1

--- a/open_instruct/reward_modeling_eval.py
+++ b/open_instruct/reward_modeling_eval.py
@@ -97,11 +97,11 @@ def evaluate(
 
     model.train()
     return {
-        "accuracy": total_accuracy / total_batches,
-        "loss": total_loss / total_batches,
-        "chosen_rewards": total_chosen_rewards / total_batches,
-        "rejected_rewards": total_rejected_rewards / total_batches,
-        "reward_margin": total_reward_margin / total_batches,
+        "eval/rm/accuracy": total_accuracy / total_batches,
+        "eval/rm/loss": total_loss / total_batches,
+        "eval/rm/chosen_rewards": total_chosen_rewards / total_batches,
+        "eval/rm/rejected_rewards": total_rejected_rewards / total_batches,
+        "eval/rm/reward_margin": total_reward_margin / total_batches,
     }, table
 
 

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -463,13 +463,12 @@ def combine_dataset(
             [col for col in dataset.column_names if col not in (columns_to_keep + ["id"])]
         )
         datasets.append(dataset)
-    
-    datasets = concatenate_datasets(datasets)
 
+    datasets = concatenate_datasets(datasets)
 
     # optional save
     if save_data_dir:
-        datasets.to_json(save_data_dir + f"mixed_ds.json")
+        datasets.to_json(save_data_dir + "mixed_ds.json")
 
     if not keep_ids:
         # remove id column
@@ -477,7 +476,6 @@ def combine_dataset(
             datasets = datasets.remove_columns("id")
 
     return datasets
-
 
 
 # ----------------------------------------------------------------------------

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -385,6 +385,101 @@ def get_datasets(
     return raw_datasets
 
 
+def combine_dataset(
+    dataset_mixer: Union[dict, list],
+    splits: List[str],
+    configs: Optional[List[str]] = None,
+    columns_to_keep: Optional[List[str]] = None,
+    shuffle: bool = False,
+    save_data_dir: Optional[str] = None,
+    keep_ids: bool = False,
+) -> DatasetDict:
+    """
+    Loads and mixes datasets according to proportions specified in `dataset_mixer`.
+
+    Args:
+        dataset_mixer (`dict`):
+            Dictionary containing the dataset names and their training proportions.
+        splits (Optional[List[str]], *optional*, defaults to `None`):
+            Dataset splits to load and mix. Assumes the splits exist in
+            all datasets and have a `train_` or `test_` prefix.
+        configs (Optional[List[str]], *optional*, defaults to `None`):
+            List of dataset config names. If given must be the same length as 'dataset_mixer' keys.
+        columns_to_keep (Optional[List[str]], *optional*, defaults to `None`):
+            Column names to keep in the dataset. Useful in the datamixer to avoid schema conflicts,
+            and for cpt this should be (at least) the text column.
+        shuffle (`bool`, *optional*, defaults to `False`):
+            Whether to shuffle the training and testing/validation data.
+        save_data_dir (Optional[str], *optional*, defaults to `None`):
+            Optional directory to save training/test mixes on.
+        keep_ids (`bool`, *optional*, defaults to `False`):
+            Whether to keep ids for training that are added during mixing.
+            Used primarily in mix_data.py for saving, or the saved dataset has IDs already.
+    """
+    if any(frac_or_samples < 0 for frac_or_samples in dataset_mixer.values()):
+        raise ValueError("Dataset fractions / lengths cannot be negative.")
+
+    configs = [None] * len(dataset_mixer) if not configs else configs
+    columns_to_keep = [] if columns_to_keep is None else columns_to_keep
+
+    if configs is not None and len(configs) != len(dataset_mixer):
+        raise ValueError("The number of given dataset config names must be the same as the given number of datasets.")
+
+    # print save location
+    if save_data_dir:
+        print(f"Saving mixed dataset to {save_data_dir}")
+
+    datasets = []
+    for (ds, frac_or_samples), ds_config, split in zip(dataset_mixer.items(), configs, splits):
+        # if dataset ends with .json or .jsonl, load from file
+        if ds.endswith(".json") or ds.endswith(".jsonl"):
+            dataset = load_dataset("json", data_files=ds, split=split)
+        else:
+            try:
+                # Try first if dataset on a Hub repo
+                dataset = load_dataset(ds, ds_config, split=split)
+            except DatasetGenerationError:
+                # If not, check local dataset
+                dataset = load_from_disk(os.path.join(ds, split))
+
+        # shuffle dataset if set
+        if shuffle:
+            dataset = dataset.shuffle(seed=42)
+
+        # select a fraction of the dataset
+        if frac_or_samples > 1.0:
+            samples = int(frac_or_samples)
+        else:
+            samples = int(frac_or_samples * len(dataset))
+        dataset = dataset.select(range(samples))
+
+        # if id not in dataset, create it as ds-{index}
+        if "id" not in dataset.column_names:
+            id_col = [f"{ds}_{i}_{split}" for i in range(len(dataset))]
+            dataset = dataset.add_column("id", id_col)
+
+        # Remove redundant columns to avoid schema conflicts on load
+        dataset = dataset.remove_columns(
+            [col for col in dataset.column_names if col not in (columns_to_keep + ["id"])]
+        )
+        datasets.append(dataset)
+    
+    datasets = concatenate_datasets(datasets)
+
+
+    # optional save
+    if save_data_dir:
+        datasets.to_json(save_data_dir + f"mixed_ds.json")
+
+    if not keep_ids:
+        # remove id column
+        if "id" in datasets.column_names:
+            datasets = datasets.remove_columns("id")
+
+    return datasets
+
+
+
 # ----------------------------------------------------------------------------
 # Arguments utilities
 class ArgumentParserPlus(HfArgumentParser):


### PR DESCRIPTION
Many improvements at once.

1. Now we support the data mixer:

```
python open_instruct/reward_modeling.py \
    --dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0, "ai2-adapt-dev/summarize_from_feedback_small": 1.0}' \
    --dataset_train_splits train train \
    --dataset_eval_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0}' \
    --dataset_eval_splits test \
    --model_name_or_path EleutherAI/pythia-1b-deduped \
    --chat_template simple_concat_with_space \
    --learning_rate 3e-6 \
    --per_device_train_batch_size 64 \
    --per_device_eval_batch_size 64 \
    --gradient_accumulation_steps 1 \
    --max_token_length 1024 \
    --max_prompt_token_lenth 1024 \
    --num_train_epochs 1 \
    --output_dir models/rm/rm_sentiment_1b
```

2. printing is improved
<img width="716" alt="image" src="https://github.com/user-attachments/assets/8b025fc9-4c69-4171-b967-1faad98888f7">

3. we now try to cleverly figure out how many `num_proc` to use, based on allocated beaker CPU and how fast the apply chat template works. For example, in the screenshot below, we use different `num_proc` for filtering and `apply_chat_template` operations.

<img width="769" alt="image" src="https://github.com/user-attachments/assets/63705862-d2ec-436b-85b1-1c5c9615a7fb">

