### PR TITLE
Fix auto-eval 2

### DIFF
--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -699,7 +699,8 @@ def beaker_experiment_succeeded(experiment_id: str) -> bool:
     experiment = get_beaker_experiment_info(experiment_id)
     if not experiment:
         return False
-    return any(["finalized" in job["status"] and "exitCode" in job and job["status"]["exitCode"] == 0 for job in experiment["jobs"]])
+    print([job["status"] for job in experiment["jobs"]])
+    return any(["finalized" in job["status"] and "exitCode" in job["status"] and job["status"]["exitCode"] == 0 for job in experiment["jobs"]])
 
 
 def get_beaker_dataset_ids(experiment_id: str) -> Optional[List[str]]:


### PR DESCRIPTION
This PR fixes auto-eval. 

```
pprint([job["status"] for job in experiment["jobs"]])
[
│   {
│   │   'created': '2024-09-11T00:38:25.419144Z',
│   │   'scheduled': '2024-09-11T00:39:30.312568Z',
│   │   'started': '2024-09-11T00:46:58.977307Z',
│   │   'exited': '2024-09-11T00:51:16.137042Z',
│   │   'finalized': '2024-09-11T00:51:16.812024Z',
│   │   'exitCode': 143,
│   │   'canceled': '2024-09-11T00:51:10.490376Z',
│   │   'canceledFor': 'preempted by job "01J7F900DW06TTTH02XM81SMFD" with "urgent" priority',
│   │   'canceledCode': 1,
│   │   'idleSince': '2024-09-11T00:51:16.068653Z',
│   │   'ready': '2024-09-11T00:46:58.32884Z'
│   },
│   {
│   │   'created': '2024-09-11T00:51:10.490376Z',
│   │   'scheduled': '2024-09-11T00:51:22.587394Z',
│   │   'started': '2024-09-11T01:00:28.646076Z',
│   │   'exited': '2024-09-11T01:09:46.662708Z',
│   │   'finalized': '2024-09-11T01:09:47.354516Z',
│   │   'exitCode': 143,
│   │   'canceled': '2024-09-11T01:09:40.917523Z',
│   │   'canceledFor': 'preempted by job "01J7FA1XK8SJWZD33ARY8AS7Z3" with "urgent" priority',
│   │   'canceledCode': 1,
│   │   'idleSince': '2024-09-11T01:09:46.596689Z',
│   │   'ready': '2024-09-11T01:00:28.036196Z'
│   },
│   {
│   │   'created': '2024-09-11T01:09:40.917523Z',
│   │   'scheduled': '2024-09-11T02:23:20.328924Z',
│   │   'started': '2024-09-11T02:31:34.465562Z',
│   │   'exited': '2024-09-11T03:35:43.267282Z',
│   │   'finalized': '2024-09-11T03:50:22.541243Z',
│   │   'exitCode': 0,
│   │   'idleSince': '2024-09-11T03:35:43.195864Z',
│   │   'ready': '2024-09-11T02:31:33.780166Z'
│   }
]
```

Tested with 

```
python scripts/wait_beaker_dataset_model_upload_then_evaluate_model.py --beaker_workload_id 01J7F88TCBX771KD9FNWX1X5KW --model_name fae_numina_math_gsm8k_pref_numina_fmt_1.0_sft_4.27___model__42__1726021903
```