### PR TITLE
Update safety eval for larger models

### DIFF
--- a/docs/safety-eval/safety.md
+++ b/docs/safety-eval/safety.md
@@ -40,7 +40,7 @@ For all benchmarks requiring safety evaluation unless noted otherwise, as a defa
 PYTHONPATH=safety-eval python evaluation/run_all_generation_benchmarks.py    \
  --model_name_or_path allenai/tulu-2-dpo-7b     --model_input_template_path_or_name tulu2    \
   --report_output_path ./generation_results/metrics.json     --save_individual_results_path ./generation_results/all.json \
-  --hf_upload_name {HF upload name} --upload_to_hf {HF repo ID}
+  --hf_upload_name {HF upload name} --upload_to_hf {HF repo ID} --min_gpus_per_task {num. GPUs available}
 ```
 
 **Changing classifiers for safety benchmarks**:

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -611,7 +611,7 @@ if args.run_safety_evaluations:
     task_spec = d["tasks"][0]
     task_spec["name"] = experiment_name
     task_spec["arguments"][0] = f'''
-PYTHONPATH=. python evaluation/run_all_generation_benchmarks.py \
+VLLM_WORKER_MULTIPROC_METHOD=spawn PYTHONPATH=. python evaluation/run_all_generation_benchmarks.py \
     --model_name_or_path /model \
     --model_input_template_path_or_name hf \
     --report_output_path /output/metrics.json \

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -628,6 +628,18 @@ PYTHONPATH=. python evaluation/run_all_generation_benchmarks.py \
     else:  # if it's a beaker model, mount the beaker dataset to `/model`
         task_spec['datasets'][1]['source']['beaker'] = model_info[1]
 
+    task_spec = adjust_gpus(
+        task_spec=task_spec,
+        experiment_group="safety_eval",
+        model_name=model_info[0],
+        gpu_multiplier=args.gpu_multiplier,
+    )
+
+    # add gpu information.
+    # we just assume you want to use all the gpus for one task at a time
+    num_gpus = task_spec['resources']['gpuCount']
+    task_spec["arguments"][0]+= f" --min_gpus_per_task {num_gpus}"
+
     if args.upload_to_hf:
         hf_dataset = args.upload_to_hf
         # to match the way oe-eval script works.


### PR DESCRIPTION
Some updates to make our eval script allow running larger models with the oe-safety fork.