### PR TITLE
Add train file support back to finetune

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -624,7 +624,6 @@ class DatasetConfig:
     dataset_commit_hash: Optional[str] = None
 
     def __post_init__(self):
-        self.dataset_commit_hash = get_commit_hash(self.dataset_name, self.dataset_revision, "README.md", "dataset")
         # if the file exists locally, use the local file
         if os.path.exists(self.dataset_name) and self.dataset_name.endswith('.jsonl'):
             assert self.dataset_split is "train", "Only train split is supported for local jsonl files."
@@ -634,6 +633,8 @@ class DatasetConfig:
                 split=self.dataset_split,
             )
         else:
+            # commit hash only works for hf datasets
+            self.dataset_commit_hash = get_commit_hash(self.dataset_name, self.dataset_revision, "README.md", "dataset")
             self.dataset = load_dataset(
                 self.dataset_name,
                 split=self.dataset_split,

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -625,11 +625,20 @@ class DatasetConfig:
 
     def __post_init__(self):
         self.dataset_commit_hash = get_commit_hash(self.dataset_name, self.dataset_revision, "README.md", "dataset")
-        self.dataset = load_dataset(
-            self.dataset_name,
-            split=self.dataset_split,
-            revision=self.dataset_revision,
-        )
+        # if the file exists locally, use the local file
+        if os.path.exists(self.dataset_name) and self.dataset_name.endswith('.jsonl'):
+            assert self.dataset_split is "train", "Only train split is supported for local jsonl files."
+            self.dataset = load_dataset(
+                "json",
+                data_files=self.dataset_name,
+                split=self.dataset_split,
+            )
+        else:
+            self.dataset = load_dataset(
+                self.dataset_name,
+                split=self.dataset_split,
+                revision=self.dataset_revision,
+            )
         if self.dataset_range is None:
             dataset_range = len(self.dataset)
             self.update_range(dataset_range)
@@ -761,7 +770,10 @@ def get_cached_dataset(dcs: List[DatasetConfig], tc: TokenizerConfig, hf_entity:
 
 
 def get_cached_dataset_tulu_sft(
-    dataset_mixer_list: List[str], tc: TokenizerConfig, max_seq_length: int, hf_entity: Optional[str] = None
+    dataset_mixer_list: List[str],
+    tc: TokenizerConfig,
+    max_seq_length: int,
+    hf_entity: Optional[str] = None,
 ) -> Dataset:
     dcs = []
     assert len(dataset_mixer_list) % 2 == 0, f"Data mixer list length is not even: {dataset_mixer_list}"


### PR DESCRIPTION
The caching stuff added removed the ability to point to a train file, which was useful for random one-off training jobs. This adds it back via the unified caching stuff.

One thing is the commit hash function doesn't seem to work with local files.

example of a successful job: https://beaker.allen.ai/orgs/ai2/workspaces/tulu-2-improvements/work/01JKCB1S4M6YNDDX3J5RG0FV7V?taskId=01JKCB1S4SF0A893FTZZ9X00C4&jobId=01JKCB1S9QR6TGP2AGBD72DEB0