### PR TITLE
add arg for eval_priority, default normal

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -281,6 +281,8 @@ class Args:
     """The beaker evaluation tasks to launch"""
     oe_eval_max_length: int = 4096
     """the max generation length for evaluation for oe-eval"""
+    eval_priority: str = "normal"
+    """the priority of auto-launched evaluation jobs"""
 
     def __post_init__(self):
         if self.single_gpu_mode:
@@ -958,6 +960,7 @@ class PolicyTrainerRayProcess(RayProcess):
                     args.oe_eval_tasks,
                     args.stop_strings,
                     args.gs_bucket_path,
+                    args.eval_priority,
                 )
             )
         else:

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -281,7 +281,7 @@ class Args:
     """The beaker evaluation tasks to launch"""
     oe_eval_max_length: int = 4096
     """the max generation length for evaluation for oe-eval"""
-    eval_priority: str = "normal"
+    eval_priority: Literal["low", "normal", "high", "urgent"] = "normal"
     """the priority of auto-launched evaluation jobs"""
 
     def __post_init__(self):

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -310,6 +310,8 @@ class Args:
     """What dataset to upload the metadata to. If unset, don't upload metadata"""
     oe_eval_max_length: int = 4096
     """the max generation length for evaluation for oe-eval"""
+    eval_priority: str = "normal"
+    """the priority of auto-launched evaluation jobs"""
 
     def __post_init__(self):
         assert self.number_samples_per_prompt > 1, "Number of samples per prompt must be greater than 1 for GRPO!"
@@ -1390,6 +1392,7 @@ class PolicyTrainerRayProcess(RayProcess):
                                 args.oe_eval_tasks,
                                 args.stop_strings,
                                 args.gs_bucket_path,
+                                args.eval_priority,
                             )
                         )
                         # if a future is done, remove it from the deque
@@ -1415,6 +1418,7 @@ class PolicyTrainerRayProcess(RayProcess):
                         args.oe_eval_tasks,
                         args.stop_strings,
                         args.gs_bucket_path,
+                        args.eval_priority,
                     )
                 )
                 ray.get(list(eval_futures))

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -310,7 +310,7 @@ class Args:
     """What dataset to upload the metadata to. If unset, don't upload metadata"""
     oe_eval_max_length: int = 4096
     """the max generation length for evaluation for oe-eval"""
-    eval_priority: str = "normal"
+    eval_priority: Literal["low", "normal", "high", "urgent"] = "normal"
     """the priority of auto-launched evaluation jobs"""
 
     def __post_init__(self):

--- a/open_instruct/ppo2.py
+++ b/open_instruct/ppo2.py
@@ -316,7 +316,7 @@ class Args:
     """Whether to try to save the model to Beaker dataset `/output` after training"""
     oe_eval_tasks: Optional[List[str]] = None
     """The beaker evaluation tasks to launch"""
-    eval_priority: str = "normal"
+    eval_priority: Literal["low", "normal", "high", "urgent"] = "normal"
     """the priority of auto-launched evaluation jobs"""
     hf_metadata_dataset: Optional[str] = "allenai/tulu-3-evals"
     """What dataset to upload the metadata to. If unset, don't upload metadata"""

--- a/open_instruct/ppo2.py
+++ b/open_instruct/ppo2.py
@@ -316,6 +316,8 @@ class Args:
     """Whether to try to save the model to Beaker dataset `/output` after training"""
     oe_eval_tasks: Optional[List[str]] = None
     """The beaker evaluation tasks to launch"""
+    eval_priority: str = "normal"
+    """the priority of auto-launched evaluation jobs"""
     hf_metadata_dataset: Optional[str] = "allenai/tulu-3-evals"
     """What dataset to upload the metadata to. If unset, don't upload metadata"""
 
@@ -1567,7 +1569,7 @@ python scripts/submit_eval_jobs.py \
     --cluster ai2/saturn-cirrascale ai2/neptune-cirrascale \
     --is_tuned \
     --workspace "tulu-3-results" \
-    --priority high \
+    --priority {args.eval_priority} \
     --preemptible \
     --use_hf_tokenizer_template \
     --beaker_image "nathanl/open_instruct_auto" \

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -311,6 +311,8 @@ class Args:
     """Whether to try to save the model to Beaker dataset `/output` after training"""
     oe_eval_tasks: Optional[List[str]] = None
     """The beaker evaluation tasks to launch"""
+    eval_priority: str = "normal"
+    """the priority of auto-launched evaluation jobs"""
     hf_metadata_dataset: Optional[str] = "allenai/tulu-3-evals"
     """What dataset to upload the metadata to. If unset, don't upload metadata"""
 
@@ -1570,7 +1572,7 @@ python scripts/submit_eval_jobs.py \
     --cluster ai2/saturn-cirrascale ai2/neptune-cirrascale \
     --is_tuned \
     --workspace "tulu-3-results" \
-    --priority high \
+    --priority {args.eval_priority} \
     --preemptible \
     --use_hf_tokenizer_template \
     --beaker_image "nathanl/open_instruct_auto" \

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -311,7 +311,7 @@ class Args:
     """Whether to try to save the model to Beaker dataset `/output` after training"""
     oe_eval_tasks: Optional[List[str]] = None
     """The beaker evaluation tasks to launch"""
-    eval_priority: str = "normal"
+    eval_priority: Literal["low", "normal", "high", "urgent"] = "normal"
     """the priority of auto-launched evaluation jobs"""
     hf_metadata_dataset: Optional[str] = "allenai/tulu-3-evals"
     """What dataset to upload the metadata to. If unset, don't upload metadata"""

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -883,6 +883,7 @@ def launch_ai2_evals_on_weka(
     oe_eval_tasks: Optional[List[str]] = None,
     stop_strings: Optional[List[str]] = None,
     gs_bucket_path: Optional[str] = None,
+    eval_priority: Optional[str] = "normal",
 ) -> None:
     """
     auto eval the metrics as `f"{args.exp_name}_step_{training_step}"` in our leaderboard
@@ -921,7 +922,7 @@ python scripts/submit_eval_jobs.py \
 --cluster {cluster} \
 --is_tuned \
 --workspace "tulu-3-results" \
---priority high \
+--priority {eval_priority} \
 --preemptible \
 --use_hf_tokenizer_template \
 --beaker_image "nathanl/open_instruct_auto" \


### PR DESCRIPTION
I haven't tested it yet...but this should add and pass an arg `eval_priority` in each of 4 training scripts where some form (either from `utils.py` or locally redefined) of `launch_ai2_evals_on_weka` is called