### PR TITLE
Support weka evaluation oe eval

### DIFF
--- a/configs/beaker_configs/default_eval.yaml
+++ b/configs/beaker_configs/default_eval.yaml
@@ -45,9 +45,9 @@ tasks:
       - mountPath: /model
         source:
           beaker: 01GVYXDGJC6DV0JW9JZ16YM07G
-      - mountPath: /net/nfs.cirrascale
-        source:
-          hostPath: /net/nfs.cirrascale
+      # - mountPath: /net/nfs.cirrascale
+      #   source:
+      #     hostPath: /net/nfs.cirrascale
     result:
       # Beaker will capture anything that's written to this location and store it in the results
       # dataset.

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -193,4 +193,5 @@ for TASK in "${TASKS[@]}"; do
         ${REVISION_ARG} \
         --beaker-retries 2 \
         --beaker-priority "$PRIORITY"
+    fi
 done

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -47,7 +47,8 @@ set -ex
 
 # Function to print usage
 usage() {
-    echo "Usage: $0 --model-name MODEL_NAME --model-location MODEL_LOCATION [--num_gpus GPUS] [--hf-upload] [--revision REVISION] [--max-length <max_length>] [--unseen-evals] [--priority priority]"
+    echo "Usage: $0 --model-name MODEL_NAME --model-location MODEL_LOCATION [--num_gpus GPUS] [--hf-upload] [--revision REVISION] [--max-length <max_length>] [--unseen-evals] [--priority priority] [--tasks TASKS] [--evaluate_on_weka]"
+    echo "TASKS should be a comma-separated list of task specifications (e.g., 'gsm8k::tulu,bbh:cot::tulu')"
     exit 1
 }
 
@@ -62,6 +63,8 @@ while [[ "$#" -gt 0 ]]; do
         --max-length) MAX_LENGTH="$2"; shift ;;
         --unseen-evals) UNSEEN_EVALS="true" ;;
         --priority) PRIORITY="$2"; shift ;;
+        --tasks) CUSTOM_TASKS="$2"; shift ;;
+        --evaluate_on_weka) EVALUATE_ON_WEKA="true" ;;
         *) echo "Unknown parameter passed: $1"; usage ;;
     esac
     shift
@@ -84,6 +87,7 @@ HF_UPLOAD="${HF_UPLOAD:-false}"
 MAX_LENGTH="${MAX_LENGTH:-4096}"
 UNSEEN_EVALS="${UNSEEN_EVALS:-false}"
 PRIORITY="${PRIORITY:normal}"
+EVALUATE_ON_WEKA="${EVALUATE_ON_WEKA:-false}"
 
 # Set HF_UPLOAD_ARG if HF_UPLOAD is true
 if [ "$HF_UPLOAD" == "true" ]; then
@@ -104,31 +108,38 @@ else
     REVISION_ARG=""
 fi
 
+# Define default tasks if no custom tasks provided
+DEFAULT_TASKS=(
+    "gsm8k::tulu"
+    "bbh:cot::tulu"
+    "drop::llama3"
+    "minerva_math::tulu"
+    "codex_humaneval::tulu"
+    "codex_humanevalplus::tulu"
+    "ifeval::tulu"
+    "popqa::tulu"
+    "mmlu:mc::tulu"
+    "alpaca_eval_v2::tulu"
+    "truthfulqa::tulu"
+)
+UNSEEN_TASKS=(
+    "agi_eval_english:0shot_cot::tulu3"
+    "gpqa:0shot_cot::tulu3"
+    "mmlu_pro:0shot_cot::tulu3"
+    "deepmind_math:0shot_cot::tulu3"
+    "bigcodebench_hard::tulu"
+    "gpqa:0shot_cot::llama3.1"
+    "mmlu_pro:cot::llama3.1"
+    "bigcodebench::tulu"
+)
+
+# If custom tasks provided, convert comma-separated string to array
 if [ "$UNSEEN_EVALS" == "true" ]; then
-    TASKS=(
-        "agi_eval_english:0shot_cot::tulu3"
-        "gpqa:0shot_cot::tulu3"
-        "mmlu_pro:0shot_cot::tulu3"
-        "deepmind_math:0shot_cot::tulu3"
-        "bigcodebench_hard::tulu"
-        "gpqa:0shot_cot::llama3.1"
-        "mmlu_pro:cot::llama3.1"
-        "bigcodebench::tulu"
-    )
+    TASKS=("${UNSEEN_TASKS[@]}")
+elif [[ -n "$CUSTOM_TASKS" ]]; then
+    IFS=',' read -ra TASKS <<< "$CUSTOM_TASKS"
 else
