### PR TITLE
Fix minor HF download bug.

### DIFF
--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -947,7 +947,22 @@ def live_subprocess_output(cmd: List[str]) -> str:
 def download_from_hf(model_name_or_path: str, revision: str) -> None:
     cmd = ["huggingface-cli", "download", model_name_or_path, "--revision", revision]
     print(f"Downloading from HF with command: {cmd}")
-    return live_subprocess_output(cmd)
+    output = live_subprocess_output(cmd)
+    # for some reason, sometimes the output includes the line including some loading message.
+    # so do some minor cleaning.
+    if "\n" in output:
+        output = output.split("\n")[-1].strip()
+    return output
+
+
+['gsutil', '-o', 'GSUtil:parallel_composite_upload_threshold=150M', 'cp', '-r', '/root/.cache/huggingface/hub/models--Qwen--Qwen3-8B/snapshots/9c925d64d72725edaf899c6cb9c377fd0709d9c5', 'gs://ai2-llm/post-training/deletable_cache_models/Qwen/Qwen3-8B/9c925d64d72725edaf899c6cb9c377fd0709d9c5']
+
+
+
+
+
+
+
 
 
 def download_from_gs_bucket(src_path: str, dest_path: str) -> None:


### PR DESCRIPTION
As reported by @ValentinaPy , sometimes the prior output from the hf download command gets captured, like so:
```
Fetching 14 files:  0%|     | 0/14 [00:00<?, ?it/s]\nFetching 14 files: 100%|██████████| 14/14 [00:00<00:00, 99357.46it/s]\n/root/.cache/huggingface/hub/models--Qwen--Qwen3-8B/snapshots/9c925d64d72725edaf899c6cb9c377fd0709d9c5
```
When really only
```
/root/.cache/huggingface/hub/models--Qwen--Qwen3-8B/snapshots/9c925d64d72725edaf899c6cb9c377fd0709d9c5
```
Should be captured. This is a minor patch to fix this by doing some little string cleaning.