### PR TITLE
Fix multi-node-eval

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest torch datasets transformers==4.40.2 accelerate
+          python -m pip install pytest torch datasets transformers==4.40.2 accelerate rich
       - name: Run unit tests
         run: pytest open_instruct/test_utils.py

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -30,8 +30,8 @@ from datasets import DatasetDict, concatenate_datasets, load_dataset, load_from_
 from datasets.builder import DatasetGenerationError
 from dateutil import parser
 from huggingface_hub import HfApi
-from transformers import MODEL_FOR_CAUSAL_LM_MAPPING, HfArgumentParser
 from rich.pretty import pprint
+from transformers import MODEL_FOR_CAUSAL_LM_MAPPING, HfArgumentParser
 
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_CAUSAL_LM_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)


### PR DESCRIPTION
@fabrahman shared this [beaker job](https://beaker.org/ex/01J971096BM0CSBEAEP6TE5RC1/tasks/01J971096HZKFPA3BBXCCYR40X/job/01J97109BEGAK2KBVYMJMDT59W) which creates [this auto eval](https://beaker.org/ex/01J98BM7735M79TY28GHPGY47C/tasks/01J98BM77815691ES20JFWR5FQ/job/01J98BM7C7FTP0WKE3PMA1ZNTB) which experiences multinode auto eval issues, and this PR should fix it.

1. Previous behavior:
    * beaker_experiment_succeed was set to True if any job's status was "finalized".
    * This approach was initially implemented to support preemptible jobs in auto-evaluation.
1. New behavior:
    * beaker_experiment_succeed is now set to True only if all multi-node jobs have a "finalized" status.

So the new behavior should handle both 1) multi node jobs and 2) preemptible jobs.


Note that the new behavior does require all replicas to quit gracefully. If you have jobs with 4 replicas, but 1 replica failed, then auto eval would not launch, even if one replica has the trained model.



