### PR TITLE
Bypass reward model usage when `reward_model_multiplier` is 0

### DIFF
--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -1098,8 +1098,6 @@ class PolicyTrainerRayProcess(RayProcess):
                             self.reward_model, postprocessed_query_response, tokenizer.pad_token_id, context_length
                         )
                         score *= args.reward_model_multiplier
-
-                    # also apply verifiable reward
                     if args.apply_verifiable_reward:
                         # we need to batch the gt to match query.
                         ground_truth = ground_truths[i : i + args.local_rollout_forward_batch_size]

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -702,15 +702,15 @@ class PolicyTrainerRayProcess(RayProcess):
                 use_cache=False,
             )
             disable_dropout_in_model(self.reward_model)
-        ds_config = get_eval_ds_config(
-            offload=False,
-            stage=args.deepspeed_stage,
-            bf16=True,
-        )
-        ds_config["train_micro_batch_size_per_gpu"] = args.per_device_train_batch_size
-        ds_config["train_batch_size"] = args.mini_batch_size
-        self.reward_model, *_ = deepspeed.initialize(model=self.reward_model, config=ds_config)
-        self.reward_model.eval()
+            ds_config = get_eval_ds_config(
+                offload=False,
+                stage=args.deepspeed_stage,
+                bf16=True,
+            )
+            ds_config["train_micro_batch_size_per_gpu"] = args.per_device_train_batch_size
+            ds_config["train_batch_size"] = args.mini_batch_size
+            self.reward_model, *_ = deepspeed.initialize(model=self.reward_model, config=ds_config)
+            self.reward_model.eval()
 
     def get_vocab_size(self):
         return self.policy.config.vocab_size

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -1097,8 +1097,7 @@ class PolicyTrainerRayProcess(RayProcess):
                         _, score, _ = get_reward(
                             self.reward_model, postprocessed_query_response, tokenizer.pad_token_id, context_length
                         )
-                        if args.reward_model_multiplier != 1.0:
-                            score *= args.reward_model_multiplier
+                        score *= args.reward_model_multiplier
 
                     # also apply verifiable reward
                     if args.apply_verifiable_reward:


### PR DESCRIPTION
# What does this PR do?

A tiny PR to bypass reward model usage  in RLVR training when `reward_model_multiplier` is 0.0