### PR TITLE
grpo_fast correct eval freq and get eval metrics

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1552,7 +1552,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
             # ------------------------------------------------------------------------------------------------
             # Optionally evaluate the model
             try:
-                # timeout 0.01 unless this is the last training step or we're not evaluating
+                # timeout 0.01 if this is the last training step or we're not evaluating
                 # otherwise, wait to get the last evaluation generations
                 timeout = 0.01 if (training_step < args.num_training_steps or args.eval_freq < 0) else None
                 eval_responses, eval_finish_reasons = evaluation_inference_results_Q.get(timeout=timeout)


### PR DESCRIPTION
currently `grpo_fast` 
1. checks for eval results before training (and finds none)
2. then the generation thread will generate eval results after first train results
3. then it may log the eval generation from the 1st step during the 2nd training step

as well
- you do not do a final evaluation after the last step
- there are no metrics saved from the evaluation generations

This PR
- adds evaluation metrics
- switches to a more standard evaluation scheme
  - eval every `eval_freq` so that you also do an evaluation after the last step 
  - i.e. total steps = 10, num_evals = 2 will evaluate after the 5th step and after the 10th (final) step
  - total_steps = 32, num_evals = 4 will evaluate after the 8th, 16th, 24th, and 32nd step

If getting the eval generations from the first step is important, I can add an arg for that 