### PR TITLE
fix of load from disk

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1088,7 +1088,7 @@ class LocalDatasetTransformationCache:
         # Check if the cache exists
         if os.path.exists(cache_path) and not dataset_skip_cache:
             print(f"✅ Found cached dataset at {cache_path}")
-            return Dataset.load_from_disk(cache_path)
+            return Dataset.load_from_disk(cache_path, keep_in_memory=True)
 
         print(f"Cache not found or invalid, transforming datasets...")
 
@@ -1108,7 +1108,7 @@ class LocalDatasetTransformationCache:
         self.save_config(self.config_hash, dcs, tc)
         print(f"🚀 Saved transformed dataset to {cache_path}")
         print(f"✅ Found cached dataset at {cache_path}")
-        return combined_dataset
+        return Dataset.load_from_disk(cache_path, keep_in_memory=True)
 
 
 def get_cached_dataset(


### PR DESCRIPTION
Looks like when loading the dataset via `Dataset.load_from_disk`, during `dataset.shuffle`, it creates `cache-2d0a802b78a30b76.arrow`, which seems to cause problems. 

The fix is to set `Dataset.load_from_disk(cache_path, keep_in_memory=True)`, which does not create that arrow file anymore, and it seems to help.

```
➜  oi git:(load-from-disk-fix) ✗ ls /home/costa/Documents/go/github.com/vwxyzjn/oi/local_dataset_cache/1b7223d7c4
cache-2d0a802b78a30b76.arrow  config.json  data-00000-of-00001.arrow  dataset_info.json  state.json
```


See https://beaker.allen.ai/orgs/ai2/workspaces/tulu-3-dev/work/01JR0SG2DHG4KW1NZRKTF0CE4T/logs?jobId=01JR0SG2JERY8470RWWQ4HX9RM for an example. 