### PR TITLE
fix epoch logging in grpo_fast

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1504,7 +1504,7 @@ def main(args: Args, model_config: ModelConfig, reward_fn: Callable):
                     "episode": episode,
                     "training_step": training_step,
                     "val/num_total_tokens": num_total_tokens,
-                    "epoch": episode / len(train_dataset),
+                    "epoch": episode / len(train_dataset) / args.num_samples_per_prompt_rollout,
                     "tokens_per_second": num_total_tokens / (time.time() - start_time),
                     **data_thread_metrics,
                     **average_metrics,

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1504,7 +1504,7 @@ def main(args: Args, model_config: ModelConfig, reward_fn: Callable):
                     "episode": episode,
                     "training_step": training_step,
                     "val/num_total_tokens": num_total_tokens,
-                    "epoch": episode / len(train_dataset) / args.num_samples_per_prompt_rollout,
+                    "epoch": episode / args.num_samples_per_prompt_rollout / len(train_dataset),
                     "tokens_per_second": num_total_tokens / (time.time() - start_time),
                     **data_thread_metrics,
                     **average_metrics,


### PR DESCRIPTION
GRPO fast epoch logging doesn't take into account that we are sampling multiple times from a prompt in each step (and counting that to the episode count). This fixes.