### PR TITLE
Fix dataset mixing logic

### DIFF
--- a/docs/algorithms/online_dpo.md
+++ b/docs/algorithms/online_dpo.md
@@ -31,7 +31,7 @@ python open_instruct/online_dpo_vllm_thread.py \
     --dataset_eval_mixer '{"trl-internal-testing/tldr-preference-sft-trl-style": 1.0}' \
     --dataset_eval_splits validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --model_name_or_path cleanrl/EleutherAI_pythia-1b-deduped__sft__tldr \
     --reward_model_path cleanrl/EleutherAI_pythia-1b-deduped__reward__tldr \
     --non_stop_penalty \
@@ -43,7 +43,7 @@ python open_instruct/online_dpo_vllm_thread.py \
     --per_device_eval_batch_size 2 \
     --gradient_accumulation_steps 64 \
     --max_token_length 2048 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --num_train_epochs 1 \
     --beta 0.1 \
     --output_dir models/rm/rm_sentiment_1b \
@@ -64,7 +64,7 @@ python open_instruct/online_dpo_vllm_thread.py \
     --dataset_eval_mixer '{"trl-internal-testing/tldr-preference-sft-trl-style": 1.0}' \
     --dataset_eval_splits validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --model_name_or_path cleanrl/EleutherAI_pythia-1b-deduped__sft__tldr \
     --reward_model_path cleanrl/EleutherAI_pythia-1b-deduped__reward__tldr \
     --non_stop_penalty \
@@ -76,7 +76,7 @@ python open_instruct/online_dpo_vllm_thread.py \
     --per_device_eval_batch_size 2 \
     --gradient_accumulation_steps 64 \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --num_train_epochs 1 \
     --beta 0.1 \
     --output_dir models/rm/rm_sentiment_1b \
@@ -112,7 +112,7 @@ python mason.py \
     --dataset_eval_mixer '{"trl-internal-testing/tldr-preference-sft-trl-style": 1.0}' \
     --dataset_eval_splits validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 3e-6 \
     --output_dir models/minimal/online_dpo_vllm_thread_tldr \
     --per_device_train_batch_size 16 \
@@ -158,7 +158,7 @@ python mason.py \
     --dataset_eval_mixer '{"HuggingFaceH4/no_robots": 1.0}' \
     --dataset_eval_splits test \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 8e-7 \
     --output_dir /output/ \
     --chat_template tulu \
@@ -211,7 +211,7 @@ python mason.py \
     --dataset_eval_mixer '{"allenai/ultrafeedback_binarized_cleaned": 1.0}' \
     --dataset_eval_splits test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 8e-7 \
     --output_dir /output/ \
     --chat_template tulu \
@@ -265,7 +265,7 @@ python mason.py \
     --dataset_eval_mixer '{"allenai/ultrafeedback_binarized_cleaned": 1.0}' \
     --dataset_eval_splits test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 8e-7 \
     --output_dir /output/ \
     --chat_template tulu \

--- a/docs/algorithms/ppo.md
+++ b/docs/algorithms/ppo.md
@@ -31,7 +31,7 @@ python open_instruct/ppo_vllm_thread.py \
     --dataset_eval_mixer '{"trl-internal-testing/tldr-preference-sft-trl-style": 1.0}' \
     --dataset_eval_splits validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --model_name_or_path cleanrl/EleutherAI_pythia-1b-deduped__sft__tldr \
     --reward_model_path cleanrl/EleutherAI_pythia-1b-deduped__reward__tldr \
     --non_stop_penalty \
@@ -43,7 +43,7 @@ python open_instruct/ppo_vllm_thread.py \
     --per_device_eval_batch_size 2 \
     --gradient_accumulation_steps 64 \
     --max_token_length 2048 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --num_train_epochs 1 \
     --beta 0.1 \
     --output_dir models/rm/rm_sentiment_1b \
