### PR TITLE
Minor fixes to mason + caching

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -798,28 +798,28 @@ class DatasetTransformationCache:
         config_hash = self.compute_config_hash(dcs, tc)
         repo_name = f"{self.hf_entity}/dataset-mix-cached"
 
+        # NOTE: the cached dataset is always train split
+        DEFAULT_SPLIT_FOR_CACHED_DATASET = "train"
+
         # Check if the revision exists
         if revision_exists(repo_name, config_hash, repo_type="dataset"):
             print(f"✅ Found cached dataset at https://huggingface.co/datasets/{repo_name}/tree/{config_hash}")
             # Use the split from the first dataset config as default
-            return load_dataset(repo_name, split=dcs[0].dataset_split, revision=config_hash)
+            return load_dataset(repo_name, split=DEFAULT_SPLIT_FOR_CACHED_DATASET, revision=config_hash)
 
         print(f"Cache not found, transforming datasets...")
 
         # Transform each dataset
-        transformed_datasets = {}
+        transformed_datasets = []
         for dc in dcs:
             dataset = get_dataset_v1(dc, tc)
-            split = dc.dataset_split
-            if split in transformed_datasets:
-                transformed_datasets[split] = concatenate_datasets([transformed_datasets[split], dataset])
-            else:
-                transformed_datasets[split] = dataset
+            transformed_datasets.append(dataset)
 
-        transformed_datasets = DatasetDict(transformed_datasets)
+        # Combine datasets
+        combined_dataset = concatenate_datasets(transformed_datasets)
 
         # Push to hub with config hash as revision
-        transformed_datasets.push_to_hub(
+        combined_dataset.push_to_hub(
             repo_name,
             private=True,
             revision=config_hash,
@@ -856,7 +856,7 @@ This is a cached dataset produced by https://github.com/allenai/open-instruct
 
         # NOTE: Load the dataset again to make sure it's downloaded to the HF cache
         print(f"✅ Found cached dataset at https://huggingface.co/datasets/{repo_name}/tree/{config_hash}")
-        return load_dataset(repo_name, split=dc.dataset_split, revision=config_hash)
+        return load_dataset(repo_name, split=DEFAULT_SPLIT_FOR_CACHED_DATASET, revision=config_hash)
 
 
 def get_cached_dataset(dcs: List[DatasetConfig], tc: TokenizerConfig, hf_entity: Optional[str] = None) -> Dataset:

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -50,7 +50,7 @@ from typing import Any, Dict, List, Optional
 
 import torch
 import transformers
-from datasets import Dataset, concatenate_datasets, load_dataset
+from datasets import Dataset, concatenate_datasets, load_dataset, DatasetDict
 from huggingface_hub import HfApi, ModelCard, revision_exists
 from rich.console import Console
 from rich.text import Text
@@ -807,16 +807,19 @@ class DatasetTransformationCache:
         print(f"Cache not found, transforming datasets...")
 
         # Transform each dataset
-        transformed_datasets = []
+        transformed_datasets = {}
         for dc in dcs:
             dataset = get_dataset_v1(dc, tc)
-            transformed_datasets.append(dataset)
+            split = dc.dataset_split
+            if split in transformed_datasets:
+                transformed_datasets[split] = concatenate_datasets([transformed_datasets[split], dataset])
+            else:
+                transformed_datasets[split] = dataset
 
-        # Combine datasets
-        combined_dataset = concatenate_datasets(transformed_datasets)
+        transformed_datasets = DatasetDict(transformed_datasets)
 
         # Push to hub with config hash as revision
-        combined_dataset.push_to_hub(
+        transformed_datasets.push_to_hub(
             repo_name,
             private=True,
             revision=config_hash,


### PR DESCRIPTION
1. Add the ability to manually specify extra secrets for `mason.py`
2. respect the split argument for datasets. The old code split if you used a non-train split for the eval dataset. This fixes it by instead constructing a dataset dict following the specified splits in the dataset config.