### PR TITLE
Mount oe-training weka bucket

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -13,10 +13,28 @@ def parse_beaker_dataset(dataset_str):
 
     return {"mount_path": splt[0], "beaker": splt[1]}
 
+NFS_CLUSTERS = [
+    "ai2/allennlp-cirrascale",
+    "ai2/aristo-cirrascale",
+    "ai2/climate-cirrascale",
+    "ai2/general-cirrascale",
+    "ai2/general-cirrascale-a5000",
+    "ai2/mosaic-cirrascale",
+    "ai2/mosaic-cirrascale-a100",
+    "ai2/pluto-cirrascale",
+    "ai2/prior-cirrascale",
+    "ai2/s2-cirrascale",
+    "ai2/s2-cirrascale-l40",
+]
+
 WEKA_CLUSTERS = [
     "ai2/jupiter-cirrascale-2",
     "ai2/saturn-cirrascale",
     "ai2/neptune-cirrascale",
+    "ai2/allennlp-elara-cirrascale",
+]
+GCP_CLUSTERS = [
+    "ai2/augusta-google-1"
 ]
 
 
@@ -160,7 +178,7 @@ def get_env_vars(pure_docker_mode: bool, cluster: List[str], beaker_secrets: Lis
         ])
     
     # if none of the cluster is in weka, we mount the NFS
-    if all(c not in WEKA_CLUSTERS for c in cluster):
+    if all(c in NFS_CLUSTERS for c in cluster):
         env_vars.extend([
             beaker.EnvVar(
                 name="HF_DATASETS_CACHE",
@@ -194,16 +212,20 @@ def get_env_vars(pure_docker_mode: bool, cluster: List[str], beaker_secrets: Lis
     elif all(c in WEKA_CLUSTERS for c in cluster):
         env_vars.extend([
             beaker.EnvVar(
+                name="HF_HOME",
+                value="/weka/oe-adapt-default/allennlp/.cache/huggingface",
+            ),
+            beaker.EnvVar(
                 name="HF_DATASETS_CACHE",
-                value="/weka/allennlp/.cache/huggingface",
+                value="/weka/oe-adapt-default/allennlp/.cache/huggingface",
             ),
             beaker.EnvVar(
                 name="HF_HUB_CACHE",
-                value="/weka/allennlp/.cache/hub",
+                value="/weka/oe-adapt-default/allennlp/.cache/hub",
             ),
             beaker.EnvVar(
                 name="CHECKPOINT_OUTPUT_DIR",
-                value=f"/weka/allennlp/deletable_checkpoint_states/{global_wandb_id}",
+                value=f"/weka/oe-adapt-default/allennlp/deletable_checkpoint_states/{global_wandb_id}",
             ),
         ])
         if num_nodes > 1:
@@ -219,6 +241,120 @@ def get_env_vars(pure_docker_mode: bool, cluster: List[str], beaker_secrets: Lis
                 beaker.EnvVar(
                     name="NCCL_DEBUG",
                     value="INFO",
+                ),
+            ])
+    # if all cluster is in gcp we add the following env
+
+    elif all(c in GCP_CLUSTERS for c in cluster):
+        if num_nodes > 1:
+            env_vars.extend([
+                beaker.EnvVar(
+                    name="LD_LIBRARY_PATH",
+                    value=r"/var/lib/tcpxo/lib64:${LD_LIBRARY_PATH}",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_CROSS_NIC",
+                    value="0",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_ALGO",
+                    value="Ring,Tree",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_PROTO",
+                    value="Simple",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_MIN_NCHANNELS",
+                    value="4",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_P2P_NET_CHUNKSIZE",
+                    value="524288",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_P2P_PCI_CHUNKSIZE",
+                    value="524288",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_P2P_NVL_CHUNKSIZE",
+                    value="1048576",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_FASTRAK_NUM_FLOWS",
+                    value="2",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_FASTRAK_ENABLE_CONTROL_CHANNEL",
+                    value="0",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_BUFFSIZE",
+                    value="8388608",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_FASTRAK_USE_SNAP",
+                    value="1",
+                ),
+                beaker.EnvVar(
+                    name="CUDA_VISIBLE_DEVICES",
+                    value="0,1,2,3,4,5,6,7",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_NET_GDR_LEVEL",
+                    value="PIX",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_FASTRAK_ENABLE_HOTPATH_LOGGING",
+                    value="0",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_TUNER_PLUGIN",
+                    value="libnccl-tuner.so",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_TUNER_CONFIG_PATH",
+                    value="/var/lib/tcpxo/lib64/a3plus_tuner_config.textproto",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE",
+                    value="/var/lib/tcpxo/lib64/a3plus_guest_config.textproto",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_FASTRAK_PLUGIN_ACCEPT_TIMEOUT_MS",
+                    value="600000",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_NVLS_ENABLE",
+                    value="0",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_DEBUG",
+                    value="WARN",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_FASTRAK_CTRL_DEV",
+                    value="enp0s12",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_FASTRAK_IFNAME",
+                    value="enp6s0,enp7s0,enp13s0,enp14s0,enp134s0,enp135s0,enp141s0,enp142s0",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_SOCKET_IFNAME",
+                    value="enp0s12",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_USE_SNAP",
+                    value="1",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_FASTRAK_USE_LLCM",
+                    value="1",
+                ),
+                beaker.EnvVar(
+                    name="NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY",
+                    value="/dev/aperture_devices",
                 ),
             ])
     # don't mount anything; assume no cache
@@ -244,7 +380,7 @@ def get_datasets(beaker_datasets, cluster: List[str]):
     """if pure docker mode we don't mount the NFS; so we can run it on jupiter2"""
     res = []
     # if none of the cluster is in weka, we mount the NFS
-    if all(c not in WEKA_CLUSTERS for c in cluster):
+    if all(c in NFS_CLUSTERS for c in cluster):
         res = [
             beaker.DataMount(
                 source=beaker.DataSource(host_path="/net/nfs.cirrascale"),
@@ -256,7 +392,11 @@ def get_datasets(beaker_datasets, cluster: List[str]):
         res = [
             beaker.DataMount(
                 source=beaker.DataSource(weka="oe-adapt-default"),
-                mount_path="/weka",
+                mount_path="/weka/oe-adapt-default",
+            ),
+            beaker.DataMount(
+                source=beaker.DataSource(weka="oe-training-default"),
+                mount_path="/weka/oe-training-default",
             ),
         ]
     for beaker_dataset in beaker_datasets:


### PR DESCRIPTION
This allows us to run a converter easily to convert olmo checkpoints to olmo1124 checkpoints!

```
python mason.py \
    --cluster ai2/neptune-cirrascale ai2/saturn-cirrascale ai2/jupiter-cirrascale-2 \
    --priority high \
    --image costah/oe-eval-olmo1124-11142024 \
    --pure_docker_mode \
    --workspace ai2/tulu-3-dev \
    --budget ai2/allennlp \
    --preemptible \
    --gpus 0 -- \
    python convert_olmo_1124_weights_to_hf.py \
    --input_dir /weka/oe-training-default/ai2-llm/checkpoints/OLMo-medium/peteish7-anneal-from-928646-50B-nowup-moremath-dclm07-fw2/step11931 \
    --hf_repo_id allenai/open_instruct_dev \
    --hf_repo_revision peteish7-anneal-from-928646-50B-nowup-moremath-dclm07-fw2_step11931_hf \
    --output_dir /weka/oe-adapt-default/costah/models/converter_test
```

https://beaker.org/ex/01JCP4XSMTCVQY0Z4TW6ADRKD6