### PR TITLE
Better update command args

### DIFF
--- a/update_command_args.py
+++ b/update_command_args.py
@@ -105,5 +105,20 @@ def main():
     
     print(modified_content)
 
+
+def test_modify_command():
+    content = "python train.py --dataset_mixer_list xxx 1.0 --cluster ai2/augusta-google-1 --priority normal"
+    new_args = {
+        "dataset_mixer_list": ["xxx", "1.0"],
+        "cluster": "ai2/augusta-google-1",
+        "priority": "normal",
+        "image": "costah/open_instruct_dev0320_11"
+    }
+    modified_content = modify_command(content, new_args)
+    normalized_content = " ".join(modified_content.replace("\\\n", "").split())
+    assert normalized_content == "python train.py --dataset_mixer_list xxx 1.0 --cluster ai2/augusta-google-1 --priority normal --priority normal --image costah/open_instruct_dev0320_11"
+
+
 if __name__ == "__main__":
-    main() 
+    test_modify_command()
+    main()

--- a/update_command_args.py
+++ b/update_command_args.py
@@ -12,40 +12,64 @@ would replace the `--cluster`, `--priority`, `--image` arguments in the script w
 """
 
 import sys
-import re
 import argparse
+from typing import List
 
-def read_shell_script(filename):
+def read_shell_script(filename: str) -> str:
     with open(filename, 'r') as f:
         return f.read()
 
-def modify_command(content, new_args):
-    # Split content into lines while preserving line continuations
-    lines = content.replace('\\\n', ' ').split('\n')
-    
-    # Join all non-empty lines to get the full command
-    command = ' '.join(line.strip() for line in lines if line.strip())
-    
-    # For each new argument
-    for arg, value in new_args.items():
-        arg_pattern = f"--{arg} [^ ]+"
-        if re.search(arg_pattern, command):
-            # Replace existing argument
-            command = re.sub(arg_pattern, f"--{arg} {value}", command)
+def modify_command(content: str, new_args: List[str]) -> str:
+    split_content = content.split(" ")
+    new_content = []
+    flag_args = []
+    flag = None
+    for _, part in enumerate(split_content):
+        if flag is None:
+            if not part.startswith('--'):
+                new_content.append(part)
+            else:
+                flag = part.split('--')[1]
+                flag_args.append(part)
         else:
-            # Add new argument at the end
-            command = f"{command} --{arg} {value}"
-    
-    # Reformat with line continuations every 2 arguments
-    parts = command.split(' --')
-    formatted = parts[0]  # First part (python mason.py)
-    for i, part in enumerate(parts[1:], 1):
-        if i % 2 == 1:
-            formatted += f" \\\n    --{part}"
+            if not part.startswith('--'):
+                flag_args.append(part)
+            else:
+                if flag in new_args:
+                    new_content.append(f"--{flag}")
+                    new_args_values = new_args[flag]
+                    if isinstance(new_args_values, list):
+                        new_content.extend(new_args_values)
+                    else:
+                        new_content.append(new_args_values)
+                        # hack the convention to make the format nicer
+                    new_content.extend(["\\\n", "", "", ""])
+                    del new_args[flag]
+                else:
+                    new_content.append(f"--{flag}")
+                    if isinstance(flag_args, list):
+                        new_content.extend(flag_args)
+                    else:   
+                        new_content.append(flag_args)
+                flag = part.split('--')[1]
+                flag_args = []
+    if flag is not None:
+        new_content.append(f"--{flag}")
+        if isinstance(flag_args, list):
+            new_content.extend(flag_args)
         else:
-            formatted += f" --{part}"
-    
-    return formatted
+            new_content.append(flag_args)
+
+
+    # add the remaining args
+    for flag, value in new_args.items():
+        new_content.append(f"--{flag}")
+        if isinstance(value, list):
+            new_content.extend(value)
+        else:
+            new_content.append(value)
+        new_content.extend(["\\\n", "", "", ""])
+    return " ".join(new_content)
 
 def main():
     if len(sys.argv) < 2:
@@ -55,15 +79,26 @@ def main():
     script_file = sys.argv[1]
     
     # Parse remaining arguments as key-value pairs
+    # NOTE: we need to handle `nargs` for cases like `--dataset_mixer_list xxx 1.0`
     parser = argparse.ArgumentParser()
-    for i in range(2, len(sys.argv), 2):
-        if i + 1 < len(sys.argv):
+    num_values = 0
+    last_arg = None
+    for i in range(2, len(sys.argv)):
+        if sys.argv[i].startswith('--'):
             arg = sys.argv[i].lstrip('-')
-            parser.add_argument(f"--{arg}")
-    
+            nargs = "+" if num_values % 2 == 0 else "?"
+            if last_arg is not None:
+                parser.add_argument(f"--{last_arg}", nargs=nargs)
+            last_arg = arg
+            num_values = 0
+        else:
+            num_values += 1
+    nargs = "+" if num_values % 2 == 0 else "?"
+    if last_arg is not None:
+        parser.add_argument(f"--{last_arg}", nargs=nargs)
+
     args = parser.parse_args(sys.argv[2:])
     new_args = {k: v for k, v in vars(args).items() if v is not None}
-    
     # Read and modify the script
     content = read_shell_script(script_file)
     modified_content = modify_command(content, new_args)

--- a/update_command_args.py
+++ b/update_command_args.py
@@ -5,6 +5,7 @@ This script is used to add or update arguments in a shell script. For example,
 python update_command_args.py scripts/train/tulu3/grpo_fast_8b.sh \
     --cluster ai2/augusta-google-1 \
     --priority normal \
+    --dataset_mixer_list allenai/RLVR-GSM 1.0 allenai/RLVR-MATH 1.0 \
     --image costah/open_instruct_dev0320_11 | uv run bash
 ```
 
@@ -79,7 +80,6 @@ def main():
     script_file = sys.argv[1]
     
     # Parse remaining arguments as key-value pairs
-    # NOTE: we need to handle `nargs` for cases like `--dataset_mixer_list xxx 1.0`
     parser = argparse.ArgumentParser()
     num_values = 0
     last_arg = None


### PR DESCRIPTION
The refactored version should handle `--dataset_mixer_list allenai/RLVR-GSM 1.0 allenai/RLVR-MATH 1.0`. Previous version would have errored out because it assumes the flag only have one arg.

This script is actually hand-rolled lol; claude kept writing something different.


<img width="849" alt="image" src="https://github.com/user-attachments/assets/32b03f7e-a6d3-42a8-96a9-4ab70f63f393" />



<img width="809" alt="image" src="https://github.com/user-attachments/assets/b0727e26-10d4-404c-9b24-78a5392a8a1c" />
