### PR TITLE
Fix final eval + other bugs

### DIFF
--- a/Dockerfile.uv
+++ b/Dockerfile.uv
@@ -31,9 +31,9 @@ RUN --mount=type=cache,target=${UV_CACHE_DIR} \
 RUN --mount=type=cache,target=${UV_CACHE_DIR} \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --extra compile
+    uv sync --frozen --no-install-project --extra compile --extra liger
 RUN --mount=type=cache,target=${UV_CACHE_DIR} \
-    uv sync --frozen --extra compile
+    uv sync --frozen --extra compile --extra liger
 
 WORKDIR /stage/
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ python -m nltk.downloader punkt
 * **Local installation with uv (preview)**: We are experimenting with using [uv](https://docs.astral.sh/uv/). You can install via
 ```bash
 uv sync
-uv sync --extra compile # to install flash attention
+uv sync --extra compile --extra liger # to install flash attention and liger-kernel
 ```
 
 

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -66,6 +66,7 @@ from transformers import (
 from transformers.utils.hub import (
     _CACHED_NO_EXIST,
     TRANSFORMERS_CACHE,
+    _CACHED_NO_EXIST,
     extract_commit_hash,
     try_to_load_from_cache,
 )
@@ -86,9 +87,13 @@ def custom_cached_file(model_name_or_path: str, filename: str, revision: str = N
         else:
             return None
     else:
-        return try_to_load_from_cache(
+        resolved_file = try_to_load_from_cache(
             model_name_or_path, filename, cache_dir=TRANSFORMERS_CACHE, revision=revision, repo_type=repo_type
         )
+        # special return value from try_to_load_from_cache
+        if resolved_file == _CACHED_NO_EXIST:
+            return None
+        return resolved_file
 
 
 def get_commit_hash(

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -66,7 +66,6 @@ from transformers import (
 from transformers.utils.hub import (
     _CACHED_NO_EXIST,
     TRANSFORMERS_CACHE,
-    _CACHED_NO_EXIST,
     extract_commit_hash,
     try_to_load_from_cache,
 )

--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -9,8 +9,8 @@ import json
 import logging
 import re
 import string
-from collections import Counter
 from abc import ABC, abstractmethod
+from collections import Counter
 from typing import Any, Dict, List, Union
 
 from open_instruct.if_functions import IF_FUNCTIONS_MAP

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -326,9 +326,7 @@ class Args:
     def __post_init__(self):
         assert self.num_samples_per_prompt_rollout > 0, "Number of samples per prompt must be greater than 0!"
         if self.num_samples_per_prompt_rollout == 1:
-            print(
-                "WARNING: num_samples_per_prompt_rollout is 1. This reduces GRPO to REINFORCE. "
-            )
+            print("WARNING: num_samples_per_prompt_rollout is 1. This reduces GRPO to REINFORCE. ")
         assert (
             self.apply_verifiable_reward or self.apply_r1_style_format_reward or self.non_stop_penalty
         ), "At least one reward must be applied!"
@@ -1157,7 +1155,11 @@ def vllm_generate_thread(
         inference_results_Q.put((response_ids, finish_reasons))
 
         # Evaluate the model
-        if eval_prompt_token_ids is not None and num_evals > 0 and ((training_step - 1) % eval_freq == 0 or training_step == num_training_steps):
+        if (
+            eval_prompt_token_ids is not None
+            and num_evals > 0
+            and ((training_step - 1) % eval_freq == 0 or training_step == num_training_steps)
+        ):
             response_ids, finish_reasons = generate_with_engines(eval_prompt_token_ids, eval_generation_config)
             evaluation_inference_results_Q.put((response_ids, finish_reasons))
 

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -324,7 +324,11 @@ class Args:
     """the priority of auto-launched evaluation jobs"""
 
     def __post_init__(self):
-        assert self.num_samples_per_prompt_rollout > 1, "Number of samples per prompt must be greater than 1 for GRPO!"
+        assert self.num_samples_per_prompt_rollout > 0, "Number of samples per prompt must be greater than 0!"
+        if self.num_samples_per_prompt_rollout == 1:
+            print(
+                "WARNING: num_samples_per_prompt_rollout is 1. This reduces GRPO to REINFORCE. "
+            )
         assert (
             self.apply_verifiable_reward or self.apply_r1_style_format_reward or self.non_stop_penalty
         ), "At least one reward must be applied!"

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1720,8 +1720,8 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
             # Optionally evaluate the model
             try:
                 # timeout 0.01 if this is the last training step or we're not evaluating
-                # otherwise, wait to get the last evaluation generations
-                timeout = 0.01 if (training_step < args.num_training_steps or args.eval_freq < 0) else None
+                # otherwise, wait to get the last evaluation generations (long timeout just in case)
+                timeout = 0.01 if (training_step < args.num_training_steps or args.eval_freq < 0) else 100
                 eval_responses, eval_finish_reasons = evaluation_inference_results_Q.get(timeout=timeout)
                 print("[Main Thread] 📊 Evaluation responses received")
 

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -56,9 +56,9 @@ import time
 from argparse import Namespace
 from collections import deque
 from dataclasses import asdict, dataclass, field
+from itertools import chain
 from queue import Empty, Queue
 from typing import Any, Callable, Iterator, List, Literal, Optional, Tuple
-from itertools import chain
 
 import numpy as np
 import pandas as pd
@@ -333,9 +333,7 @@ class Args:
     def __post_init__(self):
         assert self.number_samples_per_prompt > 0, "Number of samples per prompt must be greater than 0!"
         if self.number_samples_per_prompt == 1:
-            print(
-                "WARNING: number_samples_per_prompt is 1. This reduces GRPO to REINFORCE. "
-            )
+            print("WARNING: number_samples_per_prompt is 1. This reduces GRPO to REINFORCE. ")
 
 
 def process_dataset_mixer(value) -> Tuple[Optional[dict], Optional[str]]:

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -331,7 +331,11 @@ class Args:
     """the priority of auto-launched evaluation jobs"""
 
     def __post_init__(self):
-        assert self.number_samples_per_prompt > 1, "Number of samples per prompt must be greater than 1 for GRPO!"
+        assert self.number_samples_per_prompt > 0, "Number of samples per prompt must be greater than 0!"
+        if self.number_samples_per_prompt == 1:
+            print(
+                "WARNING: number_samples_per_prompt is 1. This reduces GRPO to REINFORCE. "
+            )
 
 
 def process_dataset_mixer(value) -> Tuple[Optional[dict], Optional[str]]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,6 +81,7 @@ jsonschema==4.23.0
 jsonschema-specifications==2024.10.1
 kiwisolver==1.4.8
 lark==1.2.2
+liger-kernel==0.5.4
 llguidance==0.7.9 ; platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'x86_64'
 llvmlite==0.43.0
 lm-format-enforcer==0.10.11


### PR DESCRIPTION
- We had an assertion that GRPO requires > 1 sample per prompt. This is true, but running 1 sample per prompt can be interesting to try (basically just REINFORCE), so I removed the assert and added a log warning.
- #651 added some changes where we always eval on the final step, but the generation thread was not updated. This meant that the code would hang waiting for an evaluation generation thread to finish that would never come. This PR should fix that.
- Sometimes `try_load_from_cache` can return `_CACHED_NO_EXIST`, an empty object (see https://github.com/huggingface/huggingface_hub/blob/main/src/huggingface_hub/file_download.py#L1380-L1381). This fixes our code to handle that return value.
- We had liger kernel stuff in SFT, but its fallen out. Added it back into the default install things.