### PR TITLE
add corresponding lora finetuning with config scripts

### DIFF
--- a/configs/train_configs/sft/tulu2_7b_lora.yaml
+++ b/configs/train_configs/sft/tulu2_7b_lora.yaml
@@ -1,0 +1,26 @@
+# Note, the exact model was trained on TPUs in a different repo
+model_name_or_path: meta-llama/Llama-2-7b
+model_revision: main
+use_flash_attn: true
+use_lora: true
+lora_rank: 64
+lora_alpha: 16
+lora_dropout: 0.1
+tokenizer_name: meta-llama/Llama-2-7b
+use_slow_tokenizer: true
+dataset_name: allenai/tulu-v2-sft-mixture
+max_seq_length: 4096 # Note, reduced from 8192 to fit on one GPU with DeepSpeed Stage3
+preprocessing_num_workers: 16
+per_device_train_batch_size: 1 # note, this is set up for 8 GPUs
+gradient_accumulation_steps: 16 # effective batch size 128 for tulu 2
+learning_rate: 1.0e-04
+lr_scheduler_type: linear
+warmup_ratio: 0.03
+weight_decay: 0.0
+num_train_epochs: 5
+output_dir: output/tulu_v2_7b/
+with_tracking: true
+report_to:
+  - wandb
+logging_steps: 1
+checkpointing_steps: epoch

--- a/configs/train_configs/sft/tulu2_7b_qlora.yaml
+++ b/configs/train_configs/sft/tulu2_7b_qlora.yaml
@@ -1,0 +1,28 @@
+# Note, the exact model was trained on TPUs in a different repo
+model_name_or_path: meta-llama/Llama-2-7b
+model_revision: main
+use_flash_attn: true
+gradient_checkpointing: true
+use_qlora: true
+use_lora: true
+lora_rank: 64
+lora_alpha: 16
+lora_dropout: 0.1
+tokenizer_name: meta-llama/Llama-2-7b
+use_slow_tokenizer: true
+dataset_name: allenai/tulu-v2-sft-mixture
+max_seq_length: 4096 # Note, reduced from 8192 to fit on one GPU with DeepSpeed Stage3
+preprocessing_num_workers: 16
+per_device_train_batch_size: 1 # note, this is set up for 8 GPUs
+gradient_accumulation_steps: 16 # effective batch size 128 for tulu 2
+learning_rate: 1.0e-04
+lr_scheduler_type: linear
+warmup_ratio: 0.03
+weight_decay: 0.0
+num_train_epochs: 5
+output_dir: output/tulu_v2_7b/
+with_tracking: true
+report_to:
+  - wandb
+logging_steps: 1
+checkpointing_steps: epoch

--- a/scripts/finetune_lora_with_accelerate_config.sh
+++ b/scripts/finetune_lora_with_accelerate_config.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# example usage
+# sh scripts/finetune_with_accelerate_config.sh 1 configs/train_configs/sft/default.yaml
+# sh scripts/finetune_with_accelerate_config.sh 8 configs/train_configs/sft/olmo_17_sft.yaml
+
+# Check if exactly two arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <num_gpus> <config_file>"
+    echo "Example: $0 2 path/to/config.yaml"
+    exit 1
+fi
+
+NUM_GPUS="$1"
+CONFIG_FILE="$2"
+
+# Generate CUDA_VISIBLE_DEVICES as a range from 0 to NUM_GPUS-1
+CUDA_VISIBLE_DEVICES=$(seq -s, 0 $((NUM_GPUS-1)))
+export CUDA_VISIBLE_DEVICES
+
+echo "Number of GPUs: $NUM_GPUS"
+echo "Using config file: $CONFIG_FILE"
+echo "CUDA_VISIBLE_DEVICES: $CUDA_VISIBLE_DEVICES"
+
+# You can also set --gradient_checkpointing or use `stage3_offloading_accelerate.conf` to save memory, 
+# but it will trade off speed.
+accelerate launch \
+    --mixed_precision bf16 \
+    --num_machines 1 \
+    --num_processes $NUM_GPUS \
+    --use_deepspeed \
+    --deepspeed_config_file configs/ds_configs/stage3_no_offloading_accelerate.conf \
+    open_instruct/finetune.py \
+    "$2" #\
+    #--report_to=tensorboard,wandb
+
+
+python open_instruct/merge_lora.py \
+    --config_file $CONFIG_FILE \
+    --push_to_hub \
+    --save_tokenizer

--- a/scripts/finetune_qlora_with_accelerate_config.sh
+++ b/scripts/finetune_qlora_with_accelerate_config.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# example usage
+# sh scripts/finetune_with_accelerate_config.sh 1 configs/train_configs/sft/default.yaml
+# sh scripts/finetune_with_accelerate_config.sh 8 configs/train_configs/sft/olmo_17_sft.yaml
+
+# Check if exactly two arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <num_gpus> <config_file>"
+    echo "Example: $0 2 path/to/config.yaml"
+    exit 1
+fi
+
+NUM_GPUS="$1"
+CONFIG_FILE="$2"
+
+# Generate CUDA_VISIBLE_DEVICES as a range from 0 to NUM_GPUS-1
+CUDA_VISIBLE_DEVICES=$(seq -s, 0 $((NUM_GPUS-1)))
+export CUDA_VISIBLE_DEVICES
+
+echo "Number of GPUs: $NUM_GPUS"
+echo "Using config file: $CONFIG_FILE"
+echo "CUDA_VISIBLE_DEVICES: $CUDA_VISIBLE_DEVICES"
+
+# You can also set --gradient_checkpointing or use `stage3_offloading_accelerate.conf` to save memory, 
+# but it will trade off speed.
+accelerate launch \
+    --num_machines 1 \
+    --num_processes $NUM_GPUS \
+    open_instruct/finetune.py \
+    "$2" #\
+    #--report_to=tensorboard,wandb
+
+
+python open_instruct/merge_lora.py \
+    --config_file $CONFIG_FILE \
+    --push_to_hub \
+    --save_tokenizer


### PR DESCRIPTION
Hi, I don't know if it's necessary. I added the corresponding lora fine-tune scripts with config. These scripts work for the same purpose as `scripts/finetune_with_accelerate_config.sh`. The main changes include:

- Add lora and qlora fine-tune scripts with the config file.
- `merge_lora` is modified to be compatible with both scripts using config and old scripts, so the old scripts like `scripts/finetune_lora_with_accelerate.sh` still work.
- During merging, `base_model` will be loaded as `bfloat16` if it was trained by lora. I found merged model dtype changed from `bfloat16` to `float32`. The dtype is normal for qlora. I think you forgot to add `torch_dtype=torch.bfloat16` for lora.
- Add config files (`tulu2_7b_lora.yaml` and `tulu2_7b_qlora.yaml`) as examples.

I have tested scripts using lora, qlora was not tested but should work fine.