### PR TITLE
Fix final ckpt + allow env var passing in Mason

### DIFF
--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -1439,8 +1439,9 @@ python scripts/submit_eval_jobs.py \
     --run_oe_eval_experiments \
     --evaluate_on_weka \
     --run_id {wandb_url} \
-    --step {training_step} \
     --skip_oi_evals"""
+            if training_step is not None:
+                command += f" --step {training_step}"
             if args.oe_eval_tasks is not None:
                 command += f" --oe_eval_tasks {','.join(args.oe_eval_tasks)}"
             print(f"Launching eval jobs with command: {command}")


### PR DESCRIPTION
Two changes:
- Final eval submission would fail since `training_step` wasn't provided, and explicitly passing None errors (see logs in https://legacy.beaker.org/api/v3/jobs/01JK1RJESD1M3QJYN74KVJ3ZZN/logs?tail=2). This fixes.
- Allow passing env vars in mason. This allows e.g. setting VLLM_ALLOW_LONG_MAX_MODEL_LEN=1, which is important for RLVR training w/ increasing seq length.