### PR TITLE
fix: only skip batches once on resume

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -751,14 +751,17 @@ def main(args: FlatArguments, tc: TokenizerConfig):
     local_total_tokens = torch.tensor(0, dtype=torch.int64, device=accelerator.device)
     total_token_including_padding = torch.tensor(0, dtype=torch.int64, device=accelerator.device)
     start_time = time.time()
+    skipped_batches = False
     for epoch in range(starting_epoch, args.num_train_epochs):
         model.train()
         train_dataloader.set_epoch(epoch)
         total_loss = 0
         total_aux_loss = 0
-        if last_checkpoint_path and resume_step is not None:
-            # We skip the first `n` batches in the dataloader when resuming from a checkpoint
+        if last_checkpoint_path and resume_step is not None and not skipped_batches:
+            # We skip the first `n` batches in the dataloader when resuming from a checkpoint.
             active_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)
+            # Only perform this skip once
+            skipped_batches = True
         else:
             active_dataloader = train_dataloader
         for step, batch in enumerate(active_dataloader):


### PR DESCRIPTION
Fixes the skip-batch logic so that we only skip `resume_step` batches once. The current logic causes `resume_step` batches to be skipped every epoch.