### PR TITLE
enable training from resumption

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -532,6 +532,13 @@ def make_internal_command(command: List[str], args: argparse.Namespace, whoami: 
                     return i
             return -1
 
+        def remove_arg_from_list(lst: List[str], item: str, remove_value: bool = False):
+            idx = find_list_idx(lst, item)
+            if idx != -1 and idx + 1 < len(lst):
+                if remove_value:
+                    lst.pop(idx + 1)
+                lst.pop(idx)
+
         # Save the runtime `whoami` calls
         command.append("--hf_entity")
         command.append("allenai")
@@ -547,8 +554,10 @@ def make_internal_command(command: List[str], args: argparse.Namespace, whoami: 
                 if idx != -1:
                     # then try executing the same command with 
                     caching_command = command.copy()
-                    if "--with_tracking" in caching_command:
-                        caching_command.remove("--with_tracking")
+                    remove_arg_from_list(caching_command, "--with_tracking", False)
+                    remove_arg_from_list(caching_command, "--checkpoint_state_freq", True)
+                    remove_arg_from_list(caching_command, "--checkpoint_state_dir", True)
+                    remove_arg_from_list(caching_command, "--gs_checkpoint_state_dir", True)
                     caching_command = "python " + " ".join(caching_command[idx:]) + " --cache_dataset_only"
                     console.log(f"📦📦📦 Running the caching command with `--cache_dataset_only`")
                     import subprocess

--- a/mason.py
+++ b/mason.py
@@ -9,6 +9,8 @@ import string
 from rich.console import Console
 from rich.text import Text
 import select
+import time
+import random
 
 console = Console()
 
@@ -25,6 +27,12 @@ OPEN_INSTRUCT_COMMANDS = [
     "open_instruct/reward_modeling.py",
 ]
 
+OPEN_INSTRUCT_RESUMABLES = [
+    "open_instruct/grpo_fast.py",
+]
+
+# ----------------------------------------------------------------------
+# Mason logic
 def parse_beaker_dataset(dataset_str):
     splt = dataset_str.split(":")
     if len(splt) != 2:
@@ -156,6 +164,10 @@ def get_args():
     parser.add_argument(
         "--auto_output_dir_path", type=str, default="/weka/oe-adapt-default/allennlp/deletable_checkpoint",
         help="If given, automatically replace the `--output_dir` argument with this path, essentially using it as a prefix"
+    )
+    parser.add_argument(
+        "--auto_checkpoint_state_dir", type=str, default="/weka/oe-adapt-default/allennlp/deletable_checkpoint_states",
+        help="If given, automatically replace the `--checkpoint_state_dir` argument with this path, essentially using it as a prefix"
     )
     parser.add_argument(
         "--env",
@@ -592,6 +604,25 @@ def make_internal_command(command: List[str], args: argparse.Namespace, whoami: 
                     return_code = result.returncode
                     console.log("✅✅✅ Finished running the caching command")
 
+                if file in OPEN_INSTRUCT_RESUMABLES and idx != -1 and len(args.auto_checkpoint_state_dir) > 0:
+                    need_to_override_checkpoint_state_dir = True
+                    default_checkpoint_state_freq = 200
+                    for idx, cmd in enumerate(command):
+                        if cmd == "--checkpoint_state_dir":
+                            if idx + 1 < len(command):
+                                if "/weka/" in command[idx + 1]:
+                                    need_to_override_checkpoint_state_dir = False
+                        if cmd == "--checkpoint_state_freq":
+                            if idx + 1 < len(command):
+                                default_checkpoint_state_freq = command[idx + 1]
+                                        
+                    if need_to_override_checkpoint_state_dir and is_open_instruct_training and not is_external_user:
+                        new_checkpoint_state_dir = f"{args.auto_checkpoint_state_dir}/{whoami}/{int(time.time())}_{random.randint(0, 1000000)}"
+                        console.log(f"🔍🔍🔍 Automatically overriding the `--checkpoint_state_dir` argument to be in `{new_checkpoint_state_dir}`")
+                        command.append("--checkpoint_state_dir")
+                        command.append(new_checkpoint_state_dir)
+                        command.append("--checkpoint_state_freq")
+                        command.append(str(default_checkpoint_state_freq))
 
         # For Weka clusters, we need to override the output_dir parameter to make auto-evaluation work
         # If the output_dir is already set to a path in /weka/, we'll keep that path

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1498,15 +1498,15 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
         pg=pg if args.single_gpu_mode else None,
     )
     resume_training_step = ray.get(inits)[0] + 1
-    if resume_training_step > 1:
-        print(f"Resuming training from step {resume_training_step}... Broadcasting weights to vLLM engines.")
-        with Timer("[Main Thread] 🔄 Loading weights using shared memory"):
-            ray.get([m.broadcast_to_vllm.remote() for m in policy_group.models])
     episode = (resume_training_step - 1) * args.num_unique_prompts_rollout * args.num_samples_per_prompt_rollout
     print("======== ✅ all models and vLLM engines initialized =========")
 
     ray.get([m.setup_model_update_group.remote(vllm_engines=vllm_engines) for m in policy_group.models])
     print("======== ✅ model update group setup successfully =========")
+    if resume_training_step > 1:
+        print(f"Resuming training from step {resume_training_step}... Broadcasting weights to vLLM engines.")
+        with Timer("[Main Thread] 🔄 Loading weights using shared memory"):
+            ray.get([m.broadcast_to_vllm.remote() for m in policy_group.models])
 
     # Setup training
     generation_config = SamplingParams(

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1656,7 +1656,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
                 }
                 scalar_metrics = {}
                 for key, value in metrics.items():
-                    if isinstance(value, float):
+                    if isinstance(value, float) or isinstance(value, int):
                         writer.add_scalar(key, value, episode)
                         scalar_metrics[key] = value
                     if isinstance(value, np.ndarray) or isinstance(value, list):

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -142,6 +142,8 @@ class Args:
     """The hash of the dataset configuration for evaluation."""
     dataset_skip_cache: bool = False
     """Whether to skip the cache."""
+    shuffle_eval_dataset: bool = False
+    """Whether to shuffle the evaluation dataset."""
     max_token_length: int = 512
     """The maximum token length to use for the dataset"""
     max_prompt_token_length: int = 256
@@ -1453,7 +1455,8 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
             dataset_local_cache_dir=args.dataset_local_cache_dir,
             dataset_skip_cache=args.dataset_skip_cache,
         )
-        # NOTE: eval dataset should not be shuffled
+        if args.shuffle_eval_dataset:
+            eval_dataset = eval_dataset.shuffle(seed=args.seed)
     if args.cache_dataset_only:
         return
 

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -342,6 +342,7 @@ class Args:
         if self.checkpoint_state_dir is not None:
             calibrate_checkpoint_state_dir(self.checkpoint_state_dir)
 
+
 def get_train_ds_config(
     offload,
     adam_offload=False,

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -331,7 +331,7 @@ class Args:
             raise ValueError("`checkpoint_state_dir` must be provided if `checkpoint_state_freq` is greater than 0!")
         if self.checkpoint_state_dir is not None and self.checkpoint_state_freq == -1:
             raise ValueError("`checkpoint_state_freq` must be greater than 0 if `checkpoint_state_dir` is provided!")
-        if self.gs_bucket_path is not None:
+        if self.gs_bucket_path is not None and self.gs_checkpoint_state_dir is None:
             beaker_users = get_beaker_whoami()
             if beaker_users is not None:
                 self.gs_checkpoint_state_dir = f"{self.gs_bucket_path}/{beaker_users}/{self.checkpoint_state_dir}"

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1498,6 +1498,10 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
         pg=pg if args.single_gpu_mode else None,
     )
     resume_training_step = ray.get(inits)[0] + 1
+    if resume_training_step > 1:
+        print(f"Resuming training from step {resume_training_step}... Broadcasting weights to vLLM engines.")
+        with Timer("[Main Thread] 🔄 Loading weights using shared memory"):
+            ray.get([m.broadcast_to_vllm.remote() for m in policy_group.models])
     episode = (resume_training_step - 1) * args.num_unique_prompts_rollout * args.num_samples_per_prompt_rollout
     print("======== ✅ all models and vLLM engines initialized =========")
 

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -227,7 +227,7 @@ class Args:
     ref_policy_update_freq: Optional[int] = None
     """How many training steps to take before updating the reference policy."""
     advantage_normalization_type: Literal["standard", "centered"] = "standard"
-    """The type of advantage normalization to use. Standard normalization is the default: it subtracts the mean and 
+    """The type of advantage normalization to use. Standard normalization is the default: it subtracts the mean and
     divides by the standard deviation. Centered normalization is the same but subtracts the mean only (e.g., used in
     DR.GRPO https://arxiv.org/pdf/2503.20783)."""
 

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -700,18 +700,17 @@ def clean_last_n_checkpoints(output_dir: str, keep_last_n_checkpoints: int) -> N
     logger.info("Remaining files:" + str(os.listdir(output_dir)))
 
 
-
 def clean_last_n_checkpoints_deepspeed(output_dir: str, keep_last_n_checkpoints: int) -> None:
     # Identify checkpoint files that follow the pattern global_step{number}
     all_files = os.listdir(output_dir)
     checkpoint_files = []
     for file in all_files:
-        if file.startswith("global_step") and file[len("global_step"):].isdigit():
+        if file.startswith("global_step") and file[len("global_step") :].isdigit():
             checkpoint_files.append(file)
-    
+
     # Sort checkpoints by step number
-    checkpoints = sorted(checkpoint_files, key=lambda x: int(x[len("global_step"):]), reverse=True)
-    
+    checkpoints = sorted(checkpoint_files, key=lambda x: int(x[len("global_step") :]), reverse=True)
+
     # Keep the N most recent checkpoints and remove the rest
     if keep_last_n_checkpoints >= 0 and len(checkpoints) > keep_last_n_checkpoints:
         for checkpoint in checkpoints[keep_last_n_checkpoints:]:
@@ -721,7 +720,7 @@ def clean_last_n_checkpoints_deepspeed(output_dir: str, keep_last_n_checkpoints:
                 shutil.rmtree(checkpoint_path)
             elif os.path.isfile(checkpoint_path):
                 os.remove(checkpoint_path)
-    
+
     # Keep special files like zero_to_fp32.py and latest
     print("Remaining files:" + str(os.listdir(output_dir)))
 
@@ -729,8 +728,8 @@ def clean_last_n_checkpoints_deepspeed(output_dir: str, keep_last_n_checkpoints:
 def calibrate_checkpoint_state_dir(checkpoint_state_dir: str) -> None:
     """
     Find the latest valid checkpoint directory and update the 'latest' file.
-    
-    Edge case: 
+
+    Edge case:
     it's possible sometimes the checkpoint save / upload (1) completely or (2) partially failed (i.e., having incomplete files),
     so we should fall back to a checkpoint that actually exists -- we should pick the latest folder which has the most files.
     The folders look like this:
@@ -743,15 +742,17 @@ def calibrate_checkpoint_state_dir(checkpoint_state_dir: str) -> None:
     """
     if not os.path.exists(checkpoint_state_dir):
         return
-        
+
     # Get all checkpoint directories
-    checkpoint_dirs = [d for d in os.listdir(checkpoint_state_dir) 
-                      if d.startswith("global_step") and 
-                      os.path.isdir(os.path.join(checkpoint_state_dir, d))]
-    
+    checkpoint_dirs = [
+        d
+        for d in os.listdir(checkpoint_state_dir)
+        if d.startswith("global_step") and os.path.isdir(os.path.join(checkpoint_state_dir, d))
+    ]
+
     if not checkpoint_dirs:
         return
-        
+
     # Create a list of (dir_name, step_number, file_count) tuples
     checkpoint_info = []
     for dir_name in checkpoint_dirs:
@@ -760,32 +761,35 @@ def calibrate_checkpoint_state_dir(checkpoint_state_dir: str) -> None:
         # Count files in the directory, not directories
         file_count = len(os.listdir(dir_path))
         checkpoint_info.append((dir_name, step_number, file_count))
-    
+
     # Find the maximum file count
     max_file_count = max(info[2] for info in checkpoint_info)
-    
+
     # Filter to only include checkpoints with the maximum file count
     valid_checkpoints = [info for info in checkpoint_info if info[2] >= max_file_count]
     invalid_checkpoints = [info for info in checkpoint_info if info[2] < max_file_count]
-    
+
     # Remove invalid checkpoint directories
     for dir_name, _, _ in invalid_checkpoints:
         checkpoint_path = os.path.join(checkpoint_state_dir, dir_name)
         print(f"Removing incomplete checkpoint: {dir_name}")
         shutil.rmtree(checkpoint_path)
-    
+
     # Sort by step number (descending)
     valid_checkpoints.sort(key=lambda x: x[1], reverse=True)
-    
+
     # Get the latest valid checkpoint
     latest_checkpoint, latest_step, file_count = valid_checkpoints[0]
-    
+
     # Update the 'latest' file
     with open(os.path.join(checkpoint_state_dir, "latest"), "w") as f:
         f.write(f"global_step{latest_step}")
-    
-    print(f"Found latest checkpoint: {latest_checkpoint} with {file_count} files, "
-                f"updated 'latest' file to global_step{latest_step}")
+
+    print(
+        f"Found latest checkpoint: {latest_checkpoint} with {file_count} files, "
+        f"updated 'latest' file to global_step{latest_step}"
+    )
+
 
 # ----------------------------------------------------------------------------
 # Ai2 user utilities
@@ -962,7 +966,17 @@ def upload_to_gs_bucket(src_path: str, dest_path: str) -> None:
 
 
 def sync_gs_bucket(src_path: str, dest_path: str) -> None:
-    cmd = ["gsutil", "-o", "GSUtil:parallel_composite_upload_threshold=150M", "-m", "rsync", "-r", "-d", src_path, dest_path]
+    cmd = [
+        "gsutil",
+        "-o",
+        "GSUtil:parallel_composite_upload_threshold=150M",
+        "-m",
+        "rsync",
+        "-r",
+        "-d",
+        src_path,
+        dest_path,
+    ]
     print(f"Copying model to GS bucket with command: {cmd}")
     live_subprocess_output(cmd)
 

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -726,6 +726,67 @@ def clean_last_n_checkpoints_deepspeed(output_dir: str, keep_last_n_checkpoints:
     print("Remaining files:" + str(os.listdir(output_dir)))
 
 
+def calibrate_checkpoint_state_dir(checkpoint_state_dir: str) -> None:
+    """
+    Find the latest valid checkpoint directory and update the 'latest' file.
+    
+    Edge case: 
+    it's possible sometimes the checkpoint save / upload (1) completely or (2) partially failed (i.e., having incomplete files),
+    so we should fall back to a checkpoint that actually exists -- we should pick the latest folder which has the most files.
+    The folders look like this:
+    checkpoint_state_dir/global_step14
+    checkpoint_state_dir/global_step15
+    ...
+    checkpoint_state_dir/global_step20
+    we would then update the `checkpoint_state_dir/latest` file
+    with the latest global_step number.
+    """
+    if not os.path.exists(checkpoint_state_dir):
+        return
+        
+    # Get all checkpoint directories
+    checkpoint_dirs = [d for d in os.listdir(checkpoint_state_dir) 
+                      if d.startswith("global_step") and 
+                      os.path.isdir(os.path.join(checkpoint_state_dir, d))]
+    
+    if not checkpoint_dirs:
+        return
+        
+    # Create a list of (dir_name, step_number, file_count) tuples
+    checkpoint_info = []
+    for dir_name in checkpoint_dirs:
+        step_number = int(dir_name.replace("global_step", ""))
+        dir_path = os.path.join(checkpoint_state_dir, dir_name)
+        # Count files in the directory, not directories
+        file_count = len(os.listdir(dir_path))
+        checkpoint_info.append((dir_name, step_number, file_count))
+    
+    # Find the maximum file count
+    max_file_count = max(info[2] for info in checkpoint_info)
+    
+    # Filter to only include checkpoints with the maximum file count
+    valid_checkpoints = [info for info in checkpoint_info if info[2] >= max_file_count]
+    invalid_checkpoints = [info for info in checkpoint_info if info[2] < max_file_count]
+    
+    # Remove invalid checkpoint directories
+    for dir_name, _, _ in invalid_checkpoints:
+        checkpoint_path = os.path.join(checkpoint_state_dir, dir_name)
+        print(f"Removing incomplete checkpoint: {dir_name}")
+        shutil.rmtree(checkpoint_path)
+    
+    # Sort by step number (descending)
+    valid_checkpoints.sort(key=lambda x: x[1], reverse=True)
+    
+    # Get the latest valid checkpoint
+    latest_checkpoint, latest_step, file_count = valid_checkpoints[0]
+    
+    # Update the 'latest' file
+    with open(os.path.join(checkpoint_state_dir, "latest"), "w") as f:
+        f.write(f"global_step{latest_step}")
+    
+    print(f"Found latest checkpoint: {latest_checkpoint} with {file_count} files, "
+                f"updated 'latest' file to global_step{latest_step}")
+
 # ----------------------------------------------------------------------------
 # Ai2 user utilities
 @dataclass
@@ -912,23 +973,6 @@ def download_latest_checkpoint_from_gs(gs_checkpoint_state_dir: str, checkpoint_
         os.makedirs(checkpoint_state_dir, exist_ok=True)
         print(f"Downloading model checkpoint from GCS to {checkpoint_state_dir}")
         sync_gs_bucket(gs_checkpoint_state_dir, checkpoint_state_dir)
-
-        # Edge case: it's possible sometimes the checkpoint upload failed, so we should fall back to
-        # a checkpoint that actually exists. The folders look like this:
-        # checkpoint_state_dir/global_step14
-        # checkpoint_state_dir/global_step15
-        # ...
-        # checkpoint_state_dir/global_step20
-        # you need to sort the folder by picking its latest name, then override the checkpoint_state_dir/`latest` file
-        # with the latest global_step number.
-        checkpoint_dirs = [d for d in os.listdir(checkpoint_state_dir) if d.startswith("global_step")]
-        if checkpoint_dirs:
-            checkpoint_dirs.sort(key=lambda x: int(x.replace("global_step", "")))
-            latest_checkpoint = checkpoint_dirs[-1]
-            latest_step = latest_checkpoint.replace("global_step", "")
-            with open(os.path.join(checkpoint_state_dir, "latest"), "w") as f:
-                f.write(f"global_step{latest_step}")
-            print(f"Found latest checkpoint: {latest_checkpoint}, updated 'latest' file to global_step{latest_step}")
 
 
 def launch_ai2_evals_on_weka(


### PR DESCRIPTION
This PR enables grpo training to resume from checkpoints. It works like this:


### auto-resume:

If the run was preemptied, it could auto-resume. If the run errored out from nccl error, we could "restart" the same beaker job, and the training would continue.

So for the following job, I tried cancel the job and hit the refresh button, and it was able to resume training pretty nicely. We can reasonably assume that resuming from preemption is gonna work nicely, too.

<img width="1181" alt="image" src="https://github.com/user-attachments/assets/f7ee203c-9ba9-4482-b9ec-b45a1abe9434" />


### arbitrary resume: we allow the user to specify a `--checkpoint_state_dir` or `--gs_checkpoint_state_dir` to start from an arbitrary checkpoint


```
python update_command_args.py scripts/train/qwen/grpo_fast_7b.sh \
    --cluster ai2/augusta-google-1 \
    --workspace ai2/scaling-rl \
    --image costah/open_instruct_dev_0415_9 \
    --wandb_project_name open_instruct_public \
    --checkpoint_state_dir /weka/oe-adapt-default/allennlp/deletable_checkpoint_states/costah/1744804711_477946 \
    --gs_checkpoint_state_dir gs://ai2-llm/post-training//costah//weka/oe-adapt-default/allennlp/deletable_checkpoint_states/costah/1744804711_477946 \
    --checkpoint_state_freq 200 \
    --priority high | uv run bash
```

<img width="1176" alt="image" src="https://github.com/user-attachments/assets/168ff562-94be-4dc0-8a0b-e681fd1b1a93" />


### Edge cases and limitations:

An edge case was that the upload could fail. For example, imagine the upload or saving failed somehow. In that case, my implementation would try to locate the latest checkpoint folder that "has the most files" as the intact checkpoint to resume.


One limitation is that if preemptied, we do not have that sigterm handling which saves the model on preemption, but we do save the checkpoints periodically so this is prob enough for now.


### Evaluation:

For eval, you do need to gather all the separate run_ids from wandb, but you can grab them by doing a filtering step in wandb


<img width="1035" alt="image" src="https://github.com/user-attachments/assets/b8de086f-a06c-4565-90b9-f30129c250c1" />