@@ -64,7 +64,7 @@ python open_instruct/ppo_vllm_thread.py \
     --dataset_eval_mixer '{"trl-internal-testing/tldr-preference-sft-trl-style": 1.0}' \
     --dataset_eval_splits validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --model_name_or_path cleanrl/EleutherAI_pythia-1b-deduped__sft__tldr \
     --reward_model_path cleanrl/EleutherAI_pythia-1b-deduped__reward__tldr \
     --non_stop_penalty \
@@ -76,7 +76,7 @@ python open_instruct/ppo_vllm_thread.py \
     --per_device_eval_batch_size 2 \
     --gradient_accumulation_steps 64 \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --num_train_epochs 1 \
     --beta 0.1 \
     --output_dir models/rm/rm_sentiment_1b \
@@ -112,7 +112,7 @@ python mason.py \
     --dataset_eval_mixer '{"trl-internal-testing/tldr-preference-sft-trl-style": 1.0}' \
     --dataset_eval_splits validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 3e-6 \
     --output_dir models/minimal/ppo_vllm_thread_tldr \
     --per_device_train_batch_size 16 \
@@ -158,7 +158,7 @@ python mason.py \
     --dataset_eval_mixer '{"HuggingFaceH4/no_robots": 1.0}' \
     --dataset_eval_splits test \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 8e-7 \
     --output_dir /output/ \
     --chat_template tulu \
@@ -211,7 +211,7 @@ python mason.py \
     --dataset_eval_mixer '{"allenai/ultrafeedback_binarized_cleaned": 1.0}' \
     --dataset_eval_splits test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 8e-7 \
     --output_dir /output/ \
     --chat_template tulu \

--- a/docs/algorithms/reward_modeling.md
+++ b/docs/algorithms/reward_modeling.md
@@ -40,7 +40,7 @@ python -i open_instruct/reward_modeling.py \
     --per_device_eval_batch_size 1 \
     --gradient_accumulation_steps 32 \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 1024 \
+    --max_prompt_token_length 1024 \
     --num_train_epochs 1 \
     --output_dir models/rm/rm \
     --sanity_check \
@@ -71,7 +71,7 @@ python mason.py \
     --per_device_eval_batch_size 16 \
     --gradient_accumulation_steps 4 \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --num_train_epochs 1 \
     --output_dir models/rm/rm_sentiment_1b \
     --with_tracking \
@@ -103,7 +103,7 @@ python mason.py \
     --per_device_eval_batch_size 8 \
     --gradient_accumulation_steps 8 \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --num_train_epochs 1 \
     --output_dir models/rm/rm_sentiment_1b \
     --with_tracking \
@@ -134,7 +134,7 @@ python mason.py \
     --per_device_eval_batch_size 8 \
     --gradient_accumulation_steps 4 \
     --max_token_length 2048 \
-    --max_prompt_token_lenth 1024 \
+    --max_prompt_token_length 1024 \
     --num_train_epochs 1 \
     --output_dir models/rm/rm_hh_1b \
     --with_tracking \
@@ -165,7 +165,7 @@ python mason.py \
     --per_device_eval_batch_size 8 \
     --gradient_accumulation_steps 4 \
     --max_token_length 2048 \
-    --max_prompt_token_lenth 1024 \
+    --max_prompt_token_length 1024 \
     --num_train_epochs 1 \
     --output_dir models/rm/rm_hh_1b \
     --with_tracking \
@@ -198,7 +198,7 @@ python mason.py \
     --per_device_eval_batch_size 1 \
     --gradient_accumulation_steps 32 \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 1024 \
+    --max_prompt_token_length 1024 \
     --num_train_epochs 1 \
     --output_dir models/rm/rm_tulu_8b \
     --gradient_checkpointing \
