### PR TITLE
COT added to MMLU

### DIFF
--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -94,6 +94,7 @@ TASKS=(
     "ifeval::tulu"
     "popqa::tulu"
     "mmlu:mc::tulu"
+    "mmlu:cot::reasoning"
     "alpaca_eval_v2::tulu"
     "truthfulqa::tulu"
 )


### PR DESCRIPTION
The main changes happened in `oe-eval-internal`. In this repo, the only change is adding the task `mmlu:cot::reasoning` to `oe_eval.py`