### PR TITLE
Change accumulation steps to avoid leftover data during training

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -724,7 +724,15 @@ class PolicyTrainerRayProcess(RayProcess):
         to_device_inplace(collated_position_ids, self.device)
         to_device_inplace(collated_advantages, self.device)
         to_device_inplace(collated_response_masks, self.device)
-        accumulation_steps = len(collated_query_responses) // (num_mini_batches)
+        accumulation_steps = (len(collated_query_responses) + num_mini_batches - 1) // num_mini_batches
+        leftover = len(collated_query_responses) % accumulation_steps
+        if leftover > 0:
+            collated_query_responses = collated_query_responses[0:-leftover]
+            collated_tool_masks = collated_tool_masks[0:-leftover]
+            collated_attention_masks = collated_attention_masks[0:-leftover]
+            collated_position_ids = collated_position_ids[0:-leftover]
+            collated_advantages = collated_advantages[0:-leftover]
+            collated_response_masks = collated_response_masks[0:-leftover]
 
         # Calculate the logprob of the reference policy
         collated_ref_logprobs = []

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -55,6 +55,7 @@ from dataclasses import asdict, dataclass, field
 from queue import Empty, Queue
 from typing import Callable, Dict, Iterator, List, Literal, Optional
 
+import math
 import numpy as np
 import pandas as pd
 import ray
@@ -724,7 +725,7 @@ class PolicyTrainerRayProcess(RayProcess):
         to_device_inplace(collated_position_ids, self.device)
         to_device_inplace(collated_advantages, self.device)
         to_device_inplace(collated_response_masks, self.device)
-        accumulation_steps = (len(collated_query_responses) + num_mini_batches - 1) // num_mini_batches
+        accumulation_steps = math.ceil(len(collated_query_responses)/num_mini_batches - 0.5)
         leftover = len(collated_query_responses) % accumulation_steps
         if leftover > 0:
             collated_query_responses = collated_query_responses[0:-leftover]

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -725,7 +725,7 @@ class PolicyTrainerRayProcess(RayProcess):
         to_device_inplace(collated_position_ids, self.device)
         to_device_inplace(collated_advantages, self.device)
         to_device_inplace(collated_response_masks, self.device)
-        accumulation_steps = math.ceil(len(collated_query_responses)/num_mini_batches - 0.5)
+        accumulation_steps = math.ceil(len(collated_query_responses) / num_mini_batches - 0.5)
         leftover = len(collated_query_responses) % accumulation_steps
         if leftover > 0:
             collated_query_responses = collated_query_responses[0:-leftover]


### PR DESCRIPTION
Hello,

This PR fixes a bug in the grpo_fast.py script where the accumulation steps are getting computed:
accumulation_steps = len(collated_query_responses) // (num_mini_batches)

If the len(collated_query_responses) is a **prime number** and **num_mini_batches is > 1**, then there will be some leftover data in the end for which the backward pass won't be computed. I believe it leads to some **active modules** in the deepspeed model, which then leads to the following error when updating the **VLLM engine weights**:

AssertionError: {'id': 0, 'status': 'AVAILABLE', 'numel': 622329856, 'ds_numel': 622329856, 'shape': (151936, 4096), 'ds_shape': (151936, 4096), 'requires_grad': True, 'grad_shape': None, 'persist': False, 'active_sub_modules': {2}, 'ds_tensor.shape': torch.Size([38895616])}

One way to solve this is to let go of the leftover data so that such an error does not occur.

Another issue is: If we take the **floor of the division operation** in the above equation, it can lead to many unnecessary updates, for eg:
if the len(collated_query_responses) is 31 and num_mini_batches is 16, 31 // 16 will be 1 and will lead to 31 gradient updates; on the other hand, if we take the ceil instead, it will result in 15 gradient updates (leaving the last 1 sample of leftover data) which is more desirable.

The PR implements the above two changes.