### PR TITLE
removing incorrect date cutoffs

### DIFF
--- a/scripts/data/sft/filter_cutoff_date.py
+++ b/scripts/data/sft/filter_cutoff_date.py
@@ -1,0 +1,118 @@
+import re
+import argparse
+from datasets import load_dataset
+from typing import List, Dict
+from datasets import Features, Value, Sequence
+
+"""
+Motivated by: realizing the SFT mix has lots of "as my last update in April 2023" snippets. for next version, we should really template these, so we can add exact cutoff date.
+
+Run with:
+python scripts/data/sft/filter_cutoff_date.py --dataset allenai/tulu-3-sft-mixture --column messages
+"""
+
+# More permissive pattern to catch variations
+CUT_OFF_PATTERN = re.compile(
+    r"""(?ix)                   # Case insensitive, verbose mode
+    (?:                         # Non-capturing group for prefix variations
+        as\s+(?:of\s+)?        # "as of" or "as"
+        (?:my\s+)?             # Optional "my"
+        (?:last|latest)\s+     # "last" or "latest"
+        (?:update|knowledge)    # Followed by "update" or "knowledge"
+        (?:\s+was)?\s+in       # Optional "was" and mandatory "in"
+        |
+        knowledge\s+cutoff     # Or "knowledge cutoff"
+        |
+        last\s+updated?\s+in   # Or "last update(d) in"
+    )
+    \s+
+    (?:                        # Month-year pattern
+        (?:January|February|March|April|May|June|July|
+           August|September|October|November|December)
+        \s+
+    )?
+    (\d{4})                    # Year
+    """
+)
+
+def process_example(example: Dict, column: str) -> Dict:
+    """
+    Extract cutoff date mentions from the specified column and add them to the example.
+    """
+    messages = example.get(column, [])
+    matches = []
+    
+    id = example.get("id", "")
+    source = example.get("source", "")
+
+    for msg in messages:
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            found_matches = list(CUT_OFF_PATTERN.finditer(content))
+            matches.extend(str(match.group(0)) for match in found_matches)
+    
+    new_features = {k: v for k, v in example.items()}
+    new_features["cutoff_matches"] = matches
+    new_features["id"] = id
+    new_features["source"] = source
+    return new_features
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset", type=str, default="allenai/tulu-3-sft-mixture")
+    parser.add_argument("--column", type=str, default="messages")
+    parser.add_argument("--num_proc", type=int, default=16)
+    args = parser.parse_args()
+
+    dataset = load_dataset(args.dataset)
+    
+    for split_name, split_data in dataset.items():
+        print(f"\nProcessing split: {split_name}")
+        print(f"Number of examples in split: {len(split_data)}")
+        
+        # Add new features including cutoff_matches
+        new_features = split_data.features.copy()
+        new_features["cutoff_matches"] = Sequence(Value("string"))
+        new_features["id"] = Value("string")
+        new_features["source"] = Value("string")
+        
+        # Process examples with the new features
+        processed = split_data.map(
+            lambda ex: process_example(ex, column=args.column),
+            num_proc=args.num_proc,
+            desc="Extracting cutoff matches",
+            features=new_features
+        )
+        
+        # Filter examples with matches
+        filtered = processed.filter(
+            lambda ex: bool(ex["cutoff_matches"]),
+            num_proc=args.num_proc,
+            desc="Filtering examples with cutoff mentions"
+        )
+        
+        # Collect all matches
+        all_matches = [match for ex in filtered for match in ex["cutoff_matches"]]
+        
+        # print ids and counter of sources
+        sources = {}
+        for ex in filtered:
+            source = ex["source"]
+            if source not in sources:
+                sources[source] = 0
+            sources[source] += 1
+        print(f"\nSources and counts:")
+        for source, count in sources.items():
+            print(f"- {source}: {count}")
+
+        print(f"\nFound {len(filtered)} examples with cutoff mentions")
+        print(f"Total mentions: {len(all_matches)}")
+        if all_matches:
+            print("\nExample matches:")
+            for match in all_matches[:10]:
+                print(f"- {match}")
+
+                
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
~900 of our SFT examples have things like "As of my last update in 2023" which makes the model learn an incorrect date cutoff. Adding a script for removing this.

I filtered the following datasets:
* Origin tulu 3 sft --> https://huggingface.co/datasets/allenai/tulu-3-sft-mixture-filter-datecutoff
* OLMo 2 SFT --> https://huggingface.co/datasets/allenai/tulu-3-sft-olmo-2-mixture-filter-datecutoff
* Tulu 405B pref data (has ~400 entries) --> https://huggingface.co/datasets/allenai/llama-3.1-tulu-3-405b-preference-mixture-filter-datecutoff

We should run this before every final-ish training run.