### PR TITLE
Various bag of fixes.

### DIFF
--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -282,7 +282,7 @@ class IFEvalVerifier(VerifierFunction):
         constraint_dict = constraint_dict[0]
         if isinstance(constraint_dict, str):
             constraint_dict = json.loads(constraint_dict)
-        answer = remove_thinking_section(prediction)
+        answer = remove_thinking_section(prediction).strip()
         instruction_keys = constraint_dict["instruction_id"]
         args_list = constraint_dict["kwargs"]
         rewards = []

--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -273,7 +273,7 @@ class IFEvalVerifier(VerifierFunction):
         instruction_keys = constraint_dict["instruction_id"]
         args_list = constraint_dict["kwargs"]
         rewards = []
-        if len(prediction) == 0:
+        if len(prediction) == 0 or len(answer) == 0:
             logger.warning("Empty prediction received for IFEvalVerifier.")
             return VerificationResult(score=0.0)
         for instruction_key, args in zip(instruction_keys, args_list):

--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -163,7 +163,7 @@ def remove_thinking_section(prediction: str) -> str:
     prediction = prediction.split("</think>")[-1]
     # remove answer tags from the prediction
     prediction = prediction.replace("<answer>", "").replace("</answer>", "")
-    return prediction
+    return prediction.strip()
 
 
 class GSM8KVerifier(VerifierFunction):
@@ -282,7 +282,7 @@ class IFEvalVerifier(VerifierFunction):
         constraint_dict = constraint_dict[0]
         if isinstance(constraint_dict, str):
             constraint_dict = json.loads(constraint_dict)
-        answer = remove_thinking_section(prediction).strip()
+        answer = remove_thinking_section(prediction)
         instruction_keys = constraint_dict["instruction_id"]
         args_list = constraint_dict["kwargs"]
         rewards = []

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -199,6 +199,8 @@ class Args:
     """RUNTIME VALUE: The frequency of evaluation steps"""
     save_freq: int = -1
     """How many train steps to save the model"""
+    allow_world_padding: bool = False
+    """Whether to allow world padding. This is useful for model sweeps, but wastes compute."""
 
     # Generation
     response_length: int = 256
