### PR TITLE
Clean up rlvr a lil, add base support

### DIFF
--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -156,7 +156,15 @@ CHAT_TEMPLATES = {
         "The reasoning process and answer are enclosed within <think> </think>"
         "and <answer> </answer> tags, respectively,"
         "i.e., <think> reasoning process here </think>"
-        "<answer> answer here </answer>. User: prompt. Assistant:"
+        "<answer> answer here </answer>."
+        "\n\n"
+        "{% for message in messages %}"
+        "{{ '\n\n' if not loop.first else '' }}"
+        "{{ message['role'].capitalize() + ': ' + message['content'] + '\n' }}"
+        "{% if loop.last and add_generation_prompt %}"
+        "{{ 'Assistant:' }}"
+        "{% endif %}"
+        "{% endfor %}"
     ),
 }
 # flake8: noqa

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -148,6 +148,16 @@ CHAT_TEMPLATES = {
         "{% endif %}"
         "{% endfor %}"
     ),
+    "deepseek_r1_zero": (
+        "A conversation between User and Assistant."
+        "The user asks a question, and the Assistant solves it."
+        "The assistant first thinks about the reasoning process in"
+        "the mind and then provides the user with the answer."
+        "The reasoning process and answer are enclosed within <think> </think>"
+        "and <answer> </answer> tags, respectively,"
+        "i.e., <think> reasoning process here </think>"
+        "<answer> answer here </answer>. User: prompt. Assistant:"
+    ),
 }
 # flake8: noqa
 

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -149,12 +149,12 @@ CHAT_TEMPLATES = {
         "{% endfor %}"
     ),
     "deepseek_r1_zero": (
-        "A conversation between User and Assistant."
-        "The user asks a question, and the Assistant solves it."
-        "The assistant first thinks about the reasoning process in"
+        "A conversation between User and Assistant. "
+        "The user asks a question, and the Assistant solves it. "
+        "The assistant first thinks about the reasoning process in "
         "the mind and then provides the user with the answer."
-        "The reasoning process and answer are enclosed within <think> </think>"
-        "and <answer> </answer> tags, respectively,"
+        "The reasoning process and answer are enclosed within <think> </think> "
+        "and <answer> </answer> tags, respectively, "
         "i.e., <think> reasoning process here </think>"
         "<answer> answer here </answer>."
         "\n\n"

--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -10,7 +10,6 @@ from open_instruct.if_functions import IF_FUNCTIONS_MAP
 
 
 def verify_gsm8k_sample(model_output, ground_truth_answer):
-    model_output = model_output.split("<|assistant|>\n")[-1].strip()
     # gsm is easy: extract numbers, and then just compare last number with answer.
     # matches how we do eval.
     predictions = None
@@ -25,7 +24,6 @@ def verify_gsm8k_sample(model_output, ground_truth_answer):
 
 
 def verify_math_sample(model_output, ground_truth_answer):
-    model_output = model_output.split("<|assistant|>\n")[-1].strip()
     raw_answer = model_output
     # for math, more complex. We will try a few different ways to extract the answer.
     # this roughly follows 'flex em' in oe-eval-internal
@@ -67,7 +65,6 @@ def verify_math_sample(model_output, ground_truth_answer):
 
 
 def verify_strict_math_sample(model_output, ground_truth_answer):
-    model_output = model_output.split("<|assistant|>\n")[-1].strip()
     raw_answer = model_output
     # just trying minerva format.
     all_answers = []
@@ -92,7 +89,6 @@ def verify_strict_math_sample(model_output, ground_truth_answer):
 
 
 def verify_ifeval_sample(model_output, constraint):
-    model_output = model_output.split("<|assistant|>\n")[-1].strip()
     # TODO: just pass in final answer. this should be fine for other evals too.
     answer = model_output.split("<|assistant|>\n")[-1].strip()
     if isinstance(constraint, str):

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -933,8 +933,6 @@ class PolicyTrainerRayProcess(RayProcess):
         if accelerator.is_main_process:
             param_prompt_Q.put((None, remove_padding(global_queries, tokenizer.pad_token_id)))
 
-        answer_extraction_model = None
-        answer_extraction_tokenizer = None
         # for _ in range(1, resume_training_step):  # we didn't store scheduler state
         #     scheduler.step()
 

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -49,6 +49,7 @@ from open_instruct.utils import retry_on_exception
 
 logger = logging.getLogger(__name__)
 
+
 @dataclass
 class ModelConfig:
     model_name_or_path: Optional[str] = None
@@ -225,7 +226,7 @@ def apply_verifiable_reward(
     # decode the responses
     decoded_responses = tokenizer.batch_decode(responses, skip_special_tokens=True)
     # for now, below is not used. but keeping it around in case we need it.
-    decoded_query_responses = tokenizer.batch_decode(query_responses, skip_special_tokens=True)
+    decoded_query_responses = tokenizer.batch_decode(query_responses, skip_special_tokens=True)  # noqa: F841
     # compare with ground truth.
     rewards = []
     for prediction, ground_truth, dataset in zip(decoded_responses, ground_truths, datasets):

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -19,6 +19,7 @@ from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import List, Literal, Optional, Tuple, Union
+import logging
 
 try:
     import deepspeed
@@ -45,6 +46,8 @@ from open_instruct.ground_truth_utils import (
 )
 from open_instruct.utils import retry_on_exception
 
+
+logger = logging.getLogger(__name__)
 
 @dataclass
 class ModelConfig:
@@ -212,36 +215,23 @@ def get_reward(
 
 
 def apply_verifiable_reward(
+    responses: torch.Tensor,
     query_responses: torch.Tensor,
     tokenizer,
     ground_truths: List[str],
     datasets: List[str],
     verify_reward: int = 10,
-    answer_extraction_model: Optional[torch.nn.Module] = None,
-    answer_extraction_tokenizer: Optional[PreTrainedTokenizer] = None,
 ):
     # decode the responses
-    decoded_responses = tokenizer.batch_decode(query_responses, skip_special_tokens=True)
-    # if we have an answer extraction model, use it to extract the answer from the response
-    if answer_extraction_model is not None:
-        prompt = "Thus, the final answer is:"
-        # add the prompt to the responses
-        decoded_responses = [f"{response} {prompt}" for response in decoded_responses]
-        # extract the answer
-        answer_extraction_inputs = answer_extraction_tokenizer(
-            decoded_responses, return_tensors="pt", padding=True, truncation=True
-        )
-        answer_extraction_outputs = answer_extraction_model(**answer_extraction_inputs)
-        # get the predicted answer
-        decoded_responses = answer_extraction_tokenizer.batch_decode(
-            answer_extraction_outputs.logits.argmax(-1), skip_special_tokens=True
-        )
+    decoded_responses = tokenizer.batch_decode(responses, skip_special_tokens=True)
+    # for now, below is not used. but keeping it around in case we need it.
+    decoded_query_responses = tokenizer.batch_decode(query_responses, skip_special_tokens=True)
     # compare with ground truth.
-    # use same logic as in gsm8k evaluation
     rewards = []
     for prediction, ground_truth, dataset in zip(decoded_responses, ground_truths, datasets):
         verified = False
         if ground_truth is None:
+            logger.warning("No ground truth provided for a sample, applying 0 reward.")
             rewards.append(0)
             continue
         if dataset.lower() == "gsm8k":
@@ -252,7 +242,7 @@ def apply_verifiable_reward(
             verified = verify_ifeval_sample(prediction, ground_truth)
         # if verified, give reward
         if verified:
-            print("Applying ground truth reward 🤗")
+            logger.info("Applying ground truth reward 🤗")
             rewards.append(verify_reward)
         else:
             rewards.append(0)

--- a/open_instruct/online_dpo_vllm_thread.py
+++ b/open_instruct/online_dpo_vllm_thread.py
@@ -386,7 +386,8 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
         tokenizer.pad_token_id = 128002  # <|reserved_special_token_0|>
     else:
         tokenizer.add_special_tokens({"pad_token": "[PAD]"})  # NOTE: we do not resize the embedding
-    tokenizer.chat_template = CHAT_TEMPLATES[dataset_config.chat_template]
+    if dataset_config.chat_template is not None:
+        tokenizer.chat_template = CHAT_TEMPLATES[dataset_config.chat_template]
 
     # create the dataset
     dataset_dict = DatasetDict()

--- a/open_instruct/ppo_vllm_thread.py
+++ b/open_instruct/ppo_vllm_thread.py
@@ -698,14 +698,6 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
     episode = args.batch_size * (resume_training_step - 1)
     model.train()
 
-    # setup extraction model. For now keep on CPU?
-    if args.answer_extraction_model:
-        answer_extraction_model = AutoModelForCausalLM.from_pretrained(args.answer_extraction_model)
-        answer_extraction_tokenizer = AutoTokenizer.from_pretrained(args.answer_extraction_model)
-    else:
-        answer_extraction_model = None
-        answer_extraction_tokenizer = None
-
     # training loop
     start_time = time.time()
     data = next(iter_dataloader)

--- a/open_instruct/ppo_vllm_thread.py
+++ b/open_instruct/ppo_vllm_thread.py
@@ -177,6 +177,9 @@ class Args:
     """whether to penalize responses that do not contain `stop_token_id`"""
     number_samples_per_prompt: int = 1
     """the number of samples to generate per prompt, useful for easy-star"""
+    stop_strings: List[str] = None
+    """List of strings that stop the generation when they are generated.
+    The returned output will not contain the stop strings."""
 
     # online PPO specific args
     beta: float = 0.05
@@ -199,7 +202,8 @@ class Args:
     """whether to apply verifiable reward"""
     reward_model_multiplier: float = 1.0
     """the reward model multiplier, for down/upscaling the reward model output"""
-    answer_extraction_model: str = None
+    verification_reward: float = 10.0
+    """the reward value for verifiable responses"""
 
     # vLLM settings. NOTE: currently we need to place the vLLM model on a separate GPU
     # for generation to work properly because vLLM would pre-alocate the memory.
@@ -467,7 +471,8 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
         tokenizer.pad_token_id = 128002  # <|reserved_special_token_0|>
     else:
         tokenizer.add_special_tokens({"pad_token": "[PAD]"})  # NOTE: we do not resize the embedding
-    tokenizer.chat_template = CHAT_TEMPLATES[dataset_config.chat_template]
+    if dataset_config.chat_template is not None:
+        tokenizer.chat_template = CHAT_TEMPLATES[dataset_config.chat_template]
 
     # create the dataset
     dataset_dict = DatasetDict()
@@ -833,13 +838,12 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
                         ground_truth = ground_truths[i : i + args.local_rollout_forward_batch_size]
                         dataset = datasets[i : i + args.local_rollout_forward_batch_size]
                         verifiable_reward, verifiable_count = apply_verifiable_reward(
+                            postprocessed_response,
                             postprocessed_query_response,
                             tokenizer,
                             ground_truth,
                             dataset,
-                            verify_reward=10,
-                            answer_extraction_model=answer_extraction_model,
-                            answer_extraction_tokenizer=answer_extraction_tokenizer,
+                            verify_reward=args.verification_reward,
                         )
                         score += verifiable_reward
                     else:

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -977,8 +977,6 @@ class PolicyTrainerRayProcess(RayProcess):
         if accelerator.is_main_process:
             param_prompt_Q.put((None, remove_padding(global_queries, tokenizer.pad_token_id)))
 
-        answer_extraction_model = None
-        answer_extraction_tokenizer = None
         # for _ in range(1, resume_training_step):  # we didn't store scheduler state
         #     scheduler.step()
 

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -1598,10 +1598,6 @@ class ModelGroup:
 
 
 def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
-    if args.cpu_only:
-        args.actor_num_gpus_per_node = [0]
-        args.world_size = args.num_cpu_workers
-        args.vllm_num_engines = 0
     calculate_runtime_args(args, model_config)
 
     # set up experiment tracking and seeds
@@ -1727,7 +1723,6 @@ def main(args: Args, dataset_config: DatasetConfig, model_config: ModelConfig):
         args.seed,
         args.enable_prefix_caching,
         max_len,
-        args.vllm_gpu_memory_utilization,
     )
 
     metrics_queue = RayQueue()


### PR DESCRIPTION
- Remove some of the hardcoded stuff in the RLVR code that assumed tulu chat template. Now we pass response-only + prompt+response to the verifiers. The latter isn't used right now, but I imagine it might be useful in the future.
- Add deepseek R1 zero template
- Add ability to set a stop string, needed for RL on base models.