### PR TITLE
Fix auto-eval with preemption

### DIFF
--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -699,7 +699,7 @@ def beaker_experiment_succeeded(experiment_id: str) -> bool:
     experiment = get_beaker_experiment_info(experiment_id)
     if not experiment:
         return False
-    return all(["finalized" in job["status"] and job["status"]["exitCode"] == 0 for job in experiment["jobs"]])
+    return any(["finalized" in job["status"] and "exitCode" in job and job["status"]["exitCode"] == 0 for job in experiment["jobs"]])
 
 
 def get_beaker_dataset_ids(experiment_id: str) -> Optional[List[str]]:


### PR DESCRIPTION
This task's first job was preemptied hence causing the auto eval fail. We should try to launch the auto eval if any job succeeded.

 https://beaker.org/ex/01J7CD8BEKTXMWH7BB641339H4/tasks/01J7CD8BERXV9YE871XWMA9T9Z/job/01J7CD8BKGGSGJ809JG7WQSTMP

```
(Pdb) pprint(experiment["jobs"][1]["status"])
{
│   'created': '2024-09-09T23:26:25.530214Z',
│   'scheduled': '2024-09-09T23:31:54.603671Z',
│   'started': '2024-09-09T23:32:16.178279Z',
│   'exited': '2024-09-10T05:31:09.980387Z',
│   'finalized': '2024-09-10T05:46:27.122536Z',
│   'exitCode': 0,
│   'idleSince': '2024-09-10T05:31:09.899198Z',
│   'ready': '2024-09-09T23:32:15.478042Z'
}
(Pdb) pprint(experiment["jobs"][0]["status"])
{
│   'created': '2024-09-09T22:07:49.714903Z',
│   'scheduled': '2024-09-09T22:24:37.101804Z',
│   'finalized': '2024-09-09T23:26:29.378928Z',
│   'message': 'Job canceled while starting',
│   'canceled': '2024-09-09T23:26:25.530214Z',
│   'canceledFor': 'This job or session has been manually preempted by michaelw.',
│   'canceledCode': 2
}
```