### PR TITLE
Hotfix for get beaker dataset id

### DIFF
--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -734,7 +734,7 @@ def get_beaker_dataset_ids(experiment_id: str, sort=False) -> Optional[List[str]
         dataset_infos.extend(
             [
                 DatasetInfo(
-                    id=dataset["id"], committed=dataset["committed"], non_empty=dataset["storage"]["totalSize"] > 0
+                    id=dataset["id"], committed=dataset["committed"], non_empty=True if dataset["storage"]["totalSize"] is None else dataset["storage"]["totalSize"] > 0
                 )
                 for dataset in datasets
             ]

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -734,7 +734,7 @@ def get_beaker_dataset_ids(experiment_id: str, sort=False) -> Optional[List[str]
         dataset_infos.extend(
             [
                 DatasetInfo(
-                    id=dataset["id"], committed=dataset["committed"], non_empty=True if dataset["storage"]["totalSize"] is None else dataset["storage"]["totalSize"] > 0
+                    id=dataset["id"], committed=dataset["committed"], non_empty=False if dataset["storage"]["totalSize"] is None else dataset["storage"]["totalSize"] > 0
                 )
                 for dataset in datasets
             ]


### PR DESCRIPTION
#353 introduces a bug causing jobs to fail. This is because `dataset["storage"]["totalSize"]` is None from beaker if starting a new job and dataset. This PR fixes it.

```
2024-09-18T19:20:07.709597179Z [rank0]:   File "/net/nfs.cirrascale/allennlp/costa/open-instruct/open_instruct/utils.py", line 737, in <listcomp>
2024-09-18T19:20:07.709626417Z [rank0]:     id=dataset["id"], committed=dataset["committed"], non_empty=dataset["storage"]["totalSize"] > 0
2024-09-18T19:20:07.709629945Z [rank0]: TypeError: '>' not supported between instances of 'NoneType' and 'int'
```