### PR TITLE
Make the oi safety eval beaker name shorter

### DIFF
--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -581,7 +581,7 @@ if args.run_oe_eval_experiments:
 # create an experiment that runs the safety eval tasks
 if args.run_safety_evaluations:
     # just take the original spec we had, modify it for safety eval.
-    experiment_name = f"open_instruct_safety_eval_{model_name}_{today}"
+    experiment_name = f"oi_safety_{model_name}"
     d["description"] = experiment_name
     # specific image for safety eval
     d["tasks"][0]["image"]["beaker"] = "hamishivi/open-safety"


### PR DESCRIPTION
This is a bit of ugly hack for now, needs better resolutions in the future.

<img width="944" alt="image" src="https://github.com/user-attachments/assets/289214e6-fc47-4a93-91ee-bff1baebdf47">
