### PR TITLE
Assert that num prompts * num rollouts / minibatches == 0

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -361,6 +361,9 @@ class Args:
             self.apply_verifiable_reward or self.apply_r1_style_format_reward or self.non_stop_penalty
         ), "At least one reward must be applied!"
         assert (
+            self.num_unique_prompts_rollout * self.num_samples_per_prompt_rollout % self.num_mini_batches == 0
+        ), "The number of unique prompts rollout times the number of samples per prompt rollout must be divisible by the number of minibatches!"
+        assert (
             self.pack_length >= self.max_prompt_token_length + self.response_length
         ), "The `pack_length` needs to be greater than the sum of `max_prompt_token_length` and `response_length`!"
         if self.checkpoint_state_freq > 0 and self.checkpoint_state_dir is None:

--- a/open_instruct/ppo_fast.py
+++ b/open_instruct/ppo_fast.py
@@ -359,6 +359,9 @@ class Args:
         assert (
             self.pack_length >= self.max_prompt_token_length + self.response_length
         ), "The `pack_length` needs to be greater than the sum of `max_prompt_token_length` and `response_length`!"
+        assert (
+            self.num_unique_prompts_rollout * self.num_samples_per_prompt_rollout % self.num_mini_batches == 0
+        ), "The number of unique prompts rollout times the number of samples per prompt rollout must be divisible by the number of minibatches!"
 
 
 def masked_mean(values: torch.Tensor, mask: torch.Tensor, axis: Optional[int] = None) -> torch.Tensor:


### PR DESCRIPTION
#698 points out a problem with minibatches and rollouts. Instead of making the loop more complex, I think it's cleaner to just prevent users from doing this, which this pr does.