### PR TITLE
fix checkpointing

### DIFF
--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -666,7 +666,7 @@ def get_last_checkpoint(folder: str, incomplete: bool = False) -> Optional[str]:
         checkpoints = [path for path in checkpoints if os.path.exists(os.path.join(folder, path, "COMPLETED"))]
     if len(checkpoints) == 0:
         return
-    return os.path.join(folder, max(checkpoints, key=lambda x: x.split("_")[-1]))
+    return os.path.join(folder, max(checkpoints, key=lambda x: int(x.split("_")[-1])))
 
 
 def get_last_checkpoint_path(args, incomplete: bool = False) -> str:
@@ -693,7 +693,7 @@ def clean_last_n_checkpoints(output_dir: str, keep_last_n_checkpoints: int) -> N
     folders = [f for f in os.listdir(output_dir) if is_checkpoint_folder(output_dir, f)]
     # find the checkpoint with the largest step
     checkpoints = sorted(folders, key=lambda x: int(x.split("_")[-1]))
-    if len(checkpoints) > keep_last_n_checkpoints:
+    if keep_last_n_checkpoints >= 0 and len(checkpoints) > keep_last_n_checkpoints:
         for checkpoint in checkpoints[: len(checkpoints) - keep_last_n_checkpoints]:
             logger.info(f"Removing checkpoint {checkpoint}")
             shutil.rmtree(os.path.join(output_dir, checkpoint))


### PR DESCRIPTION
The checkpointing code seems to be largely untested. I found two obvious bugs:

1) According to the documentation for keep_last_n_checkpoints in open-instruct/finetune.py, -1 should keep all checkpoints ("How many checkpoints to keep in the output directory. -1 for all."). However, the actual behaviour was to delete all checkpoints if keep_last_n_checkpoints <= 0 (the condition for deleting was simply "len(checkpoints) > keep_last_n_checkpoints").

2) Find the last checkpoint by sorting according to number of steps/epochs should sort numerically, i.e., if both a checkpoint "step_9000" and a checkpoint "step_10000" exist, the last checkpoint return in the get_last_checkpoint in open-instruct/utils.py should be "step_10000". However, the actual behaviour is to use string comparison and return "step_9000" as "9" is larger than "1".

Both issues are trivially fixed in this PR:

Ad 1)
The condition is extended to "keep_last_n_checkpoints >= 0 and len(checkpoints) > keep_last_n_checkpoints".

Ad 2)
The sorting is performed numerically by converting the number of steps/epoch to int.