### PR TITLE
Fix reward logging for open_instruct/grpo_vllm_thread_ray_gtrl.py

### DIFF
--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -816,7 +816,8 @@ class PolicyTrainerRayProcess(RayProcess):
         torch.set_printoptions(precision=4, sci_mode=False)
 
         # get list of all reward types in dataset, used for logging
-        reward_types = list(set(train_dataset.unique("dataset")))
+        # sorted to make sure the order is consistent
+        reward_types = sorted(list(set(train_dataset.unique("dataset"))))
 
         args = self.args
         self.modified_tokenizer = tokenizer

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -544,10 +544,10 @@ class MetricsTracker:
         def is_non_nan_metric(name):
             return name.startswith("objective/") and (name.endswith("_reward") or name.endswith("_correct_rate"))
         # create the second mask tensor
-        is_non_nan_metric = torch.zeros(self.max_metrics, device=self.metrics.device)
+        is_non_nan_metric_tensor = torch.zeros(self.max_metrics, device=self.metrics.device)
         for idx, name in enumerate(self.names2idx.keys()):
-            is_non_nan_metric[idx] = 1 if is_non_nan_metric(name) else 0
-        valid_mask = valid_mask & is_non_nan_metric
+            is_non_nan_metric_tensor[idx] = 1 if is_non_nan_metric(name) else 0
+        valid_mask = valid_mask & is_non_nan_metric_tensor
         # Replace nan with 0 so they don't contribute to the sum.
         safe_metrics = torch.where(valid_mask, self.metrics, torch.zeros_like(self.metrics))
         # Count valid (non-nan) contributions.

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -798,6 +798,9 @@ class PolicyTrainerRayProcess(RayProcess):
     ):
         torch.set_printoptions(precision=4, sci_mode=False)
 
+        # get list of all reward types in dataset, used for logging
+        reward_types = list(set(train_dataset['dataset'].unique()))
+
         args = self.args
         self.modified_tokenizer = tokenizer
 
@@ -1109,7 +1112,7 @@ class PolicyTrainerRayProcess(RayProcess):
                 scores = []
                 verifiable_counts = []
                 sequence_lengths = []
