### PR TITLE
Properly set max length for eval

### DIFF
--- a/configs/beaker_configs/default_eval.yaml
+++ b/configs/beaker_configs/default_eval.yaml
@@ -38,6 +38,8 @@ tasks:
         secret: openai_api_key
       - name: HF_TOKEN
         secret: HF_TOKEN
+      - name: VLLM_ALLOW_LONG_MAX_MODEL_LEN
+        value: 1
     datasets:
       - mountPath: /data/
         source:

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -215,6 +215,7 @@ class Args:
     stop_strings: List[str] = None
     """List of strings that stop the generation when they are generated.
     The returned output will not contain the stop strings."""
+    eval_max_length: int = 4096  # max generation length for evaluation
 
     # online PPO specific args
     beta: float = 0.05
@@ -1439,6 +1440,7 @@ python scripts/submit_eval_jobs.py \
     --run_oe_eval_experiments \
     --evaluate_on_weka \
     --run_id {wandb_url} \
+    --oe_eval_max_length {args.eval_max_length} \
     --skip_oi_evals"""
             if training_step is not None:
                 command += f" --step {training_step}"

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -220,6 +220,7 @@ class Args:
     stop_strings: List[str] = None
     """List of strings that stop the generation when they are generated.
     The returned output will not contain the stop strings."""
+    eval_max_length: int = 4096  # max generation length for evaluation
 
     # online PPO specific args
     beta: float = 0.05
@@ -1510,7 +1511,10 @@ python scripts/submit_eval_jobs.py \
     --run_safety_evaluations \
     --run_id {wandb_url} \
     --step {training_step} \
+    --oe_eval_max_length {args.eval_max_length} \
     --skip_oi_evals"""
+            if training_step is not None:
+                command += f" --step {training_step}"
             if args.oe_eval_tasks is not None:
                 command += f" --oe_eval_tasks {','.join(args.oe_eval_tasks)}"
             print(f"Launching eval jobs with command: {command}")

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -1510,7 +1510,6 @@ python scripts/submit_eval_jobs.py \
     --evaluate_on_weka \
     --run_safety_evaluations \
     --run_id {wandb_url} \
-    --step {training_step} \
     --oe_eval_max_length {args.eval_max_length} \
     --skip_oi_evals"""
             if training_step is not None:

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -178,6 +178,7 @@ for TASK in "${TASKS[@]}"; do
             $MODEL_TYPE \
             --batch-size "$BATCH_SIZE" \
             --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
+            --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH} } }'
             ${HF_UPLOAD_ARG} \
             --gpus "$GPU_COUNT" \
             --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key", "weka": "oe-adapt-default:/weka/oe-adapt-default"}' \
@@ -196,6 +197,7 @@ for TASK in "${TASKS[@]}"; do
         $MODEL_TYPE \
         --batch-size "$BATCH_SIZE" \
         --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
+        --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH} } }'
         ${HF_UPLOAD_ARG} \
         --gpus "$GPU_COUNT" \
         --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key"}' \

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -178,7 +178,7 @@ for TASK in "${TASKS[@]}"; do
             $MODEL_TYPE \
             --batch-size "$BATCH_SIZE" \
             --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
-            --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH} } }'
+            --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false } }' \
             ${HF_UPLOAD_ARG} \
             --gpus "$GPU_COUNT" \
             --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key", "weka": "oe-adapt-default:/weka/oe-adapt-default"}' \
@@ -197,7 +197,7 @@ for TASK in "${TASKS[@]}"; do
         $MODEL_TYPE \
         --batch-size "$BATCH_SIZE" \
         --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
-        --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH} } }'
+        --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false } }' \
         ${HF_UPLOAD_ARG} \
         --gpus "$GPU_COUNT" \
         --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key"}' \

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -181,7 +181,7 @@ for TASK in "${TASKS[@]}"; do
             --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false } }' \
             ${HF_UPLOAD_ARG} \
             --gpus "$GPU_COUNT" \
-            --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key", "weka": "oe-adapt-default:/weka/oe-adapt-default"}' \
+            --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key", "weka": "oe-adapt-default:/weka/oe-adapt-default", "env#132":"VLLM_ALLOW_LONG_MAX_MODEL_LEN=1"}' \
             ${REVISION_ARG} \
             --cluster ai2/neptune-cirrascale,ai2/saturn-cirrascale,ai2/jupiter-cirrascale-2 \
             --beaker-retries 2 \
@@ -200,7 +200,7 @@ for TASK in "${TASKS[@]}"; do
         --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false } }' \
         ${HF_UPLOAD_ARG} \
         --gpus "$GPU_COUNT" \
-        --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key"}' \
+        --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key", "env#132":"VLLM_ALLOW_LONG_MAX_MODEL_LEN=1"}' \
         ${REVISION_ARG} \
         --beaker-retries 2 \
         --beaker-priority "$PRIORITY" \


### PR DESCRIPTION
This sets max length for eval generation and allows it to be passed down in the GRPO/PPO scripts.