### PR TITLE
Raise error when num_processes not set for multi-node jobs.

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -766,6 +766,8 @@ def make_internal_command(command: List[str], args: argparse.Namespace, whoami: 
     join_full_command = " ".join(full_command)
     # override accelerate call
     if args.num_nodes > 1:
+        if "--num_processes" not in join_full_command:
+            raise ValueError("num_processes must be specified in the command for multi-node jobs.")
         join_full_command = re.sub(
             r'--num_processes (\d+)',
             lambda m: (


### PR DESCRIPTION
Currently if num_proceses is not set for multi-node jobs, then the regex fails silently and the job is submitted, but doesn't actually run as a multi-node job. This adds an explicit check for this (I and Ethan hit this recently).