### PR TITLE
Add customizable stop sequences for OE evaluations

### DIFF
--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -1478,6 +1478,8 @@ python scripts/submit_eval_jobs.py \
     --run_id {wandb_url} \
     --oe_eval_max_length {args.eval_max_length} \
     --skip_oi_evals"""
+            if args.stop_strings is not None:
+                command += f" --stop_strings {','.join(args.stop_strings)}"
             if training_step is not None:
                 command += f" --step {training_step}"
             if args.oe_eval_tasks is not None:

--- a/open_instruct/ppo2.py
+++ b/open_instruct/ppo2.py
@@ -1563,6 +1563,8 @@ python scripts/submit_eval_jobs.py \
     --run_id {wandb_url} \
     --oe_eval_max_length {args.eval_max_length} \
     --skip_oi_evals"""
+            if args.stop_strings is not None:
+                command += f" --stop_strings {','.join(args.stop_strings)}"
             if training_step is not None:
                 command += f" --step {training_step}"
             if args.oe_eval_tasks is not None:

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -1567,6 +1567,8 @@ python scripts/submit_eval_jobs.py \
     --run_id {wandb_url} \
     --oe_eval_max_length {args.eval_max_length} \
     --skip_oi_evals"""
+            if args.stop_strings is not None:
+                command += f" --stop_strings {','.join(args.stop_strings)}"
             if training_step is not None:
                 command += f" --step {training_step}"
             if args.oe_eval_tasks is not None:

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -198,8 +198,8 @@ for TASK in "${TASKS[@]}"; do
             --task "$TASK" \
             $MODEL_TYPE \
             --batch-size "$BATCH_SIZE" \
-            --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}${STOP_SEQUENCES_JSON}}" \
-            --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false } }" \
+            --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
+            --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false${STOP_SEQUENCES_JSON} } }" \
             ${HF_UPLOAD_ARG} \
             --gpus "$GPU_COUNT" \
             --gantry-args '{"env-secret": "OPENAI_API_KEY=openai_api_key", "weka": "oe-adapt-default:/weka/oe-adapt-default", "env#132":"VLLM_ALLOW_LONG_MAX_MODEL_LEN=1"}' \
@@ -217,8 +217,8 @@ for TASK in "${TASKS[@]}"; do
         --task "$TASK" \
         $MODEL_TYPE \
         --batch-size "$BATCH_SIZE" \
-        --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}${STOP_SEQUENCES_JSON}}" \
-        --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false } }" \
+        --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
+        --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false${STOP_SEQUENCES_JSON} } }" \
         ${HF_UPLOAD_ARG} \
         --gpus "$GPU_COUNT" \
         --gantry-args "{\"env-secret\": \"OPENAI_API_KEY=openai_api_key\", \"env\":\"VLLM_ALLOW_LONG_MAX_MODEL_LEN=1\"}" \

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -47,8 +47,9 @@ set -ex
 
 # Function to print usage
 usage() {
-    echo "Usage: $0 --model-name MODEL_NAME --model-location MODEL_LOCATION [--num_gpus GPUS] [--upload_to_hf] [--revision REVISION] [--max-length <max_length>] [--unseen-evals] [--priority priority] [--tasks TASKS] [--evaluate_on_weka]"
+    echo "Usage: $0 --model-name MODEL_NAME --model-location MODEL_LOCATION [--num_gpus GPUS] [--upload_to_hf] [--revision REVISION] [--max-length <max_length>] [--unseen-evals] [--priority priority] [--tasks TASKS] [--evaluate_on_weka] [--stop-sequences <comma_separated_stops>]"
     echo "TASKS should be a comma-separated list of task specifications (e.g., 'gsm8k::tulu,bbh:cot::tulu')"
+    echo "STOP_SEQUENCES should be a comma-separated list of strings to stop generation at (e.g., '</answer>,\\n\\n')"
     exit 1
 }
 
@@ -67,6 +68,7 @@ while [[ "$#" -gt 0 ]]; do
         --evaluate_on_weka) EVALUATE_ON_WEKA="true" ;;
         --step) STEP="$2"; shift ;;
         --run-id) RUN_ID="$2"; shift ;;
+        --stop-sequences) STOP_SEQUENCES="$2"; shift ;;
         *) echo "Unknown parameter passed: $1"; usage ;;
     esac
     shift
@@ -91,6 +93,22 @@ PRIORITY="${PRIORITY:normal}"
 EVALUATE_ON_WEKA="${EVALUATE_ON_WEKA:-false}"
 RUN_ID="${RUN_ID:-}"
 STEP="${STEP:-}"
+
+# Process stop sequences if provided
+STOP_SEQUENCES_JSON=""
+if [[ -n "$STOP_SEQUENCES" ]]; then
+    # Convert comma-separated list to JSON array
+    IFS=',' read -ra STOP_SEQS <<< "$STOP_SEQUENCES"
+    STOP_SEQUENCES_JSON=", \"stop_sequences\": ["
+    for i in "${!STOP_SEQS[@]}"; do
+        if [ $i -gt 0 ]; then
+            STOP_SEQUENCES_JSON+=", "
+        fi
+        STOP_SEQUENCES_JSON+="\"${STOP_SEQS[$i]}\""
+    done
+    STOP_SEQUENCES_JSON+="]"
+fi
+
 DATALAKE_ARGS=""
 if [[ -n "$RUN_ID" ]]; then
     DATALAKE_ARGS+="run_id=$RUN_ID"
@@ -180,7 +198,7 @@ for TASK in "${TASKS[@]}"; do
             --task "$TASK" \
             $MODEL_TYPE \
             --batch-size "$BATCH_SIZE" \
-            --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
+            --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}${STOP_SEQUENCES_JSON}}" \
             --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false } }" \
             ${HF_UPLOAD_ARG} \
             --gpus "$GPU_COUNT" \
@@ -199,7 +217,7 @@ for TASK in "${TASKS[@]}"; do
         --task "$TASK" \
         $MODEL_TYPE \
         --batch-size "$BATCH_SIZE" \
-        --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}}" \
+        --model-args "{\"model_path\":\"${MODEL_LOCATION}\", \"max_length\": ${MAX_LENGTH}${STOP_SEQUENCES_JSON}}" \
         --task-args "{ \"generation_kwargs\": { \"max_gen_toks\": ${MAX_LENGTH}, \"truncate_context\": false } }" \
         ${HF_UPLOAD_ARG} \
         --gpus "$GPU_COUNT" \

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -119,6 +119,7 @@ parser.add_argument("--evaluate_on_weka", action="store_true", help="Evaluate OE
 parser.add_argument("--oe_eval_tasks", type=str, default=None, help="Evaluate OE eval on Beaker.")
 parser.add_argument("--step", type=int, default=None, help="Step number for postgresql logging.")
 parser.add_argument("--run_id", type=str, default=None, help="A unique run ID for postgresql logging.")
+parser.add_argument("--oe_eval_stop_sequences", type=str, default=None, help="Comma-separated list of stop sequences for OE eval.")
 args = parser.parse_args()
 
 
@@ -634,6 +635,11 @@ if args.run_oe_eval_experiments or args.oe_eval_unseen_evals:
         oe_eval_cmd += " --unseen-evals"
     # add priority
     oe_eval_cmd += f" --priority {args.priority}"
+    
+    # Add stop sequences if provided
+    if args.oe_eval_stop_sequences:
+        oe_eval_cmd += f" --stop-sequences {args.oe_eval_stop_sequences}"
+        
     print(f"Running OE eval with command: {oe_eval_cmd}")
     subprocess.Popen(oe_eval_cmd, shell=True)
 


### PR DESCRIPTION
- Add stop_sequences parameter to oe-eval.sh that accepts a comma-separated list
- Add oe_eval_stop_sequences parameter to submit_eval_jobs.py
- Process stop sequences into proper JSON format for the model args

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>