@@ -391,7 +391,7 @@ dataset_config = DatasetConfig(
     dataset_name="trl-internal-testing/sentiment-trl-style",
     chat_template="simple_chat",
     max_token_length=1024,
-    max_prompt_token_lenth=1024,
+    max_prompt_token_length=1024,
 )
 tokenizer = AutoTokenizer.from_pretrained("gpt2")
 tokenizer.chat_template = CHAT_TEMPLATES["simple_chat"]

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -174,7 +174,7 @@ class DatasetConfig:
 
     # filter config
     max_token_length: Optional[int] = None
-    max_prompt_token_lenth: Optional[int] = None
+    max_prompt_token_length: Optional[int] = None
 
     # dataset.map config
     sanity_check: bool = False
@@ -314,8 +314,8 @@ class PreferenceDatasetProcessor(DatasetProcessor):
     def filter(self, dataset: Union[Dataset, DatasetDict]):
         def filter_fn(row):
             return (
-                len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_lenth
-                if self.config.max_prompt_token_lenth is not None
+                len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
+                if self.config.max_prompt_token_length is not None
                 else (
                     True and len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
                     if self.config.max_token_length is not None
@@ -388,8 +388,8 @@ class SFTDatasetProcessor(DatasetProcessor):
     def filter(self, dataset: Dataset):
         def filter_fn(row):
             max_prompt_token_length_ok = True
-            if self.config.max_prompt_token_lenth is not None:
-                max_prompt_token_length_ok = len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_lenth
+            if self.config.max_prompt_token_length is not None:
+                max_prompt_token_length_ok = len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
 
             max_token_length_ok = True
             if self.config.max_token_length is not None:

--- a/open_instruct/online_dpo_vllm_thread.py
+++ b/open_instruct/online_dpo_vllm_thread.py
@@ -391,6 +391,12 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
     # create the dataset
     dataset_dict = DatasetDict()
     dataset_processor = SFTDatasetProcessor(tokenizer=tokenizer, config=dataset_config)
+    if len(args.dataset_train_splits) != len(args.dataset_mixer_dict) and len(args.dataset_train_splits) == 1:
+        args.dataset_train_splits = [args.dataset_train_splits[0]] * len(args.dataset_mixer_dict)
+        print(f"Dataset splits not provided for all datasets. Using the same {args.dataset_train_splits[0]} split for all datasets.")
+    if len(args.dataset_eval_splits) != len(args.dataset_eval_mixer_dict) and len(args.dataset_eval_splits) == 1:
+        args.dataset_eval_splits = [args.dataset_eval_splits[0]] * len(args.dataset_eval_mixer_dict)
+        print(f"Dataset splits not provided for all datasets. Using the same {args.dataset_eval_splits[0]} split for all datasets.")
     train_dataset = combine_dataset(
         args.dataset_mixer_dict,
         splits=args.dataset_train_splits,
@@ -571,7 +577,7 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
             args=(
                 model_config.model_name_or_path,
                 model_config.model_revision,
-                dataset_config.max_prompt_token_lenth + args.response_length,
+                dataset_config.max_prompt_token_length + args.response_length,
                 args.vllm_device,
                 args.vllm_gpu_memory_utilization,
                 generation_config,

--- a/open_instruct/ppo_vllm_thread.py
+++ b/open_instruct/ppo_vllm_thread.py
@@ -457,6 +457,12 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
     # create the dataset
     dataset_dict = DatasetDict()
     dataset_processor = SFTDatasetProcessor(tokenizer=tokenizer, config=dataset_config)
+    if len(args.dataset_train_splits) != len(args.dataset_mixer_dict) and len(args.dataset_train_splits) == 1:
+        args.dataset_train_splits = [args.dataset_train_splits[0]] * len(args.dataset_mixer_dict)
+        print(f"Dataset splits not provided for all datasets. Using the same {args.dataset_train_splits[0]} split for all datasets.")
+    if len(args.dataset_eval_splits) != len(args.dataset_eval_mixer_dict) and len(args.dataset_eval_splits) == 1:
+        args.dataset_eval_splits = [args.dataset_eval_splits[0]] * len(args.dataset_eval_mixer_dict)
+        print(f"Dataset splits not provided for all datasets. Using the same {args.dataset_eval_splits[0]} split for all datasets.")
     train_dataset = combine_dataset(
         args.dataset_mixer_dict,
         splits=args.dataset_train_splits,
@@ -645,7 +651,7 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
             args=(
                 model_config.model_name_or_path,
                 model_config.model_revision,
-                dataset_config.max_prompt_token_lenth + args.response_length,
+                dataset_config.max_prompt_token_length + args.response_length,
                 args.vllm_device,
                 args.vllm_gpu_memory_utilization,
                 generation_config,

--- a/open_instruct/reward_modeling.py
+++ b/open_instruct/reward_modeling.py
@@ -246,6 +246,12 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
     # create the dataset
     dataset_dict = DatasetDict()
     dataset_processor = PreferenceDatasetProcessor(tokenizer=tokenizer, config=dataset_config)
+    if len(args.dataset_train_splits) != len(args.dataset_mixer_dict) and len(args.dataset_train_splits) == 1:
+        args.dataset_train_splits = [args.dataset_train_splits[0]] * len(args.dataset_mixer_dict)
+        print(f"Dataset splits not provided for all datasets. Using the same {args.dataset_train_splits[0]} split for all datasets.")
+    if len(args.dataset_eval_splits) != len(args.dataset_eval_mixer_dict) and len(args.dataset_eval_splits) == 1:
+        args.dataset_eval_splits = [args.dataset_eval_splits[0]] * len(args.dataset_eval_mixer_dict)
+        print(f"Dataset splits not provided for all datasets. Using the same {args.dataset_eval_splits[0]} split for all datasets.")
     train_dataset = combine_dataset(
         args.dataset_mixer_dict,
         splits=args.dataset_train_splits,

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -418,6 +418,7 @@ def combine_dataset(
             Whether to keep ids for training that are added during mixing.
             Used primarily in mix_data.py for saving, or the saved dataset has IDs already.
     """
+    assert len(splits) == len(dataset_mixer), "Number of splits must match the number of datasets."
     if isinstance(dataset_mixer, list):
         assert len(dataset_mixer) % 2 == 0, f"Data mixer list length is not even: {dataset_mixer}"
         mixer_dict = {}

--- a/test.sh
+++ b/test.sh
@@ -59,7 +59,7 @@ accelerate launch --num_processes 2 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train_prefs \
     --dataset_eval_split test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --sft_messages_key chosen \
     --learning_rate 3e-6 \
     --output_dir models/minimal/online_dpo_tulu3 \
@@ -89,7 +89,7 @@ accelerate launch --num_processes 1 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train_prefs \
     --dataset_eval_split test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --sft_messages_key chosen \
     --learning_rate 3e-6 \
     --output_dir models/minimal/online_dpo_tulu3 \
@@ -119,7 +119,7 @@ accelerate launch --num_processes 7 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train_prefs \
     --dataset_eval_split test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --sft_messages_key chosen \
     --learning_rate 3e-6 \
     --output_dir models/minimal/online_dpo_tulu3 \
@@ -310,7 +310,7 @@ accelerate launch --num_processes 2 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train_prefs \
     --dataset_eval_split test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --sft_messages_key chosen \
     --learning_rate 5e-7 \
     --output_dir models/minimal/online_dpo_tulu2_llama333 \
@@ -342,7 +342,7 @@ accelerate launch --num_processes 7 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train_prefs \
     --dataset_eval_split test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --sft_messages_key chosen \
     --learning_rate 5e-7 \
     --output_dir models/minimal/online_dpo_tulu2_llama333 \
@@ -373,7 +373,7 @@ accelerate launch --num_processes 2 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train_prefs \
     --dataset_eval_split test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --sft_messages_key chosen \
     --learning_rate 5e-7 \
     --output_dir models/minimal/online_dpo_tulu2_llama333 \
@@ -403,7 +403,7 @@ accelerate launch --num_processes 7 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train \
     --dataset_eval_split validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 5e-7 \
     --output_dir models/minimal/online_dpo_tulu2_llama333 \
     --chat_template simple_concat_with_space \
@@ -432,7 +432,7 @@ accelerate launch --num_processes 7 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train \
     --dataset_eval_split validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 5e-7 \
     --output_dir models/minimal/online_dpo_tulu2_llama333 \
     --chat_template simple_concat_with_space \
@@ -461,7 +461,7 @@ accelerate launch --num_processes 7 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train_prefs \
     --dataset_eval_split test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --sft_messages_key chosen \
     --learning_rate 5e-7 \
     --output_dir /output/ \
@@ -498,7 +498,7 @@ accelerate launch --num_processes 7 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train_prefs \
     --dataset_eval_split test_prefs \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --sft_messages_key chosen \
     --learning_rate 5e-7 \
     --output_dir /output/ \
@@ -530,7 +530,7 @@ accelerate launch --num_processes 8 --config_file configs/ds_configs/deepspeed_z
     --dataset_train_split train_prefs \
     --dataset_eval_split test_prefs \
     --max_token_length 512 \
-    --max_prompt_token_lenth 256 \
+    --max_prompt_token_length 256 \
     --sft_messages_key chosen \
     --learning_rate 5e-7 \
     --output_dir /output/ \
@@ -563,7 +563,7 @@ accelerate launch --num_processes 7 --config_file configs/ds_configs/deepspeed_z
         --dataset_eval_mixer '{"allenai/ultrafeedback_binarized_cleaned": 1.0}' \
         --dataset_eval_splits test_prefs \
         --max_token_length 1024 \
-        --max_prompt_token_lenth 512 \
+        --max_prompt_token_length 512 \
         --sft_messages_key chosen \
         --learning_rate 5e-7 \
         --output_dir /output/ \
@@ -594,7 +594,7 @@ python open_instruct/online_dpo_vllm_thread.py \
     --dataset_mixer '{"HuggingFaceH4/no_robots": 1.0}' \
     --dataset_train_splits train \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 5e-7 \
     --output_dir /output/ \
     --chat_template tulu \
@@ -633,7 +633,7 @@ python mason.py \
     --dataset_eval_mixer '{"trl-internal-testing/tldr-preference-sft-trl-style": 1.0}' \
     --dataset_eval_splits validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 3e-6 \
     --output_dir models/minimal/online_dpo_vllm_thread_tldr \
     --per_device_train_batch_size 2 \
@@ -660,7 +660,7 @@ accelerate launch --num_processes 3 --config_file configs/ds_configs/deepspeed_z
     --dataset_eval_mixer '{"trl-internal-testing/tldr-preference-sft-trl-style": 1.0}' \
     --dataset_eval_splits validation \
     --max_token_length 1024 \
-    --max_prompt_token_lenth 512 \
+    --max_prompt_token_length 512 \
     --learning_rate 3e-6 \
     --output_dir models/minimal/online_dpo_vllm_thread_tldr \
     --per_device_train_batch_size 2 \


### PR DESCRIPTION
Currently the dataset mixing logic in reward modeling / online DPO / PPO is prone to error: The number of splits need to match up with the number of items in the dataset mixer.

* `--dataset_mixer '{"trl-internal-testing/sentiment-trl-style": 1.0, "ai2-adapt-dev/summarize_from_feedback_small": 1.0}'` 
* `--dataset_train_splits train train`

Otherwise if we use `--dataset_train_splits train`, the logic will not mix in the second dataset. This PR adds an assert statement in the dataset mixer to make sure the number of splits match up the number of items in the dataset mixer. Furthermore it adds a logic that if only one split is available then we try to use that split for all the dataset mixer for easier UX.