### PR TITLE
Compiled log_softmax + gather operation to reduce vram requirements

### DIFF
--- a/open_instruct/dpo_utils.py
+++ b/open_instruct/dpo_utils.py
@@ -25,6 +25,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers import DataCollatorForSeq2Seq
 
+from open_instruct.model_utils import log_softmax_and_gather
+
 torch.backends.cuda.matmul.allow_tf32 = True
 
 
@@ -162,7 +164,7 @@ def _get_batch_logps(
     # dummy token; we'll ignore the losses on these tokens later
     labels[labels == -100] = 0
 
-    per_token_logps = torch.gather(logits.log_softmax(-1), dim=2, index=labels.unsqueeze(2)).squeeze(2)
+    per_token_logps = log_softmax_and_gather(logits, labels)
 
     if average_log_prob:
         return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -58,7 +58,6 @@ import pandas as pd
 import ray
 import torch
 import torch.distributed as dist
-import torch.nn.functional as F
 import torch.utils
 import torch.utils.data
 from datasets import Dataset
@@ -97,6 +96,7 @@ from open_instruct.model_utils import (
     exact_div,
     first_true_indices,
     get_reward,
+    log_softmax_and_gather,
     print_rich_single_line_metrics,
     print_rich_table,
     push_folder_to_hub,
@@ -775,8 +775,7 @@ class PolicyTrainerRayProcess(RayProcess):
         )
         logits = output.logits[:, context_length - 1 : -1]
         logits /= temperature + 1e-7
-        all_logprob = F.log_softmax(logits, dim=-1)
-        logprob = torch.gather(all_logprob, 2, response.unsqueeze(-1)).squeeze(-1)
+        logprob = log_softmax_and_gather(logits, response)
         return logprob
 
     def train(

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -436,6 +436,8 @@ def log_softmax_and_gather(logits: torch.Tensor, index: torch.Tensor) -> torch.T
 
     The compiled version of this opration avoids the (significant) memory overhead of
     allocating a new (batch_size, seq_len, vocab_size) tensor to store the logprobs.
+    
+    See https://github.com/allenai/open-instruct/pull/584
     """
     logprobs = logits.log_softmax(dim=-1)
     return torch.gather(logprobs, dim=-1, index=index.unsqueeze(-1)).squeeze(-1)

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -15,11 +15,11 @@
 
 
 import itertools
+import logging
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import List, Literal, Optional, Tuple, Union
-import logging
 
 try:
     import deepspeed
@@ -32,20 +32,18 @@ import transformers
 from accelerate import Accelerator
 from accelerate.state import AcceleratorState
 from huggingface_hub import HfApi
-from rich import print as rprint
-from rich.console import Console
-from rich.panel import Panel
-from rich.table import Table
-from torch.nn.parallel.distributed import DistributedDataParallel
-from transformers import PreTrainedModel, PreTrainedTokenizer
-
 from open_instruct.ground_truth_utils import (
     verify_gsm8k_sample,
     verify_ifeval_sample,
     verify_math_sample,
 )
 from open_instruct.utils import retry_on_exception
-
+from rich import print as rprint
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from torch.nn.parallel.distributed import DistributedDataParallel
+from transformers import PreTrainedModel, PreTrainedTokenizer
 
 logger = logging.getLogger(__name__)
 
@@ -436,7 +434,7 @@ def log_softmax_and_gather(logits: torch.Tensor, index: torch.Tensor) -> torch.T
 
     The compiled version of this opration avoids the (significant) memory overhead of
     allocating a new (batch_size, seq_len, vocab_size) tensor to store the logprobs.
-    
+
     See https://github.com/allenai/open-instruct/pull/584
     """
     logprobs = logits.log_softmax(dim=-1)

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -58,7 +58,6 @@ import pandas as pd
 import ray
 import torch
 import torch.distributed as dist
-import torch.nn.functional as F
 import torch.utils
 import torch.utils.data
 from datasets import Dataset
@@ -97,6 +96,7 @@ from open_instruct.model_utils import (
     exact_div,
     first_true_indices,
     get_reward,
+    log_softmax_and_gather,
     print_rich_single_line_metrics,
     print_rich_table,
     push_folder_to_hub,
@@ -825,8 +825,7 @@ class PolicyTrainerRayProcess(RayProcess):
         )
         logits = output.logits[:, context_length - 1 : -1]
         logits /= temperature + 1e-7
-        all_logprob = F.log_softmax(logits, dim=-1)
-        logprob = torch.gather(all_logprob, 2, response.unsqueeze(-1)).squeeze(-1)
+        logprob = log_softmax_and_gather(logits, response)
         return logprob
 
     def train(


### PR DESCRIPTION
The following operation is common in many post-training algorithms:
```python
all_logprobs = logits.log_softmax(dim=-1)  # shape: (batch_size, seq_len, vocab_size)
logprobs  = torch.gather(all_logprobs, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
```

However it is fairly memory inefficient because `all_logprobs` is a large tensor (the same size as logits) that is only needed temporarily for the gather operation. For a modest batch size of 16, seq length of 1024, and vocab size of 32768 this tensor requires 2147 MB of vram (1073 MB for bfloat16).

torch.compile is able to optimize away this memory allocation so that a negligible amount of memory is required for this op other than to hold the logits in the first place.

if torch.compile() is not desired, there are other ways to achieve the same effect, such as:
```python
logsumexp_values = torch.stack([torch.logsumexp(l, dim=-1) for l in logits])
token_logits = torch.gather(logits, dim=-1, index=labels.unsqueeze(-1)).squeeze(-1)
logprobs = token_logits - logsumexp_values
```