### PR TITLE
Fix minor lr warmup bug

### DIFF
--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -644,7 +644,7 @@ class PolicyTrainerRayProcess(RayProcess):
         self.optimizer = torch.optim.AdamW(self.policy.parameters(), lr=args.learning_rate)
         num_scheduler_steps = args.num_training_steps * args.num_epochs * args.num_mini_batches
         warm_up_steps = args.warm_up_steps
-        if args.warmup_ratio >= 0.0:
+        if args.warmup_ratio > 0.0:
             warm_up_steps = int(num_scheduler_steps * args.warmup_ratio)
         scheduler = get_scheduler(
             args.lr_scheduler_type,

--- a/open_instruct/ppo2.py
+++ b/open_instruct/ppo2.py
@@ -682,7 +682,7 @@ class PolicyTrainerRayProcess(RayProcess):
         self.optimizer = torch.optim.AdamW(self.policy.parameters(), lr=args.learning_rate)
         num_scheduler_steps = args.num_training_steps * args.num_epochs * args.num_mini_batches
         warm_up_steps = args.warm_up_steps
-        if args.warmup_ratio >= 0.0:
+        if args.warmup_ratio > 0.0:
             warm_up_steps = int(num_scheduler_steps * args.warmup_ratio)
         scheduler = get_scheduler(
             args.lr_scheduler_type,

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -650,7 +650,7 @@ class PolicyTrainerRayProcess(RayProcess):
         self.optimizer = torch.optim.AdamW(self.policy.parameters(), lr=args.learning_rate)
         num_scheduler_steps = args.num_training_steps * args.num_epochs * args.num_mini_batches
         warm_up_steps = args.warm_up_steps
-        if args.warmup_ratio >= 0.0:
+        if args.warmup_ratio > 0.0:
             warm_up_steps = int(num_scheduler_steps * args.warmup_ratio)
         scheduler = get_scheduler(
             args.lr_scheduler_type,


### PR DESCRIPTION
If you set num_warmup_steps, it actually makes no change since the check for warmup_ratio always passes, and sets the warmup steps back to 0. This makes it so that check only passes if warmup_steps is > 0 (not >= 0), and so overrides warmup_steps only when its also explicitly set.