-                per_func_rewards = defaultdict(list)
+                per_func_rewards = {k: [] for k in reward_types}
                 if self.rank == 0:
                     g_response_token_ids = response_ids_Q.get()
                     DUMMY_PAD_TOKEN = (

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -40,7 +40,7 @@ import subprocess
 import threading
 import time
 from argparse import Namespace
-from collections import defaultdict, deque
+from collections import deque
 from dataclasses import asdict, dataclass, field
 from queue import Empty, Queue
 from typing import Any, Callable, Iterator, List, Literal, Optional, Tuple
@@ -536,7 +536,7 @@ class MetricsTracker:
         # convert to list so to avoid multiple .item() torch calls
         reduced_metrics = self.metrics.tolist()
         return {name: reduced_metrics[idx] for name, idx in self.names2idx.items()}
-    
+
     def get_reduced_metrics_correctness(self) -> dict[str, float]:
         # count the number of valid (non-NaN) values
         valid_mask = ~torch.isnan(self.metrics)
@@ -553,6 +553,7 @@ class MetricsTracker:
 
         reduced_metrics = averaged_metrics.tolist()
         return {name: reduced_metrics[idx] for name, idx in self.names2idx.items()}
+
 
 class Timer:
     """A context manager for timing code blocks"""
@@ -815,7 +816,7 @@ class PolicyTrainerRayProcess(RayProcess):
         torch.set_printoptions(precision=4, sci_mode=False)
 
         # get list of all reward types in dataset, used for logging
-        reward_types = list(set(train_dataset.unique('dataset')))
+        reward_types = list(set(train_dataset.unique("dataset")))
 
         args = self.args
         self.modified_tokenizer = tokenizer

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -538,64 +538,39 @@ class MetricsTracker:
         return {name: reduced_metrics[idx] for name, idx in self.names2idx.items()}
     
     def get_reduced_metrics_correctness(self) -> dict[str, float]:
-        import torch.distributed as dist
-
-        # Get the number of processes.
-        world_size = dist.get_world_size()
-
-        # Define the predicate for "non-nan" (special) metrics.
-        def is_non_nan_metric(name: str) -> bool:
+        # Create a mask for valid (non-nan) values.
+        valid_mask = ~torch.isnan(self.metrics)
+        # only metrics that fit a certain name get the non-nan treatment
+        def is_non_nan_metric(name):
             return name.startswith("objective/") and (name.endswith("_reward") or name.endswith("_correct_rate"))
+        # create a mask where is all nan metrics are True
+        nan_metric_mask = torch.zeros_like(self.metrics, dtype=torch.bool)
+        for name in self.names2idx:
+            if not is_non_nan_metric(name):
+                nan_metric_mask[self.names2idx[name]] = True
+        # combine the two masks
+        valid_mask = valid_mask | nan_metric_mask.bool()
+        # Replace nan with 0 so they don't contribute to the sum.
+        safe_metrics = torch.where(valid_mask, self.metrics, torch.zeros_like(self.metrics))
+        # Count valid (non-nan) contributions.
+        valid_counts = valid_mask.float()
 
-        # Create a boolean mask for special metrics based on the order in names2idx.
-        special_mask = torch.zeros(self.max_metrics, dtype=torch.bool, device=self.metrics.device)
-        for idx, name in enumerate(self.names2idx.keys()):
-            special_mask[idx] = is_non_nan_metric(name)
+        # Sum both safe metrics and valid counts across processes.
+        dist.all_reduce(safe_metrics, op=dist.ReduceOp.SUM)
+        dist.all_reduce(valid_counts, op=dist.ReduceOp.SUM)
 
-        # Split the metrics into special and regular.
-        special_values = self.metrics[special_mask]
-        regular_values = self.metrics[~special_mask]
-
-        ### Process special metrics: nan-avoiding (like np.nanmean) ###
-        # For special metrics, we count only non-nan entries.
-        special_valid = ~torch.isnan(special_values)
-        # Replace nans with 0 so they don't contribute to the sum.
-        safe_special = torch.where(special_valid, special_values, torch.zeros_like(special_values))
-        # All-reduce the safe values and valid counts.
-        dist.all_reduce(safe_special, op=dist.ReduceOp.SUM)
-        special_counts = special_valid.float()
-        dist.all_reduce(special_counts, op=dist.ReduceOp.SUM)
-        # Compute the average: if no valid values, yield nan.
-        special_avg = torch.where(
-            special_counts > 0,
-            safe_special / special_counts,
+        # For each metric, divide the summed value by the count of valid entries.
+        # If there are no valid entries (i.e. valid_counts is 0), leave it as nan.
+        averaged_metrics = torch.where(
+            valid_counts > 0,
+            safe_metrics / valid_counts,
             torch.tensor(float('nan'), device=self.metrics.device)
         )
 
-        ### Process regular metrics: normal averaging ###
-        # For regular metrics, if any process has nan, the final result should be nan.
-        reg_sum = regular_values.clone()
-        dist.all_reduce(reg_sum, op=dist.ReduceOp.SUM)
-        # Also reduce a nan indicator: if any process has nan, we mark that metric.
-        reg_nan_indicator = regular_values.clone().detach()
-        # Create a mask: 1 if nan, 0 otherwise.
-        reg_nan_mask = torch.where(torch.isnan(reg_nan_indicator), torch.ones_like(reg_nan_indicator), torch.zeros_like(reg_nan_indicator))
-        dist.all_reduce(reg_nan_mask, op=dist.ReduceOp.SUM)
-        # If any process had nan (i.e. indicator > 0), the average becomes nan.
-        reg_avg = torch.where(
-            reg_nan_mask > 0,
-            torch.tensor(float('nan'), device=self.metrics.device),
-            reg_sum / world_size
-        )
-
-        # Reconstruct the full averaged metrics tensor.
-        averaged_metrics = torch.empty_like(self.metrics)
-        averaged_metrics[special_mask] = special_avg
-        averaged_metrics[~special_mask] = reg_avg
-
-        # Map the tensor values back to the corresponding names.
+        # Convert to list and map names.
         reduced_metrics = averaged_metrics.tolist()
         return {name: reduced_metrics[idx] for name, idx in self.names2idx.items()}
+
 
 class Timer:
     """A context manager for timing code blocks"""

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -560,13 +560,7 @@ class MetricsTracker:
         dist.all_reduce(valid_counts, op=dist.ReduceOp.SUM)
 
         # For each metric, divide the summed value by the count of valid entries.
-        # If there are no valid entries (i.e. valid_counts is 0), leave it as nan.
-        averaged_metrics = torch.where(
-            valid_counts > 0,
-            safe_metrics / valid_counts,
-            torch.tensor(float('nan'), device=self.metrics.device)
-        )
-
+        averaged_metrics = safe_metrics / valid_counts
         # Convert to list and map names.
         reduced_metrics = averaged_metrics.tolist()
         return {name: reduced_metrics[idx] for name, idx in self.names2idx.items()}

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -799,7 +799,7 @@ class PolicyTrainerRayProcess(RayProcess):
         torch.set_printoptions(precision=4, sci_mode=False)
 
         # get list of all reward types in dataset, used for logging
-        reward_types = list(set(train_dataset['dataset'].unique()))
+        reward_types = list(set(train_dataset.unique('dataset')))
 
         args = self.args
         self.modified_tokenizer = tokenizer

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -547,7 +547,7 @@ class MetricsTracker:
         is_non_nan_metric_tensor = torch.zeros(self.max_metrics, device=self.metrics.device)
         for idx, name in enumerate(self.names2idx.keys()):
             is_non_nan_metric_tensor[idx] = 1 if is_non_nan_metric(name) else 0
-        valid_mask = valid_mask & is_non_nan_metric_tensor
+        valid_mask = valid_mask & is_non_nan_metric_tensor.bool()
         # Replace nan with 0 so they don't contribute to the sum.
         safe_metrics = torch.where(valid_mask, self.metrics, torch.zeros_like(self.metrics))
         # Count valid (non-nan) contributions.

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -543,10 +543,12 @@ class MetricsTracker:
         valid_counts = valid_mask.float()
         # replace NaN values with 0
         safe_metrics = torch.where(valid_mask, self.metrics, torch.tensor(0.0, device=self.metrics.device))
+
         # for non-reward metrics, set valid counts to 1 (we will include nans)
         # and dont mask the nans
         def is_nan_metric(name):
             return not (name.startswith("objective") and (name.endswith("reward") or name.endswith("correct_rate")))
+
         for name, idx in self.names2idx.items():
             if is_nan_metric(name):
                 valid_counts[idx] = 1.0

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -547,7 +547,7 @@ class MetricsTracker:
         is_non_nan_metric_tensor = torch.zeros(self.max_metrics, device=self.metrics.device)
         for idx, name in enumerate(self.names2idx.keys()):
             is_non_nan_metric_tensor[idx] = 1 if is_non_nan_metric(name) else 0
-        valid_mask = valid_mask & is_non_nan_metric_tensor.bool()
+        valid_mask = valid_mask | is_non_nan_metric_tensor.bool()
         # Replace nan with 0 so they don't contribute to the sum.
         safe_metrics = torch.where(valid_mask, self.metrics, torch.zeros_like(self.metrics))
         # Count valid (non-nan) contributions.

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -536,6 +536,30 @@ class MetricsTracker:
         # convert to list so to avoid multiple .item() torch calls
         reduced_metrics = self.metrics.tolist()
         return {name: reduced_metrics[idx] for name, idx in self.names2idx.items()}
+    
+    def get_reduced_metrics_correctness(self) -> dict[str, float]:
+        # Create a mask indicating which entries are valid (non-NaN)
+        valid_mask = ~torch.isnan(self.metrics)
+        # Replace NaNs with zeros so they don’t affect the sum
+        safe_metrics = torch.where(valid_mask, self.metrics, torch.zeros_like(self.metrics))
+        # Count valid entries (1 if valid, 0 if NaN)
+        valid_counts = valid_mask.to(torch.float32)
+
+        # Sum safe metrics and valid counts across processes
+        dist.all_reduce(safe_metrics, op=dist.ReduceOp.SUM)
+        dist.all_reduce(valid_counts, op=dist.ReduceOp.SUM)
+
+        # Compute the average where valid, otherwise keep NaN if no valid entries
+        averaged_metrics = torch.where(
+            valid_counts > 0, 
+            safe_metrics / valid_counts, 
+            torch.tensor(float('nan'), device=self.metrics.device)
+        )
+        
+        reduced_metrics = averaged_metrics.tolist()
+        def is_valid_metric(name):
+            return name.startswith("objective/") and (name.endswith("_reward") or name.endswith("_correct_rate"))
+        return {name: reduced_metrics[idx] for name, idx in self.names2idx.items() if is_valid_metric(name)}
 
 
 class Timer:
@@ -1366,6 +1390,8 @@ class PolicyTrainerRayProcess(RayProcess):
                     "time/training": time.time() - training_time_start,
                     **local_metrics.get_reduced_metrics(),
                 }
+                # override with our nan-safe correctness metric
+                metrics.update(local_metrics.get_reduced_metrics_correctness())
                 if self.rank == 0:
                     print_rich_single_line_metrics(metrics)
                     metrics_queue.put((metrics, episode, df))

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -543,6 +543,14 @@ class MetricsTracker:
         valid_counts = valid_mask.float()
         # replace NaN values with 0
         safe_metrics = torch.where(valid_mask, self.metrics, torch.tensor(0.0, device=self.metrics.device))
+        # for non-reward metrics, set valid counts to 1 (we will include nans)
+        # and dont mask the nans
+        def is_nan_metric(name):
+            return not (name.startswith("objective") and (name.endswith("reward") or name.endswith("correct_rate")))
+        for name, idx in self.names2idx.items():
+            if is_nan_metric(name):
+                valid_counts[idx] = 1.0
+                safe_metrics[idx] = self.metrics[idx]
 
         # Reduce (sum) safe metrics and valid counts across processes.
         dist.all_reduce(safe_metrics, op=dist.ReduceOp.SUM)

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -1385,7 +1385,7 @@ class PolicyTrainerRayProcess(RayProcess):
                     # Correct rate: fraction of samples with positive reward
                     local_metrics.add(f"objective/{key}_correct_rate", (rewards_tensor > 0).float().mean())
 
-                metrics.update({
+                metrics = {
                     "episode": episode,
                     "training_step": training_step,
                     "lr": self.scheduler.get_last_lr()[0],
@@ -1393,7 +1393,7 @@ class PolicyTrainerRayProcess(RayProcess):
                     "time/from_scratch": time.time() - start_time,
                     "time/training": time.time() - training_time_start,
                     **local_metrics.get_reduced_metrics_correctness(),
-                })
+                }
                 if self.rank == 0:
                     print_rich_single_line_metrics(metrics)
                     metrics_queue.put((metrics, episode, df))

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -543,7 +543,11 @@ class MetricsTracker:
         # only metrics that fit a certain name get the non-nan treatment
         def is_non_nan_metric(name):
             return name.startswith("objective/") and (name.endswith("_reward") or name.endswith("_correct_rate"))
-        valid_mask = valid_mask & torch.tensor([is_non_nan_metric(name) for name in self.names2idx.keys()], device=self.metrics.device)
+        # create the second mask tensor
+        is_non_nan_metric = torch.zeros(self.max_metrics, device=self.metrics.device)
+        for idx, name in enumerate(self.names2idx.keys()):
+            is_non_nan_metric[idx] = 1 if is_non_nan_metric(name) else 0
+        valid_mask = valid_mask & is_non_nan_metric
         # Replace nan with 0 so they don't contribute to the sum.
         safe_metrics = torch.where(valid_mask, self.metrics, torch.zeros_like(self.metrics))
         # Count valid (non-nan) contributions.

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -538,33 +538,35 @@ class MetricsTracker:
         return {name: reduced_metrics[idx] for name, idx in self.names2idx.items()}
     
     def get_reduced_metrics_correctness(self) -> dict[str, float]:
-        # Create a mask for valid (non-nan) values.
-        valid_mask = ~torch.isnan(self.metrics)
-        # only metrics that fit a certain name get the non-nan treatment
-        def is_non_nan_metric(name):
-            return name.startswith("objective/") and (name.endswith("_reward") or name.endswith("_correct_rate"))
-        # create a mask where is all nan metrics are True
-        nan_metric_mask = torch.zeros_like(self.metrics, dtype=torch.bool)
+        # Create a mask for objective metrics that should ignore NaNs.
+        # These are metrics whose names start with "objective/" and end with "_reward" or "_correct_rate".
+        mask_obj = torch.zeros_like(self.metrics, dtype=torch.bool)
         for name in self.names2idx:
-            if not is_non_nan_metric(name):
-                nan_metric_mask[self.names2idx[name]] = True
-        # combine the two masks
-        valid_mask = valid_mask | nan_metric_mask.bool()
-        # Replace nan with 0 so they don't contribute to the sum.
-        safe_metrics = torch.where(valid_mask, self.metrics, torch.zeros_like(self.metrics))
-        # Count valid (non-nan) contributions.
+            if name.startswith("objective/") and (name.endswith("_reward") or name.endswith("_correct_rate")):
+                mask_obj[self.names2idx[name]] = True
+
+        # For non-objective metrics, we want to include NaNs.
+        mask_nonobj = ~mask_obj
+
+        # For objective metrics, valid if not NaN; for non-objective, always valid.
+        valid_mask = torch.where(mask_obj, ~torch.isnan(self.metrics), torch.ones_like(self.metrics, dtype=torch.bool))
+
+        # For objective metrics, replace NaNs with 0 so they don't contribute to the sum.
+        # For non-objective metrics, leave the value unchanged (even if it's NaN).
+        safe_metrics = torch.where(mask_obj & torch.isnan(self.metrics), torch.zeros_like(self.metrics), self.metrics)
+
         valid_counts = valid_mask.float()
 
-        # Sum both safe metrics and valid counts across processes.
+        # Reduce (sum) safe metrics and valid counts across processes.
         dist.all_reduce(safe_metrics, op=dist.ReduceOp.SUM)
         dist.all_reduce(valid_counts, op=dist.ReduceOp.SUM)
 
-        # For each metric, divide the summed value by the count of valid entries.
+        # For objective metrics, the average is computed only over valid (non-NaN) values,
+        # while for non-objective metrics, if any NaN is present, the result will be NaN.
         averaged_metrics = safe_metrics / valid_counts
-        # Convert to list and map names.
+
         reduced_metrics = averaged_metrics.tolist()
         return {name: reduced_metrics[idx] for name, idx in self.names2idx.items()}
-
 
 class Timer:
     """A context manager for timing code blocks"""

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -247,10 +247,10 @@ def apply_verifiable_reward(
         per_func_reward = {}
         for gt, ds in zip(ground_truth_list, dataset_list):
             reward_func = REWARD_FN_MAPPING.get(ds.lower())
-            reward_weight = reward_func.weight
             if reward_func is None:
                 logger.warning("No reward function found for dataset %s. Skipping reward.", ds)
                 continue
+            reward_weight = reward_func.weight
             # compare with ground truth.
             # sometimes we need the tokenized pred.
             reward_result = reward_func(


### PR DESCRIPTION
reward logging here before was mucked up, since different ranks could have different sets of rewards.
This fixes by making sure there is always some value for each reward type in the dataset logged on each rank. If the reward wasn't seen, this value ends up being NaN, and we ignore it when reducing metrics. We only apply this logic to the rewards, meaning e.g. if loss becomes NaN it will still log as normal.

Testing out here: https://wandb.ai/ai2-llm/open_instruct_internal/runs/4bqxl8io?nw=nwuserhamishivi