@@ -1232,25 +1234,26 @@ def data_preparation_thread(
 
         # if we have less batches than world size, we need to pad out so each world is fine
         # ideally, you should avoid this since its wasting computation.
-        with Timer("🤺 [Data Preparation Thread] Padding sequences for world size"):
-            shortfall = args.world_size - len(packed_sequences.query_responses)
-            if shortfall > 0:
-                print(f"Padding {shortfall} sequences for world size. In future, you should adjust your compute this.")
-                # construct "dummy" sequences for padding out the world size
-                dummy_qr = torch.tensor([tokenizer.pad_token_id, tokenizer.eos_token_id], dtype=torch.long)
-                dummy_tool_mask = torch.zeros_like(dummy_qr)
-                dummy_attention = torch.tensor([1, 1], dtype=torch.long)
-                dummy_position_ids = torch.arange(len(dummy_qr), dtype=torch.long)
-                dummy_response_mask = torch.zeros_like(dummy_qr)
-                dummy_advantage = torch.zeros_like(dummy_qr, dtype=torch.float)
-                # pad out the world size
-                for _ in range(shortfall):
-                    packed_sequences.query_responses.append(dummy_qr)
-                    packed_sequences.tool_masks.append(dummy_tool_mask)
-                    packed_sequences.attention_masks.append(dummy_attention)
-                    packed_sequences.position_ids.append(dummy_position_ids)
-                    packed_sequences.response_masks.append(dummy_response_mask)
-                    packed_sequences.advantages.append(dummy_advantage)
+        if args.allow_world_padding:
+            with Timer("🤺 [Data Preparation Thread] Padding sequences for world size"):
+                shortfall = args.world_size - len(packed_sequences.query_responses)
+                if shortfall > 0:
+                    print(f"Padding {shortfall} sequences for world size. In future, you should adjust your compute this.")
+                    # construct "dummy" sequences for padding out the world size
+                    dummy_qr = torch.tensor([tokenizer.pad_token_id, tokenizer.eos_token_id], dtype=torch.long)
+                    dummy_tool_mask = torch.zeros_like(dummy_qr)
+                    dummy_attention = torch.tensor([1, 1], dtype=torch.long)
+                    dummy_position_ids = torch.arange(len(dummy_qr), dtype=torch.long)
+                    dummy_response_mask = torch.zeros_like(dummy_qr)
+                    dummy_advantage = torch.zeros_like(dummy_qr, dtype=torch.float)
+                    # pad out the world size
+                    for _ in range(shortfall):
+                        packed_sequences.query_responses.append(dummy_qr)
+                        packed_sequences.tool_masks.append(dummy_tool_mask)
+                        packed_sequences.attention_masks.append(dummy_attention)
+                        packed_sequences.position_ids.append(dummy_position_ids)
+                        packed_sequences.response_masks.append(dummy_response_mask)
+                        packed_sequences.advantages.append(dummy_advantage)
 
         with Timer("🔄 [Data Preparation Thread] Prepare collated data for each worker"):
             B = (

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1230,6 +1230,28 @@ def data_preparation_thread(
             ]
             packed_sequences.advantages = packed_advantages
 
+        # if we have less batches than world size, we need to pad out so each world is fine
+        # ideally, you should avoid this since its wasting computation.
+        with Timer("🤺 [Data Preparation Thread] Padding sequences for world size"):
+            shortfall = args.world_size - len(packed_sequences.query_responses)
+            if shortfall > 0:
+                print(f"Padding {shortfall} sequences for world size. In future, you should adjust your compute this.")
+                # construct "dummy" sequences for padding out the world size
+                dummy_qr = torch.tensor([tokenizer.pad_token_id, tokenizer.eos_token_id], dtype=torch.long)
+                dummy_tool_mask = torch.zeros_like(dummy_qr)
+                dummy_attention = torch.tensor([1, 1], dtype=torch.long)
+                dummy_position_ids = torch.arange(len(dummy_qr), dtype=torch.long)
+                dummy_response_mask = torch.zeros_like(dummy_qr)
+                dummy_advantage = torch.zeros_like(dummy_qr, dtype=torch.float)
+                # pad out the world size
+                for _ in range(shortfall):
+                    packed_sequences.query_responses.append(dummy_qr)
+                    packed_sequences.tool_masks.append(dummy_tool_mask)
+                    packed_sequences.attention_masks.append(dummy_attention)
+                    packed_sequences.position_ids.append(dummy_position_ids)
+                    packed_sequences.response_masks.append(dummy_response_mask)
+                    packed_sequences.advantages.append(dummy_advantage)
+
         with Timer("🔄 [Data Preparation Thread] Prepare collated data for each worker"):
             B = (
                 len(packed_sequences.query_responses) // args.world_size

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -121,6 +121,7 @@ parser.add_argument("--oe_eval_tasks", type=str, default=None, help="Evaluate OE
 parser.add_argument("--step", type=int, default=None, help="Step number for postgresql logging.")
 parser.add_argument("--run_id", type=str, default=None, help="A unique run ID for postgresql logging.")
 parser.add_argument("--oe_eval_stop_sequences", type=str, default=None, help="Comma-separated list of stop sequences for OE eval.")
+parser.add_argument("--process_output", type=str, default="r1_style", help="Process output type for OE eval (e.g., 'r1_style'). Defaults to 'r1_style', which should work for most of our models, including non-thinking ones.")
 args = parser.parse_args()
 
 
@@ -643,6 +644,10 @@ if args.run_oe_eval_experiments or args.oe_eval_unseen_evals:
     # Add stop sequences if provided
     if args.oe_eval_stop_sequences:
         oe_eval_cmd += f" --stop-sequences '{args.oe_eval_stop_sequences}'"
+        
+    # Add process output if provided
+    if args.process_output:
+        oe_eval_cmd += f" --process-output {args.process_output}"
         
     # Add beaker image from existing argument
     if args.beaker_image:


### PR DESCRIPTION
1. Remove thinking traces for IFEval and GSM8k from output.
2. Add 'world padding'. This will prevent the issue of not having enough data to run a gradient step after packing in some cases, at the cost of just wasting some compute. This is mainly useful if you want to run multiple models with similar hypers, and one model just isnt training. In other cases, if you see this happen on runs, you should really just increase the batch size or reduce packing length or similar.
3. Add process_output by default to our eval runs. This means the thinking trace is stripped from the output before being passed to the evaluation, which makes AlpacaEval/IFEval style evaluations actually make sense for thinking models (we shouldn't evaluate the thinking process, just the final actual answer).