-    TASKS=(
-        "gsm8k::tulu"
-        "bbh:cot::tulu"
-        "drop::llama3"
-        "minerva_math::tulu"
-        "codex_humaneval::tulu"
-        "codex_humanevalplus::tulu"
-        "ifeval::tulu"
-        "popqa::tulu"
-        "mmlu:mc::tulu"
-        "alpaca_eval_v2::tulu"
-        "truthfulqa::tulu"
-    )
+    TASKS=("${DEFAULT_TASKS[@]}")
 fi
 
 MODEL_TYPE="--model-type vllm"
@@ -150,6 +161,36 @@ for TASK in "${TASKS[@]}"; do
         MODEL_TYPE="--model-type vllm"
         GPU_COUNT=$GPU_COUNT
     fi
-    
-    python oe-eval-internal/oe_eval/launch.py --model "$MODEL_NAME" --beaker-workspace "ai2/tulu-3-results" --beaker-budget ai2/oe-adapt --task "$TASK" $MODEL_TYPE --batch-size "$BATCH_SIZE" --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" ${HF_UPLOAD_ARG} --gpus "$GPU_COUNT" --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key"}' ${REVISION_ARG} --beaker-retries 2 --beaker-priority "$PRIORITY"
+
+    if [ "$EVALUATE_ON_WEKA" == "true" ]; then
+        python oe-eval-internal/oe_eval/launch.py \
+            --model "$MODEL_NAME" \
+            --beaker-workspace "ai2/tulu-3-results" \
+            --beaker-budget ai2/oe-adapt \
+            --task "$TASK" \
+            $MODEL_TYPE \
+            --batch-size "$BATCH_SIZE" \
+            --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
+            ${HF_UPLOAD_ARG} \
+            --gpus "$GPU_COUNT" \
+            --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key", "weka": "oe-adapt-default:/weka/oe-adapt-default"}' \
+            ${REVISION_ARG} \
+            --cluster ai2/neptune-cirrascale,ai2/saturn-cirrascale,ai2/jupiter-cirrascale-2 \
+            --beaker-retries 2 \
+            --beaker-priority "$PRIORITY"
+    else
+        python oe-eval-internal/oe_eval/launch.py \
+        --model "$MODEL_NAME" \
+        --beaker-workspace "ai2/tulu-3-results" \
+        --beaker-budget ai2/oe-adapt \
+        --task "$TASK" \
+        $MODEL_TYPE \
+        --batch-size "$BATCH_SIZE" \
+        --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
+        ${HF_UPLOAD_ARG} \
+        --gpus "$GPU_COUNT" \
+        --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key"}' \
+        ${REVISION_ARG} \
+        --beaker-retries 2 \
+        --beaker-priority "$PRIORITY"
 done

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -104,6 +104,8 @@ parser.add_argument("--skip_oi_evals", action="store_true", help="Don't run open
 parser.add_argument("--oe_eval_max_length", type=int, default=4096, help="Max length for OE eval.")
 parser.add_argument("--oe_eval_unseen_evals", action="store_true", help="Run unseen task evals instead of dev task evals on OE Eval.")
 parser.add_argument("--use_alternate_safety_image", type=str, default=None, help="Use a different image for safety eval.")
+parser.add_argument("--evaluate_on_weka", action="store_true", help="Evaluate OE eval on Beaker.")
+parser.add_argument("--oe_eval_tasks", type=str, default=None, help="Evaluate OE eval on Beaker.")
 args = parser.parse_args()
 
 
@@ -129,11 +131,25 @@ WEKA_CLUSTERS = [
 ]
 
 # remove nfs if asked or jupiter in cluster list.
-nfs_available = True
-if args.no_nfs or any([c in WEKA_CLUSTERS for c in cluster]):
-    # remove the NFS dataset - last element in the list.
-    d1['tasks'][0]['datasets'] = d1['tasks'][0]['datasets'][:-1]
-    nfs_available = False
+nfs_available = False
+weka_available = False
+if all(c in NFS_CLUSTERS for c in cluster):
+    d1['tasks'][0]['datasets'].append({
+        'mountPath': "/net/nfs.cirrascale",
+        "source": {
+            "hostPath": "/net/nfs.cirrascale"
+        }
+    })
+    nfs_available = True
+elif all(c in WEKA_CLUSTERS for c in cluster):
+    d1['tasks'][0]['datasets'].append({
+        'mountPath': "/weka/oe-adapt-default",
+        "source": {
+            "weka": "oe-adapt-default"
+        }
+    })
+    weka_available = True
+
 
 # Use a different image if requested.
 if args.beaker_image is not None:
@@ -590,10 +606,16 @@ if args.run_oe_eval_experiments or args.oe_eval_unseen_evals:
     ## model location munging: if beaker, use beaker://. If hf, just name
     if model_info[0].startswith("hf-"):
         oe_eval_cmd += f" --model-location {model_info[1]}"
+    elif model_info[1].startswith("/"):
+        oe_eval_cmd += f" --model-location {model_info[1]}"
     else:
         oe_eval_cmd += f" --model-location beaker://{model_info[1]}"
     if args.hf_revision:
         oe_eval_cmd += f" --revision {args.hf_revision}"
+    if args.evaluate_on_weka:
+        oe_eval_cmd += " --evaluate_on_weka"
+    if args.oe_eval_tasks:
+        oe_eval_cmd += f" --tasks {args.oe_eval_tasks}"
     # add string with number of gpus
     num_gpus = task_spec['resources']['gpuCount']
     # if num_gpus > 1, double it again for oe-eval configs
@@ -616,6 +638,7 @@ if args.run_oe_eval_experiments or args.oe_eval_unseen_evals:
 if args.run_safety_evaluations:
     # just take the original spec we had, modify it for safety eval.
     experiment_name = f"oi_safety_{model_name}"
+    experiment_name.replace('β', '').replace(r"{", "").replace(r"}", "") # hack: remove characters beaker doesn't like
     d["description"] = experiment_name
     # specific image for safety eval
     d["tasks"][0]["image"]["beaker"] = "hamishivi/open-safety"
@@ -636,7 +659,7 @@ VLLM_WORKER_MULTIPROC_METHOD=spawn PYTHONPATH=. python evaluation/run_all_genera
         task_spec['arguments'] = [task_spec['arguments'][0].replace("--model_name_or_path /model", f"--model_name_or_path {model_info[1]} --hf_revision {args.hf_revision}")]
         task_spec['arguments'] = [task_spec['arguments'][0].replace("--tokenizer_name_or_path /model", f"--tokenizer_name_or_path {model_info[1]}")]
     elif model_info[1].startswith("/"):  # if it's a local model, load it from the local directory
-        assert nfs_available, "NFS is required for path-based models."  # to be safe.
+        assert nfs_available or weka_available, "NFS / Weka is required for path-based models."  # to be safe.
         task_spec['arguments'] = [task_spec['arguments'][0].replace("--model_name_or_path /model", "--model_name_or_path "+model_info[1])]
         task_spec['arguments'] = [task_spec['arguments'][0].replace("--tokenizer_name_or_path /model", "--tokenizer_name_or_path "+model_info[1])]
     else:  # if it's a beaker model, mount the beaker dataset to `/model`
@@ -651,6 +674,8 @@ VLLM_WORKER_MULTIPROC_METHOD=spawn PYTHONPATH=. python evaluation/run_all_genera
 
     # add gpu information.
     # we just assume you want to use all the gpus for one task at a time
+    if "70B" in model_info[0]:
+        task_spec['resources']['gpuCount'] = 8
     num_gpus = task_spec['resources']['gpuCount']
     task_spec["arguments"][0]+= f" --min_gpus_per_task {num_gpus}"
 


### PR DESCRIPTION
Tested with the following.

```
# weka eval
python scripts/submit_eval_jobs.py \
    --model_name ppo_ray_3.9_1111_β_0.1_epoch_1__weka_eval \
    --location /weka/oe-adapt-default/costah/models/rlvr/1111/ppo_ray_3.9_1111_β_0.1_epoch_{1} \
    --cluster ai2/saturn-cirrascale ai2/neptune-cirrascale ai2/jupiter-cirrascale-2	 --evaluate_on_weka \
    --is_tuned \
    --workspace "tulu-3-results" \
    --priority high \
    --preemptible \
    --use_hf_tokenizer_template \
    --beaker_image "nathanl/open_instruct_auto" \
    --upload_to_hf allenai/tulu-3-evals \
    --run_oe_eval_experiments \
    --run_safety_evaluations \
    --skip_oi_evals

# nfs eval
python scripts/submit_eval_jobs.py \
    --model_name ppo_ray_3.9_1111_β_0.1_epoch_1__nfs_eval \
    --location 01JCE2PYZW1E96994GMW7MDB4R \
    --is_tuned \
    --workspace "tulu-3-results" \
    --priority high \
    --preemptible \
    --use_hf_tokenizer_template \
    --beaker_image "nathanl/open_instruct_auto" \
    --upload_to_hf allenai/tulu-3-evals \
    --run_oe_eval_experiments \
    --run_safety_evaluations \
    --skip_oi_evals
```

Note the only difference is that

```
    --location /weka/oe-adapt-default/costah/models/rlvr/1111/ppo_ray_3.9_1111_β_0.1_epoch_{1} \
    --cluster ai2/saturn-cirrascale ai2/neptune-cirrascale ai2/jupiter-cirrascale-2	 --evaluate_on_weka \
```

vs

```
    --location 01JCE2PYZW1E96994GMW7MDB4R \
```