### PR TITLE
Fix rlvr datasets

### DIFF
--- a/scripts/data/rlvr/gsm8k_rlvr.py
+++ b/scripts/data/rlvr/gsm8k_rlvr.py
@@ -5,8 +5,8 @@ use it for generations.
 
 Usage: 
 
-python scripts/data/gsm8k.py --push_to_hub
-python scripts/data/gsm8k.py --push_to_hub --hf_entity ai2-adapt-dev
+python scripts/data/rlvr/gsm8k_rlvr.py --push_to_hub
+python scripts/data/rlvr/gsm8k_rlvr.py --push_to_hub --hf_entity ai2-adapt-dev
 """
 
 from dataclasses import dataclass

--- a/scripts/data/rlvr/open_reasoner.py
+++ b/scripts/data/rlvr/open_reasoner.py
@@ -51,20 +51,6 @@ def main(args: Args):
         api = HfApi()
         if not args.hf_entity:
             args.hf_entity = HfApi().whoami()["name"]
-        repo_id = f"{args.hf_entity}/rlvr_gsm8k_zs"
-        print(f"Pushing dataset to Hub: {repo_id}")
-        dataset.push_to_hub(repo_id)
-        api.upload_file(
-            path_or_fileobj=__file__,
-            path_in_repo="create_dataset.py",
-            repo_type="dataset",
-            repo_id=repo_id,
-        )
-
-    if args.push_to_hub:
-        api = HfApi()
-        if not args.hf_entity:
-            args.hf_entity = HfApi().whoami()["name"]
         repo_id = f"{args.hf_entity}/rlvr_open_reasoner_math"
         print(f"Pushing dataset to Hub: {repo_id}")
         dataset.push_to_hub(repo_id)


### PR DESCRIPTION
The current `scripts/data/rlvr/open_reasoner.py` accidentally overriden the gsm8k rlvr dataset. This PR fixes it.