### PR TITLE
Support multi-node with online DPO / PPO

### DIFF
--- a/open_instruct/online_dpo_vllm_thread.py
+++ b/open_instruct/online_dpo_vllm_thread.py
@@ -679,8 +679,8 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                     g_vllm_responses[:] = g_padded_response_ids
                 broadcast(g_vllm_responses, 0)
                 local_vllm_responses = g_vllm_responses[
-                    accelerator.local_process_index
-                    * queries.shape[0] : (accelerator.local_process_index + 1)
+                    accelerator.process_index
+                    * queries.shape[0] : (accelerator.process_index + 1)
                     * queries.shape[0]
                 ]
                 query_responses = torch.cat((queries, local_vllm_responses), 1)
@@ -756,7 +756,6 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
 
                 # 4. compute rewards
                 kl = logprobs - ref_logprobs
-                print(f"{accelerator.local_process_index=}, {kl.sum(1)=}")
                 non_score_reward = -args.beta * kl
                 non_score_reward_sum = non_score_reward.sum(1)
                 rlhf_reward = scores + non_score_reward_sum

--- a/open_instruct/ppo_vllm_thread.py
+++ b/open_instruct/ppo_vllm_thread.py
@@ -753,8 +753,8 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                     g_vllm_responses[:] = g_padded_response_ids
                 broadcast(g_vllm_responses, 0)
                 local_vllm_responses = g_vllm_responses[
-                    accelerator.local_process_index
-                    * queries.shape[0] : (accelerator.local_process_index + 1)
+                    accelerator.process_index
+                    * queries.shape[0] : (accelerator.process_index + 1)
                     * queries.shape[0]
                 ]
                 query_responses = torch.cat((queries, local_vllm_responses), 1)


### PR DESCRIPTION
<img width="1352" alt="image" src="https://github.com/user-attachments/assets/2080ab28-c7f7-4763-96b5-f652dfd8b350">

Speed-up isn't precisely linear because vLLM can only be spun up in one instance. If we try to spin up in a second node we get this.

This current code works and I am inclined to include it. To run multi-node we only need to include a `--num_nodes 2` in mason.py


```diff
 python mason.py \
     --cluster ai2/pluto-cirrascale \
     --workspace ai2/tulu-3-dev \
     --priority normal \
+    --num_nodes 2 \
     --budget ai2/allennlp \
     --gpus 8 -- accelerate launch --num_processes 7 --config_file configs/ds_configs/deepspeed_zero3.yaml \
     open_instruct/online_dpo_vllm_thread.py \
     --exp_name "online_dpo_vllm_thread_beta_0.03" \
     --dataset_mixer '{"HuggingFaceH4/no_robots": 1.0}' \
     --dataset_train_splits train \
     --dataset_eval_mixer '{"HuggingFaceH4/no_robots": 1.0}' \
     --dataset_eval_splits test \
     --max_token_length 1024 \
     --max_prompt_token_lenth 512 \
     --learning_rate 8e-7 \
     --output_dir /output/ \
     --chat_template tulu \
     --per_device_train_batch_size 4 \
     --per_device_eval_batch_size 1 \
     --gradient_accumulation_steps 16 \
     --local_rollout_forward_batch_size 4 \
     --vllm_device cuda:7 \
     --num_epochs 1 \
     --num_mini_batches 1 \
     --total_episodes 100000 \
     --model_name_or_path allenai/open_instruct_dev  \
     --model_revision costa_finetune_tulu3_8b_norobot__meta-llama_Meta-Llama-3.1-8B__42__1725559869 \
     --reward_model_path vwxyzjn/reward_modeling__allenai_open_instruct_dev \
     --reward_model_revision reward_modeling__1__1725760619 \
     --non_stop_penalty \
     --stop_token eos \
     --penalty_reward_value -10.0 \
     --beta 0.03 \
     --num_evals 3 \
     --seed 3 \
     --response_length 1024 \
     --gradient_checkpointing \
     --with_tracking \
     --push_to_hub
```


![image](https://github.com/user-attachments/assets/a6089d56-0ae9-4630-b0c6-a22202280b25)


