### PR TITLE
Onlinedpo Support rm with different vocab size

### DIFF
--- a/docs/algorithms/online_dpo.md
+++ b/docs/algorithms/online_dpo.md
@@ -348,6 +348,8 @@ These are relevant implementation details on reward modeling:
 1. Truncate responses at the stop token: we truncate the responses at the `--stop_token eos` to ensure the generation is stopped at the stop token.
 1. Non-stop penalty: we use a non-stop penalty to the reward model to penalize the model for not stopping at the stop token. For example, if the model does not end at the stop token, we penalize the model by `-10.0` (see `--penalty_reward_value -10.0`).
 1. Async training and generation: we follow the architecture in https://arxiv.org/abs/2310.00036 to do rollout and training asynchronously. This is to ensure that the training is not bottlenecked by the generation.
+1. We also optimizes online DPO runtime by re-using the model training logprob to save an additional forward pass; notice that this does impact KL calculation and causes some numerical issues. See https://github.com/allenai/open-instruct/pull/364 for more detail.
+
 
 ```python
 import queue

--- a/open_instruct/online_dpo_vllm_thread.py
+++ b/open_instruct/online_dpo_vllm_thread.py
@@ -387,6 +387,9 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
     else:
         tokenizer.add_special_tokens({"pad_token": "[PAD]"})  # NOTE: we do not resize the embedding
     tokenizer.chat_template = CHAT_TEMPLATES[dataset_config.chat_template]
+    reward_model_tokenizer = AutoTokenizer.from_pretrained(
+        args.reward_model_path, revision=args.reward_model_revision, padding_side="right"
+    )
 
     # create the dataset
     dataset_dict = DatasetDict()
@@ -451,12 +454,11 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
         attn_implementation="flash_attention_2",
         use_cache=False,
     )
+    different_rm_vocab = reward_model_tokenizer.vocab_size != tokenizer.vocab_size
     if policy.config.vocab_size != reward_model.config.vocab_size:
-        raise ValueError(
-            "Policy and reward model must have the same vocab size. "
+        print(
+            "Policy and reward model have different vocab size. "
             f"Policy: {policy.config.vocab_size}, Reward: {reward_model.config.vocab_size}. "
-            "If they don't have the same vocab size, the policy could generate tokens which "
-            "is going to cause index out of bound error in the reward model."
         )
     model = policy
     if model_config.gradient_checkpointing:
@@ -475,7 +477,7 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
         num_warmup_steps=args.warm_up_steps,
         num_training_steps=args.num_training_steps * args.num_train_epochs,
     )
-    data_collator = SimpleGenerateCollator(pad_token_id=tokenizer.pad_token_id)
+    data_collator = SimpleGenerateCollator(pad_token_id=tokenizer.pad_token_id, keep_messages=different_rm_vocab)
     dataloader = DataLoader(
         train_dataset,
         batch_size=args.local_dataloader_batch_size,
@@ -606,6 +608,8 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
     queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
     queries_next = queries_next.repeat(args.num_generation_per_prompt, 1)
     send_queries(accelerator, None, tokenizer, param_prompt_Q, queries_next)
+    if different_rm_vocab:
+        data["messages"]
 
     for _ in range(1, resume_training_step):  # we didn't store scheduler state
         scheduler.step()
@@ -614,6 +618,8 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
         episode += args.batch_size
         scheduler.step()
         queries = queries_next
+        if different_rm_vocab:
+            pass
         if ph.preemptied:
             break
 
@@ -643,6 +649,8 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                     data = next(iter_dataloader)
                     queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
                     queries_next = queries_next.repeat(args.num_generation_per_prompt, 1)
+                    if different_rm_vocab:
+                        data["messages"]
                 send_queries(accelerator, generation_model, tokenizer, param_prompt_Q, queries_next)
             else:
                 if training_step != 1:
@@ -653,13 +661,14 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                     queries_next = queries_next.repeat(args.num_generation_per_prompt, 1)
                     send_queries(accelerator, generation_model, tokenizer, param_prompt_Q, queries_next)
                     queries = queries_next
+                    if different_rm_vocab:
+                        data["messages"]
 
             training_time_start = time.time()
             with torch.no_grad():
                 context_length = queries.shape[1]
                 responses = []
                 postprocessed_responses = []
-                logprobs = []
                 ref_logprobs = []
                 scores = []
                 sequence_lengths = []
@@ -688,13 +697,6 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                     query = queries[i : i + args.local_rollout_forward_batch_size]
                     query_response = query_responses[i : i + args.local_rollout_forward_batch_size]
                     response = query_response[:, context_length:]
-                    output = forward(generation_model, query_response, tokenizer.pad_token_id)
-                    logits = output.logits[:, context_length - 1 : -1]
-                    logits /= args.temperature + 1e-7
-                    all_logprob = F.log_softmax(logits, dim=-1)
-                    logprob = torch.gather(all_logprob, 2, response.unsqueeze(-1)).squeeze(-1)
-                    del output, logits, all_logprob
-                    torch.cuda.empty_cache()
 
                     ref_output = forward(ref_model, query_response, tokenizer.pad_token_id)
                     ref_logits = ref_output.logits[:, context_length - 1 : -1]
@@ -720,19 +722,17 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
 
                     responses.append(response)
                     postprocessed_responses.append(postprocessed_response)
-                    logprobs.append(logprob)
                     ref_logprobs.append(ref_logprob)
                     sequence_lengths.append(sequence_length)
                     scores.append(score)
                 responses = torch.cat(responses, 0)
                 postprocessed_responses = torch.cat(postprocessed_responses, 0)
-                logprobs = torch.cat(logprobs, 0)
                 ref_logprobs = torch.cat(ref_logprobs, 0)
                 sequence_lengths = torch.cat(sequence_lengths, 0)
                 scores = torch.cat(scores, 0)
                 global_scores = accelerator.gather(scores)
                 accelerator.print(f"global_scores: {global_scores}, {global_scores.mean()}")
-                del (logprob, ref_logprob, score)
+                del (ref_logprob, score)
                 gc.collect()
                 torch.cuda.empty_cache()
 
@@ -751,15 +751,7 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                 # be very careful with `padding_mask_p1`; see https://excalidraw.com/#json=LWnzG4w2k5DjF_EOL_xPt,e2w3a-hFJ_gX5vOfeyXGTw
                 response_idxs = torch.arange(responses.shape[1], device=responses.device).repeat(responses.shape[0], 1)
                 padding_mask = response_idxs > sequence_lengths.unsqueeze(1)
-                logprobs = torch.masked_fill(logprobs, padding_mask, INVALID_LOGPROB)
                 ref_logprobs = torch.masked_fill(ref_logprobs, padding_mask, INVALID_LOGPROB)
-
-                # 4. compute rewards
-                kl = logprobs - ref_logprobs
-                print(f"{accelerator.local_process_index=}, {kl.sum(1)=}")
-                non_score_reward = -args.beta * kl
-                non_score_reward_sum = non_score_reward.sum(1)
-                rlhf_reward = scores + non_score_reward_sum
 
                 # num_examples should be same as args.local_batch_size divided by 2
                 num_examples = scores.size(0) // 2
@@ -775,6 +767,8 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                 )
                 scores_margin = scores[chosen_indices] - scores[rejected_indices]
 
+        logprobs = []
+        concat_indices = []
         # Do multiple epochs of training on on-policy data (PPO-style), with a fresh random shuffle in each epoch
         for epoch_idx in range(args.num_epochs):
             b_inds = np.random.permutation(args.local_batch_size // args.num_generation_per_prompt)
@@ -801,6 +795,7 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                         rejected_responses = responses[rejected_mb_inds]
 
                         concat_mb_inds = torch.cat((chosen_mb_inds, rejected_mb_inds), dim=0)
+                        concat_indices.append(concat_mb_inds)
                         concat_query_responses = query_responses[concat_mb_inds]
                         concat_output = forward(model, concat_query_responses, tokenizer.pad_token_id)
                         num_examples = chosen_mb_inds.shape[0]
@@ -852,6 +847,15 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                         optimizer.step()
                         optimizer.zero_grad()
                         with torch.no_grad():
+                            if epoch_idx == 0:
+                                response = concat_query_responses[:, context_length:]
+                                logits = concat_output.logits[:, context_length - 1 : -1]
+                                logits /= args.temperature + 1e-7
+                                all_logprob = F.log_softmax(logits, dim=-1)
+                                logprob = torch.gather(all_logprob, 2, response.unsqueeze(-1)).squeeze(-1)
+                                logprob = torch.masked_fill(logprob, padding_mask[concat_mb_inds], INVALID_LOGPROB)
+                                logprobs.append(logprob)
+                                del all_logprob
                             chosen_rewards = args.beta * (chosen_logprobs_sum - chosen_ref_logprobs_sum)
                             rejected_rewards = args.beta * (rejected_logprobs_sum - rejected_ref_logprobs_sum)
                             loss_stats[epoch_idx, minibatch_idx, gradient_accumulation_idx] = loss
@@ -879,6 +883,15 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                 # del everything and empty cache
                 torch.cuda.empty_cache()
         with torch.no_grad():
+            logprobs = torch.cat(logprobs, 0)
+            concat_indices = torch.cat(concat_indices, 0)
+            restore_logprobs = torch.zeros_like(logprobs)
+            restore_logprobs[concat_indices] = logprobs
+            kl = restore_logprobs - ref_logprobs
+            print(f"{accelerator.local_process_index=}, {kl.sum(1)=}")
+            non_score_reward = -args.beta * kl
+            non_score_reward_sum = non_score_reward.sum(1)
+            rlhf_reward = scores + non_score_reward_sum
             local_metrics[0] = sequence_lengths.float().mean()
             local_metrics[1] = (responses == args.stop_token_id).sum().float().mean()
             local_metrics[2] = kl.sum(1).mean()


### PR DESCRIPTION
To test it out run

```
python mason.py \
    --cluster ai2/jupiter-cirrascale-2 --image costah/online_dpo_rm2 --pure_docker_mode \
    --workspace ai2/tulu-3-dev \
    --priority high \
    --budget ai2/allennlp \
    --preemptible \
    --gpus 8 -- accelerate launch --num_processes 7 --config_file configs/ds_configs/deepspeed_zero3.yaml \
    open_instruct/online_dpo_vllm_thread.py \
    --exp_name "online_dpo_vllm_thread_different_rm" \
    --dataset_mixer '{"HuggingFaceH4/no_robots": 9500, "AI-MO/NuminaMath-TIR": 72441}' \
    --dataset_train_splits train \
    --dataset_eval_mixer '{"HuggingFaceH4/no_robots": 1.0}' \
    --dataset_eval_splits test \
    --max_token_length 2048 \
    --max_prompt_token_lenth 2048 \
    --learning_rate 8e-7 \
    --output_dir /output/ \
    --chat_template tulu \
    --per_device_train_batch_size 1 \
    --per_device_eval_batch_size 1 \
    --gradient_accumulation_steps 64 \
    --local_rollout_forward_batch_size 1 \
    --vllm_device cuda:7 \
    --num_epochs 1 \
    --num_mini_batches 1 \
    --total_episodes 300000 \
    --model_name_or_path allenai/open_instruct_dev \
    --model_revision finetune__meta-llama_Meta-Llama-3.1-8B__42__1726352218 \
    --reward_model_path Skywork/Skywork-Reward-Llama-3.1-8B \
    --non_stop_penalty \
    --stop_token eos \
    --penalty_reward_value -10.0 \
    --beta 0.03 \
    --num_evals 3 \
    --seed 3 \
    --response_length 1536 \
    --gradient_checkpointing \
    --with_tracking \
    --push_to_hub
```

It seems to work properly

https://wandb.ai/ai2-llm/open_instruct_internal/reports/online-DPO-with-different-RM-tokenizer--Vmlldzo5NDk2OTE4