### PR TITLE
Small fix to tokenizer logic

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -352,7 +352,7 @@ def get_tokenizer_tulu_v2(tc: "TokenizerConfig"):
 
 GET_TOKENIZER_FN = {
     "get_tokenizer_simple_v1": get_tokenizer_simple_v1,
-    "get_tokenizer_tulu_v1": get_tokenizer_tulu_v1,
+    "get_tokenizer_tulu_v1": get_tokenizer_tulu_v1,  # old version, see https://github.com/allenai/open-instruct/pull/570
     "get_tokenizer_tulu_v2": get_tokenizer_tulu_v2,
 }
 

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -224,6 +224,75 @@ def get_tokenizer_tulu_v1(tc: "TokenizerConfig"):
     # no default pad token for llama!
     # here we add all special tokens again, because the default ones are not in the special_tokens_map
     # only add if the pad token is not present already.
+    if isinstance(tokenizer, LlamaTokenizer) or isinstance(tokenizer, LlamaTokenizerFast):
+        num_added_tokens = tokenizer.add_special_tokens(
+            {
+                "bos_token": "<s>",
+                "eos_token": "</s>",
+                "unk_token": "<unk>",
+                "pad_token": "<pad>",
+            }
+        )
+        assert num_added_tokens in [
+            0,
+            1,
+        ], "LlamaTokenizer should only add one special token - the pad_token, or no tokens if pad token present."
+    elif isinstance(tokenizer, GPTNeoXTokenizerFast):
+        # OLMo newer models use this tokenizer
+        if tokenizer.bos_token is None:
+            tokenizer.bos_token = tokenizer.eos_token
+            assert tc.add_bos, "For OLMo with GPTNeoX, you must add bos token to the beginning of the input sequence."
+        # else, pythia / other models
+        else:
+            num_added_tokens = tokenizer.add_special_tokens(
+                {
+                    "pad_token": "<pad>",
+                }
+            )
+            assert (
+                num_added_tokens <= 1
+            ), "GPTNeoXTokenizer should only add one special token - the pad_token (or no tokens if already set in SFT)."
+    # NOTE: (Costa) I just commented the `OPTForCausalLM` because we are not likely to use it.
+    # elif isinstance(tokenizer, GPT2Tokenizer) and isinstance(model, OPTForCausalLM):
+    #     num_added_tokens = tokenizer.add_special_tokens({"unk_token": "<unk>"})
+    elif isinstance(tokenizer, transformers.PreTrainedTokenizerFast) and tokenizer.pad_token is None:
+        num_added_tokens = tokenizer.add_special_tokens({"pad_token": "<pad>"})
+        assert num_added_tokens == 1, "We detected no padding token but add_special_tokens did not add one."
+
+    # set the tokenizer chat template to the training format
+    # this will be used for encoding the training examples
+    # and saved together with the tokenizer to be used later.
+    if tc.chat_template_name in CHAT_TEMPLATES:
+        tokenizer.chat_template = CHAT_TEMPLATES[tc.chat_template_name]
+    else:
+        try:
+            tokenizer.chat_template = AutoTokenizer.from_pretrained(tc.model_name_or_path).chat_template
+        except Exception:
+            raise ValueError(f"Could not find chat template for {tc.model_name_or_path}.")
+
+    if tc.add_bos:
+        if tokenizer.chat_template.startswith("{{ bos_token }}") or (
+            tokenizer.bos_token is not None and tokenizer.chat_template.startswith(tokenizer.bos_token)
+        ):
+            raise ValueError(
+                "You specified add_bos=True, but the chat template already has a bos_token at the beginning."
+            )
+        # also add bos in the chat template if not already there
+        tokenizer.chat_template = "{{ bos_token }}" + tokenizer.chat_template
+
+    return tokenizer
+
+
+def get_tokenizer_tulu_v2(tc: "TokenizerConfig"):
+    tokenizer = AutoTokenizer.from_pretrained(
+        tc.model_name_or_path,
+        revision=tc.revision,
+        trust_remote_code=tc.trust_remote_code,
+        use_fast=tc.use_fast,
+    )
+    # no default pad token for llama!
+    # here we add all special tokens again, because the default ones are not in the special_tokens_map
+    # only add if the pad token is not present already.
     if tokenizer.pad_token_id is None:
         if isinstance(tokenizer, LlamaTokenizer) or isinstance(tokenizer, LlamaTokenizerFast):
             num_added_tokens = tokenizer.add_special_tokens(
@@ -284,6 +353,7 @@ def get_tokenizer_tulu_v1(tc: "TokenizerConfig"):
 GET_TOKENIZER_FN = {
     "get_tokenizer_simple_v1": get_tokenizer_simple_v1,
     "get_tokenizer_tulu_v1": get_tokenizer_tulu_v1,
+    "get_tokenizer_tulu_v2": get_tokenizer_tulu_v2,
 }
 
 
@@ -295,7 +365,7 @@ class TokenizerConfig:
     use_fast: bool = True
     chat_template_name: Optional[str] = None  # TODO: should I give an option to force override?
     add_bos: bool = False
-    get_tokenizer_fn: str = "get_tokenizer_tulu_v1"
+    get_tokenizer_fn: str = "get_tokenizer_tulu_v2"
 
     # for tracking purposes
     tokenizer_commit_hash: Optional[str] = None

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -292,8 +292,8 @@ def get_tokenizer_tulu_v2(tc: "TokenizerConfig"):
     )
     # no default pad token for llama!
     # here we add all special tokens again, because the default ones are not in the special_tokens_map
-    # only add if the pad token is not present already.
-    if tokenizer.pad_token_id is None:
+    # only add if the pad token is not present already, or if the current one is set to eos_token_id.
+    if tokenizer.pad_token_id is None or tokenizer.pad_token_id == tokenizer.eos_token_id:
         if isinstance(tokenizer, LlamaTokenizer) or isinstance(tokenizer, LlamaTokenizerFast):
             num_added_tokens = tokenizer.add_special_tokens(
                 {
@@ -325,6 +325,8 @@ def get_tokenizer_tulu_v2(tc: "TokenizerConfig"):
         elif isinstance(tokenizer, transformers.PreTrainedTokenizerFast) and tokenizer.pad_token is None:
             num_added_tokens = tokenizer.add_special_tokens({"pad_token": "<pad>"})
             assert num_added_tokens == 1, "We detected no padding token but add_special_tokens did not add one."
+    
+    assert tokenizer.pad_token_id != tokenizer.eos_token_id, "pad token and eos token matching causes issues in our setup."
 
     # set the tokenizer chat template to the training format
     # this will be used for encoding the training examples


### PR DESCRIPTION
1. Qwen 1.5B tokenizer actually reuses llama tokenizer, but with its own bos/eos/pad, which errors when using open-instruct. I'm not sure why we added non-padding tokens and then asserted they weren't added, so removed.
2. Generally, our tokenizer setup is just about adding padding tokens (since base models often don't have them), so I added a check that just doesn't run the token adding if pad token is set.