### PR TITLE
pin beaker-py<2.0 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ requires-dist = ["torch", "setuptools"]
 [dependency-groups]
 dev = [
     "autoflake>=2.3.1",
-    "beaker-py>=1.32.2",
+    "beaker-py>=1.32.2,<2.0",
     "black>=24.10.0",
     "flake8>=7.1.1",
     "isort>=5.13.2",


### PR DESCRIPTION
Ethan Shen reported an issue because they had beaker-py v2 installed: https://allenai.slack.com/archives/C6MN19S05/p1747279821023939