### PR TITLE
add long-form rl-rag reward

### DIFF
--- a/open_instruct/search_rewards/README.md
+++ b/open_instruct/search_rewards/README.md
@@ -1,0 +1,265 @@
+# Search Rewards Module
+
+This module provides a comprehensive reward scoring system for evaluating responses to paper search queries. It uses a rubric-based approach with multiple scoring components to assess the quality of answers.
+
+## Overview
+
+The reward function evaluates responses based on several criteria including:
+- **Length appropriateness** - Optimal response length (300-600 words)
+- **Expertise level** - Alignment with expected user expertise
+- **Citations and excerpts** - Proper citation usage and supporting quotes
+- **Custom rubric properties** - Domain-specific evaluation criteria
+- **Evidence matching** - Presence of required supporting information
+
+## Input Format
+
+### Response Format
+The response must contain the answer wrapped in `<answer>` and `</answer>` tags:
+
+```xml
+<answer>
+Your detailed answer here with proper citations and supporting evidence.
+</answer>
+```
+
+### Test Case Format
+Each test case is a dictionary with the following structure:
+
+```python
+{
+    "metric_config": {
+        "name": "rubric_corpusqa_generic",
+        "config": {
+            "question": "The question being answered",
+            "low_length": 300,                    # Minimum optimal length
+            "high_length": 600,                   # Maximum optimal length
+            "length_weight": 0.05,                # Weight for length scoring
+            "expertise_weight": 0.05,             # Weight for expertise scoring
+            "citations_weight": 0.2,              # Weight for citation scoring
+            "excerpts_weight": 0.1,               # Weight for excerpt scoring
+            "model_name": "gpt-4-turbo",          # LLM for scoring
+            "other_properties": [                 # Custom rubric criteria
+                {
+                    "name": "criterion_name",
+                    "criterion": "Description of what to evaluate",
+                    "weight": 0.13333333333333333,
+                    "evidence": [                 # Required supporting evidence
+                        "Evidence snippet 1",
+                        "Evidence snippet 2"
+                    ]
+                }
+            ]
+        }
+    },
+    "case_id": "unique_identifier",
+    "annotator": "Annotator name",
+    "agreement": True
+}
+```
+
+## Output Format
+
+The reward function returns a dictionary with the following structure:
+
+```python
+{
+    "reward": 0.85,                    # Overall reward score (0-1)
+    "answer_extracted": "extracted answer text",
+    "extraction_success": True,        # Whether answer extraction succeeded
+    "scoring_results": {               # Detailed scoring breakdown
+        "score": 0.85,                 # Overall weighted score
+        "ann_score": 0.90,             # Annotation-only score (without static components)
+        "length": 0.95,                # Length appropriateness score
+        "expertise": 0.88,             # Expertise level score
+        "citations": 0.80,             # Citation usage score
+        "excerpts": 0.75,              # Excerpt quality score
+        "criterion_name": 0.92,        # Custom criterion scores
+        "criterion_name_evidence": 0.85 # Evidence matching scores
+    },
+    "error": None                      # Error message if any step failed
+}
+```
+
+## How It Works
+
+### 1. Answer Extraction
+The function first extracts the answer content from between `<answer>` and `</answer>` tags using regex pattern matching.
+
+### 2. Scoring Components
+
+#### Length Scoring
+- Scores response length relative to optimal range (300-600 words)
+- Perfect score for responses within the range
+- Penalty increases as length deviates from optimal range
+
+#### Expertise Scoring
+- Uses LLM to evaluate if response complexity matches expected user expertise
+- Based on the criterion: "The level of expertise required to understand the answer should be roughly aligned with the estimated expertise of a typical person who would ask the question."
+
+#### Citation and Excerpt Scoring
+- **Citations**: Evaluates what fraction of claims have associated citations
+- **Excerpts**: Evaluates what fraction of citations have supporting excerpts
+- Uses LLM to parse response and identify claims, citations, and excerpts
+
+#### Custom Rubric Properties
+- Each property has a criterion description and optional evidence list
+- LLM evaluates response against each criterion on a 0-10 scale
+- Evidence matching: LLM checks what fraction of required evidence snippets are present
+
+### 3. Weighted Scoring
+All component scores are combined using configurable weights that must sum to 1.0:
+- Static components: length, expertise, citations, excerpts
+- Dynamic components: custom rubric properties and evidence matching
+
+## Usage Examples
+
+### Single Response Evaluation
+```python
+from paper_rewards import compute_paper_reward
+
+response = """
+<answer>
+Type inference systems automatically deduce types for expressions in code.
+This approach provides static typing benefits without requiring explicit annotations.
+</answer>
+"""
+
+test_case = {
+    "metric_config": {
+        "config": {
+            "question": "What is type inference?",
+            "low_length": 300,
+            "high_length": 600,
+            "length_weight": 0.05,
+            "expertise_weight": 0.05,
+            "citations_weight": 0.2,
+            "excerpts_weight": 0.1,
+            "other_properties": []
+        }
+    }
+}
+
+result = compute_paper_reward(response, test_case)
+print(f"Reward: {result['reward']:.3f}")
+```
+
+### Batch Evaluation
+```python
+from paper_rewards import batch_compute_paper_rewards
+
+responses = [response1, response2, response3]
+test_cases = [test_case1, test_case2, test_case3]
+
+results = batch_compute_paper_rewards(responses, test_cases)
+for i, result in enumerate(results):
+    print(f"Response {i+1}: {result['reward']:.3f}")
+```
+
+## Running Tests
+
+### Prerequisites
+1. Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+2. Set up environment variables:
+```bash
+export OPENAI_API_KEY="your_openai_api_key"
+```
+
+### Running All Tests
+```bash
+# From the search_rewards directory
+python -m pytest tests/ -v
+```
+
+### Running Specific Test Files
+```bash
+# Test the main reward function
+python -m pytest tests/test_paper_rewards.py -v
+
+# Test utility functions
+python -m pytest tests/test_run_utils.py -v
+
+# Test scoring components
+python -m pytest tests/test_scoring.py -v
+```
+
+### Running Individual Test Functions
+```bash
+# Run specific test function
+python -m pytest tests/test_paper_rewards.py::test_reward_computation -v
+
+# Run with detailed output
+python -m pytest tests/test_paper_rewards.py -v -s
+```
+
+### Manual Testing
+You can also run the test files directly:
+```bash
+# Run the main test suite
+python tests/test_paper_rewards.py
+
+# Run utility tests
+python tests/test_run_utils.py
+```
+
+## Test Structure
+
+The test suite includes:
+
+- **`test_paper_rewards.py`**: Tests the main reward computation function
+  - `test_reward_computation()`: Tests normal reward calculation
+  - `test_error_handling()`: Tests error scenarios
+
+- **`test_run_utils.py`**: Tests utility functions
+  - `test_extract_json_from_response()`: Tests JSON extraction
+  - `test_run_chatopenai()`: Tests LLM API calls
+
+- **`test_scoring.py`**: Tests individual scoring components
+- **`test_answer.py`**: Tests answer extraction logic
+- **`test_case.py`**: Tests test case validation
+
+## Configuration
+
+### Model Configuration
+The scoring system uses LLMs for evaluation. Configure the model in the test case:
+```python
+"model_name": "gpt-4-turbo"  # or "gpt-3.5-turbo"
+```
+
+### Weight Configuration
+Adjust scoring weights based on your evaluation priorities:
+```python
+"length_weight": 0.05,        # How much to weight response length
+"expertise_weight": 0.05,     # How much to weight expertise matching
+"citations_weight": 0.2,      # How much to weight citation usage
+"excerpts_weight": 0.1,       # How much to weight excerpt quality
+```
+
+## Error Handling
+
+The reward function handles various error scenarios:
+- Missing `<answer>` tags in response
+- Invalid test case format
+- LLM API failures
+- JSON parsing errors
+
+All errors are captured in the `error` field of the result dictionary, and the function returns a default reward of 0.0 when errors occur.
+
+## Dependencies
+
+Key dependencies:
+- `litellm`: For LLM API calls
+- `pydantic`: For configuration validation
+- `jsonlines`: For file I/O operations
+- `pytest`: For testing framework
+
+## Contributing
+
+When adding new scoring components:
+1. Add the component to the `RubricCorpusQaGenericMetric` class
+2. Update the weight configuration in test cases
+3. Add corresponding tests
+4. Update this documentation

--- a/open_instruct/search_rewards/citation_rewards_utils.py
+++ b/open_instruct/search_rewards/citation_rewards_utils.py
@@ -1,0 +1,454 @@
+import re
+import asyncio
+from typing import Dict, List
+
+from run_utils import run_azure_openai
+
+
+citation_recall_has_citation_prompt = """You are an expert in evaluating text quality. You will receive a user's question about an uploaded document, a factual statement from an AI assistant's response based on that document, and a snippet from the document (since the document is too long to display in full). Your task is to carefully assess whether this statement is supported by the snippet. Please use the following scale to generate your rating:
+- [[Fully supported]] - Most information in the statement is supported by or extracted from the snippet. This applies only to cases where the statement and parts of the snippet are almost identical.
+- [[Partially supported]] - More than half of the content in the statement is supported by the snippet, but a small portion is either not mentioned or contradicts the snippet. For example, if the statement has two key points and the snippet supports only one of them, it should be considered [Partially supported].
+- [[No support]] - The statement is largely unrelated to the snippet, or most key points in the statement do not align with the content of the snippet.
+Ensure that you do not use any information or knowledge outside of the snippet when evaluating.
+Please provide the rating first, followed by the analysis, in the format "Rating: [[...]] Analysis: ...".
+
+<question>
+{question}
+</question>
+
+<statement>
+{statement}
+</statement>
+
+<snippet>
+{concatenated_cited_snippets}
+</snippet>"""
+
+
+citation_recall_no_citation_prompt = """You are an expert in evaluating text quality. You will receive a user's question regarding their uploaded document (due to the length of the document, it is not shown to you), an AI assistant's response based on the document, and a sentence from the response. Your task is to determine whether this sentence is a factual statement made based on the information in the document that requires citation, rather than an introductory sentence, transition sentence, or a summary, reasoning, or inference based on the previous response.
+Ensure that you do not use any other external information during your evaluation.
+Please first provide your judgment (answer with [[Yes]] or [[No]]), then provide your analysis in the format "Need Citation: [[Yes/No]] Analysis: ...".
+
+<question>
+{question}
+</question>
+
+<response>
+{full_response}
+</response>
+
+<statement>
+{statement}
+</statement>"""
+
+
+citation_precision_prompt = """You are an expert in evaluating text quality. You will receive a user's question about an uploaded document, a factual statement from an AI assistant's response based on that document, and a snippet from the document (since the document is too long to display in full). Your task is to carefully assess whether the snippet contains some key information of the statement. Please use the following grades to generate the rating:
+- [[Relevant]] - Some key points of the statement are supported by the snippet or extracted from it.
+- [[Unrelevant]] - The statement is almost unrelated to the snippet, or all key points of the statement are inconsistent with the snippet content.
+Ensure that you do not use any information or knowledge outside of the snippet when evaluating.
+Please provide the rating first, followed by the analysis, in the format "Rating: [[...]] Analysis: ...".
+
+<question>
+{question}
+</question>
+
+<statement>
+{statement}
+</statement>
+
+<snippet>
+{concatenated_cited_snippets}
+</snippet>"""
+
+
+
+def score_in_context_citations(question: str, response: str, citations: Dict[str, str]) -> Dict[str, float]:
+    """
+    Compute the cumulative weighted score for a system response such that the final score is between 0 and 1.
+    :param response:
+    :param citations:
+    :return: final weighted score with and without the static components
+    """
+    
+    def extract_claims_and_corresponding_citation_ids(response: str) -> Dict[str, str]:
+        """
+        Example response:
+        "The Great Wall of China, one of the most iconic structures in human history, stretches approximately 13,000 miles across northern China. <cite id=a1b2c3d4>Construction of the Great Wall began during the 7th century BC under various warring states, but the most famous sections were built during the Ming Dynasty (1368-1644).</cite> The wall was primarily constructed as a defensive fortification to protect Chinese states from invasions by nomadic groups from the north. <cite id=e5f6g7h8>The wall incorporates various materials including stone, brick, tamped earth, wood, and other materials, with different sections built using locally available resources.</cite> Contrary to popular belief, <cite id=i9j0k1l2>the Great Wall is not visible from space with the naked eye, a myth that has been debunked by astronauts and satellite imagery.</cite>"
+        """
+        claims = {}
+        
+        # Split the response by cite tags to separate cited and non-cited text
+        cite_pattern = r'<cite id=([^>]+)>([^<]+)</cite>'
+        parts = re.split(cite_pattern, response)
+        
+        for i in range(0, len(parts), 3):
+            # Non-cited text (before cite tag)
+            if i < len(parts) and parts[i].strip():
+                non_cited_text = parts[i].strip()
+                if non_cited_text:
+                    claims[non_cited_text] = []
+            
+            # Cited text (inside cite tag)
+            if i + 1 < len(parts) and i + 2 < len(parts):
+                citation_id = parts[i + 1]
+                cited_text = parts[i + 2].strip()
+                if cited_text:
+                    claims[cited_text] = [citation_id]
+        
+        return claims
+    
+    def concatenate_citations(citation_ids: List[str], citations: Dict[str, str]) -> str:
+        if len(citation_ids) == 0:
+            return ""
+        return "\n\n".join([citations[citation_id] for citation_id in citation_ids])
+    
+    claims = extract_claims_and_corresponding_citation_ids(response)
+    
+    citation_format_reward = score_citation_format(claims, citations)
+    
+    avg_f1 = 0
+    for claim_text, citation_ids in claims.items():
+        concatenated_citations = concatenate_citations(citation_ids, citations)
+        avg_f1 += score_citation_f1(question, claim_text, concatenated_citations, response)
+    avg_f1 /= len(claims)
+    
+    return 0.99 * avg_f1 + 0.01 * citation_format_reward
+
+
+def score_citation_format(claims: Dict[str, List[str]], citations: Dict[str, str]) -> Dict[str, float]:
+    """
+    Check if the model has hallucinated citations.
+    """
+    all_citations = []
+    for claim in claims.items():
+        all_citations.extend(claim[1])
+    all_citations = list(set(all_citations))
+    if len(all_citations) == 0:
+        return 1
+    valid_citations = [citation for citation in all_citations if citation in citations]
+    return len(valid_citations) / len(all_citations)
+
+
+def score_citation_f1(question: str, claim: str, concatenated_citations: str, full_response: str) -> float:
+    recall = score_citation_recall(question, claim, concatenated_citations, full_response)
+    precision = score_citation_precision(question, claim, concatenated_citations)
+    f1 = 2 * (recall * precision) / (recall + precision)
+    return f1
+
+
+def score_citation_recall(question: str, claim: str, concatenated_citations: str, full_response: str) -> float:
+    if len(concatenated_citations) == 0:
+        return score_no_citation_recall(question, claim, full_response)
+    else:
+        return score_with_citation_recall(question, claim, concatenated_citations)
+
+
+def score_with_citation_recall(question: str, claim: str, concatenated_citations: str) -> float:
+    user_prompt = citation_recall_has_citation_prompt.format(question=question, statement=claim, concatenated_cited_snippets=concatenated_citations)
+    response = run_llm_judge(user_prompt)
+    return extract_recall_rating_from_response(response)
+
+
+def score_no_citation_recall(question: str, claim: str, full_response: str) -> float:
+    user_prompt = citation_recall_no_citation_prompt.format(question=question, statement=claim, full_response=full_response)
+    response = run_llm_judge(user_prompt)
+    return extract_yes_no_from_response(response)
+
+
+def score_citation_precision(question: str, claim: str, concatenated_citations: str) -> float:
+    if len(concatenated_citations) == 0:
+        return 1
+    user_prompt = citation_precision_prompt.format(question=question, statement=claim, concatenated_cited_snippets=concatenated_citations)
+    response = run_llm_judge(user_prompt)
+    return extract_relevant_rating_from_response(response)
+
+
+def extract_recall_rating_from_response(response: str) -> float:
+    rating = re.search(r'Rating: \[\[(.*)\]\]', response)
+    if rating:
+        extracted_text = rating.group(1).strip().lower()
+        if extracted_text == "fully supported":
+            return 1.0
+        elif extracted_text == "partially supported":
+            return 0.5
+        elif extracted_text == "no support":
+            return 0.0
+        else:
+            # If the extracted text doesn't match any expected values, return 0 as default
+            return 0.0
+    else:
+        return 0.0
+
+
+def extract_yes_no_from_response(response: str) -> int:
+    yes_no = re.search(r'Need Citation: \[\[(.*)\]\]', response)
+    if yes_no:
+        extracted_text = yes_no.group(1).strip().lower()
+        if extracted_text == "yes":
+            return 1
+        elif extracted_text == "no":
+            return 0
+        else:
+            # If the extracted text is neither "yes" nor "no", return 0 as default
+            return 0
+    else:
+        return 0
+
+
+def extract_relevant_rating_from_response(response: str) -> int:
+    rating = re.search(r'Rating: \[\[(.*)\]\]', response)
+    if rating:
+        extracted_text = rating.group(1).strip().lower()
+        if extracted_text == "relevant":
+            return 1
+        elif extracted_text == "unrelevant":
+            return 0
+        else:
+            # If the extracted text is neither "relevant" nor "unrelevant", return 0 as default
+            return 0
+    else:
+        return 0
+
+
+def run_llm_judge(user_prompt: str, model_name: str="gpt-4.5-preview", deployment: str="gpt-4.5-preview-standard") -> str:
+    response = run_azure_openai(
+        model_name,
+        None,
+        user_prompt=user_prompt,
+        deployment=deployment,
+        max_completion_tokens=800,
+        top_p=1.0,
+        frequency_penalty=0.0,
+        presence_penalty=0.0)
+    return response
+
+
+
+async def run_llm_judge_async(user_prompt: str, model_name: str="gpt-4.5-preview", deployment: str="gpt-4.5-preview-standard") -> str:
+    # For now, we'll use the sync version in a thread pool to avoid blocking
+    # In the future, you might want to implement a proper async Azure OpenAI client
+    loop = asyncio.get_event_loop()
+    response = await loop.run_in_executor(
+        None, 
+        lambda: run_azure_openai(
+            model_name,
+            None,
+            user_prompt=user_prompt,
+            deployment=deployment,
+            max_completion_tokens=800,
+            top_p=1.0,
+            frequency_penalty=0.0,
+            presence_penalty=0.0
+        )
+    )
+    return response
+
+
+async def score_citation_f1_async(question: str, claim: str, concatenated_citations: str, full_response: str) -> float:
+    # Run recall and precision calculations in parallel
+    if len(concatenated_citations) == 0:
+        recall_task = score_no_citation_recall_async(question, claim, full_response)
+        precision_task = asyncio.create_task(asyncio.sleep(0))  # Precision is 1 for empty citations
+        recall, precision = await asyncio.gather(recall_task, precision_task)
+        precision = 1.0  # Set precision to 1 for empty citations
+    else:
+        recall_task = score_with_citation_recall_async(question, claim, concatenated_citations)
+        precision_task = score_citation_precision_async(question, claim, concatenated_citations)
+        recall, precision = await asyncio.gather(recall_task, precision_task)
+    
+    f1 = 2 * (recall * precision) / (recall + precision) if (recall + precision) > 0 else 0
+    return f1
+
+
+async def score_with_citation_recall_async(question: str, claim: str, concatenated_citations: str) -> float:
+    user_prompt = citation_recall_has_citation_prompt.format(question=question, statement=claim, concatenated_cited_snippets=concatenated_citations)
+    response = await run_llm_judge_async(user_prompt)
+    return extract_recall_rating_from_response(response)
+
+
+async def score_no_citation_recall_async(question: str, claim: str, full_response: str) -> float:
+    user_prompt = citation_recall_no_citation_prompt.format(question=question, statement=claim, full_response=full_response)
+    response = await run_llm_judge_async(user_prompt)
+    return extract_yes_no_from_response(response)
+
+
+async def score_citation_precision_async(question: str, claim: str, concatenated_citations: str) -> float:
+    if len(concatenated_citations) == 0:
+        return 1
+    user_prompt = citation_precision_prompt.format(question=question, statement=claim, concatenated_cited_snippets=concatenated_citations)
+    response = await run_llm_judge_async(user_prompt)
+    return extract_relevant_rating_from_response(response)
+
+
+async def score_in_context_citations_async(question: str, response: str, citations: Dict[str, str]) -> Dict[str, float]:
+    """
+    Async version of score_in_context_citations that runs LLM calls in parallel.
+    """
+    
+    def extract_claims_and_corresponding_citation_ids(response: str) -> Dict[str, str]:
+        """
+        Example response:
+        "The Great Wall of China, one of the most iconic structures in human history, stretches approximately 13,000 miles across northern China. <cite id=a1b2c3d4>Construction of the Great Wall began during the 7th century BC under various warring states, but the most famous sections were built during the Ming Dynasty (1368-1644).</cite> The wall was primarily constructed as a defensive fortification to protect Chinese states from invasions by nomadic groups from the north. <cite id=e5f6g7h8>The wall incorporates various materials including stone, brick, tamped earth, wood, and other materials, with different sections built using locally available resources.</cite> Contrary to popular belief, <cite id=i9j0k1l2>the Great Wall is not visible from space with the naked eye, a myth that has been debunked by astronauts and satellite imagery.</cite>"
+        """
+        claims = {}
+        
+        # Split the response by cite tags to separate cited and non-cited text
+        cite_pattern = r'<cite id=([^>]+)>([^<]+)</cite>'
+        parts = re.split(cite_pattern, response)
+        
+        for i in range(0, len(parts), 3):
+            # Non-cited text (before cite tag)
+            if i < len(parts) and parts[i].strip():
+                non_cited_text = parts[i].strip()
+                if non_cited_text:
+                    claims[non_cited_text] = []
+            
+            # Cited text (inside cite tag)
+            if i + 1 < len(parts) and i + 2 < len(parts):
+                citation_id = parts[i + 1]
+                cited_text = parts[i + 2].strip()
+                if cited_text:
+                    claims[cited_text] = [citation_id]
+        
+        return claims
+    
+    def concatenate_citations(citation_ids: List[str], citations: Dict[str, str]) -> str:
+        if len(citation_ids) == 0:
+            return ""
+        return "\n\n".join([citations[citation_id] for citation_id in citation_ids])
+    
+    claims = extract_claims_and_corresponding_citation_ids(response)
+    
+    citation_format_reward = score_citation_format(claims, citations)
+    
+    # Create tasks for all F1 calculations to run in parallel
+    f1_tasks = []
+    for claim_text, citation_ids in claims.items():
+        concatenated_citations = concatenate_citations(citation_ids, citations)
+        task = score_citation_f1_async(question, claim_text, concatenated_citations, response)
+        f1_tasks.append(task)
+    
+    # Wait for all F1 calculations to complete
+    f1_scores = await asyncio.gather(*f1_tasks)
+    
+    # Calculate average F1 score
+    avg_f1 = sum(f1_scores) / len(f1_scores) if f1_scores else 0
+    
+    return 0.99 * avg_f1 + 0.01 * citation_format_reward
+
+
+def score_in_context_citations_async_wrapper(question: str, response: str, citations: Dict[str, str]) -> Dict[str, float]:
+    """
+    Synchronous wrapper for the async scoring function.
+    Use this when you want to run the async version from synchronous code.
+    """
+    return asyncio.run(score_in_context_citations_async(question, response, citations))
+
+
+if __name__ == "__main__":
+    # Simple test case for citation scoring functions
+    example_response = "The Great Wall of China, one of the most iconic structures in human history, stretches approximately 13,000 miles across northern China. <cite id=a1b2c3d4>Construction of the Great Wall began during the 7th century BC under various warring states, but the most famous sections were built during the Ming Dynasty (1368-1644).</cite> The wall was primarily constructed as a defensive fortification to protect Chinese states from invasions by nomadic groups from the north. <cite id=e5f6g7h8>The wall incorporates various materials including stone, brick, tamped earth, wood, and other materials, with different sections built using locally available resources.</cite> Contrary to popular belief, <cite id=i9j0k1l2>the Great Wall is not visible from space with the naked eye, a myth that has been debunked by astronauts and satellite imagery.</cite>"
+    
+    # Create a simple test citations dictionary
+    test_citations = {
+        "a1b2c3d4": "The Great Wall of China is a series of fortifications built across the historical northern borders of ancient Chinese states. While walls were built as early as the 7th century BC by various warring states, the most famous sections of the wall were constructed during the Ming Dynasty between 1368 and 1644.",
+        "e5f6g7h8": "The Great Wall was constructed using a variety of materials depending on the local terrain and available resources. In mountainous areas, stone was the primary material, while in desert regions, tamped earth and sand were used.",
+        "i9j0k1l2": "The claim that the Great Wall of China is visible from space with the naked eye is a widespread myth that has been repeatedly debunked. NASA and various astronauts have confirmed that the Great Wall is not visible to the naked eye from low Earth orbit without aid."
+    }
+    
+    test_question = "What is the history and construction of the Great Wall of China?"
+    
+    # Test the original synchronous scoring function
+    print("Testing synchronous version...")
+    score_sync = score_in_context_citations(test_question, example_response, test_citations)
+    print(f"Synchronous citation score: {score_sync}")
+    
+    # Test the async scoring function
+    print("\nTesting async version...")
+    score_async = score_in_context_citations_async_wrapper(test_question, example_response, test_citations)
+    print(f"Async citation score: {score_async}")
+    
+    print("\nTest completed successfully!")
+
+
+async def test_async_scoring():
+    """Test the async scoring function in an async context"""
+    example_response = "The Great Wall of China, one of the most iconic structures in human history, stretches approximately 13,000 miles across northern China. <cite id=a1b2c3d4>Construction of the Great Wall began during the 7th century BC under various warring states, but the most famous sections were built during the Ming Dynasty (1368-1644).</cite>"
+    
+    test_citations = {
+        "a1b2c3d4": "The Great Wall of China is a series of fortifications built across the historical northern borders of ancient Chinese states. While walls were built as early as the 7th century BC by various warring states, the most famous sections of the wall were constructed during the Ming Dynasty between 1368 and 1644.",
+    }
+    
+    test_question = "What is the history and construction of the Great Wall of China?"
+    
+    print("Testing async version in async context...")
+    score = await score_in_context_citations_async(test_question, example_response, test_citations)
+    print(f"Async citation score: {score}")
+    print("Async test completed successfully!")
+
+
+# Uncomment the line below to run the async test
+# asyncio.run(test_async_scoring())
+
+
+def example_usage():
+    """
+    Example showing how to use both synchronous and asynchronous versions
+    of the citation scoring functions.
+    """
+    print("=== Citation Scoring Example ===\n")
+    
+    # Example data
+    question = "What are the health benefits of exercise?"
+    response = "Regular exercise has numerous health benefits. <cite id=ref1>Exercise can reduce the risk of heart disease by up to 30%.</cite> Additionally, <cite id=ref2>physical activity helps maintain healthy body weight and improves mental health.</cite>"
+    
+    citations = {
+        "ref1": "Studies have shown that regular physical activity can reduce the risk of cardiovascular disease by approximately 30% when compared to sedentary lifestyles.",
+        "ref2": "Exercise plays a crucial role in weight management and has been linked to improved mental health outcomes, including reduced symptoms of depression and anxiety."
+    }
+    
+    print("Question:", question)
+    print("Response:", response)
+    print("Citations:", citations)
+    print("\n" + "="*50 + "\n")
+    
+    # Synchronous version (original)
+    print("1. Using synchronous version (sequential API calls):")
+    import time
+    start_time = time.time()
+    score_sync = score_in_context_citations(question, response, citations)
+    sync_time = time.time() - start_time
+    print(f"   Score: {score_sync:.4f}")
+    print(f"   Time: {sync_time:.2f} seconds")
+    
+    print("\n2. Using asynchronous version (parallel API calls):")
+    start_time = time.time()
+    score_async = score_in_context_citations_async_wrapper(question, response, citations)
+    async_time = time.time() - start_time
+    print(f"   Score: {score_async:.4f}")
+    print(f"   Time: {async_time:.2f} seconds")
+    
+    if async_time < sync_time:
+        speedup = sync_time / async_time
+        print(f"   Speedup: {speedup:.2f}x faster")
+    else:
+        print("   Note: Async version may be slower for single examples due to overhead")
+    
+    print("\n3. Using async version in async context:")
+    async def demo_async():
+        start_time = time.time()
+        score = await score_in_context_citations_async(question, response, citations)
+        async_time = time.time() - start_time
+        print(f"   Score: {score:.4f}")
+        print(f"   Time: {async_time:.2f} seconds")
+    
+    # Run the async demo
+    asyncio.run(demo_async())
+    
+    print("\n" + "="*50)
+    print("Note: The async version is most beneficial when processing multiple examples")
+    print("or when you have multiple claims that need to be evaluated simultaneously.")
+
+
+# Uncomment the line below to run the example
+example_usage() 

--- a/open_instruct/search_rewards/global_rewards_utils.py
+++ b/open_instruct/search_rewards/global_rewards_utils.py
@@ -1,0 +1,216 @@
+import itertools
+import logging
+from typing import Any, Dict, List
+
+from pydantic.v1 import BaseModel, Field
+
+from run_utils import extract_json_from_response
+from citation_rewards_utils import score_in_context_citations, run_llm_judge
+
+LOGGER = logging.getLogger(__name__)
+
+
+class CorpusQaRubricPropertyConfig(BaseModel):
+    name: str
+    criterion: str
+    weight: float
+    evidence: List[str] = Field(default_factory=list)
+
+
+class CorpusQaRubricConfig(BaseModel):
+    question: str
+    low_length: int = 300
+    high_length: int = 600
+    length_weight: float = 0.05
+    expertise_weight: float = 0.05
+    citations_weight: float = 0 #0.2
+    excerpts_weight: float = 0 #0.1
+    other_properties: List[CorpusQaRubricPropertyConfig] = Field(default_factory=list)
+    model_name: str = "gpt-4-turbo"
+
+
+class RubricCorpusQaGenericMetric:
+    def __init__(self, config: Dict[str, Any]):
+        self.config = CorpusQaRubricConfig.parse_obj(config)
+
+    def _score_length(self, response: str, low_length, high_length) -> float:
+        """
+        Score the length of the response. The score is 1 if the length is up to low_length, and decreases
+        with further increase in length, reaching 0 at high_length or more.
+        :param response: the response to be scored
+        :param low_length: defaults to 300
+        :param high_length: default to 600
+        :return: score between 0 and 1 after deducting the penalty for length
+        """
+        word_count = len(response.split())
+        return 1 - (
+                (max(min(high_length, word_count), low_length) - low_length)
+                / (high_length - low_length)
+        )
+
+    def _score_property(self, response: str, question: str, prop: str) -> float:
+        """
+        Score the response as per the annotation rubric/criterion represented here by ``prop``.
+        The score is calculated by asking an LLM to judge the response for satisfaction of the rubric/criterion
+        on a scale of 0-10.
+        :param response: the response to be scored
+        :param question: the question for which the response is being scored
+        :param prop: the rubric/criterion to be satisfied
+        :return: score between 0 and 1 after normalizing the LLM score
+        """
+        system_prompt = """You will be given a question someone asked (in <question></question> tags) and the corresponding response (in <response></response> tags) given to them by an assistant.  You will then be given a specific criterion of the response to evaluate (in <criterion></criterion> tags).
+Return a score on a scale of 0 to 10 indicating how appropriate the response is based on the given criterion.  Judge only the specified aspect(s), not any other qualities of the answer.  Output JSON in the format: {{"score": x}}."""
+        user_prompt = f"""<question>{question}</question>\n<response>{response}</response>\n<criterion>{prop}</criterion>"""
+        
+        resp = run_llm_judge(
+            f"{system_prompt}\n\n{user_prompt}",
+            self.config.model_name,
+        )
+
+        obj = extract_json_from_response(resp)
+        if not obj:
+            return 0.0
+
+        return obj["score"] / 10.0
+
+    def _score_evidence(self, response: str, evidence: List[str]) -> float:
+        """
+        Score the response based on the snippets provided as supporting quotes with the rubric.
+        The score is the fraction of the snippets that are present in the response, as detected by an LLM.
+        :param response: the response to be scored
+        :param evidence: the list of supporting snippets
+        :return: normalized count of snippets present in the response
+        """
+        snippets = "\n".join(f"{i + 1}. {x}" for i, x in enumerate(evidence))
+        system_prompt = f"""You are given the response given by a scientific assistant to a user query enclosed in <response></response> tags.
+              In addition you are also given a list of snippets numbered from 1 to {len(evidence)} enclosed in <snippets></snippets> tags, which should be present in the true answer. 
+              Your job is to count how many snippets out of the given list are relevant to the provided response. 
+              A snippet is relevant if the information provided by it is partly or completely present in the response. Count every snippet only once. 
+              Output JSON with the count as a number in the format: {{"score": x}}."""
+        user_prompt = f"""<response>{response}</response>\n<snippets>{snippets}</snippets>"""
+        
+        resp = run_llm_judge(
+            f"{system_prompt}\n\n{user_prompt}",
+            self.config.model_name,
+        )
+
+        obj = extract_json_from_response(resp)
+        if not obj:
+            return 0.0
+        return min(obj["score"] / len(evidence), 1.0)
+
+    def _score_citations_excerpts(self, response: str) -> Dict[str, float]:
+
+        try:
+            score_components = self._score_citations_excerpts_inner(response)
+        except (KeyError, TypeError) as e:
+            LOGGER.warning(f"Could not extract citations and excerpts: {e}")
+            score_components = {"citations": 0.0, "excerpts": 0.0}
+
+        return score_components
+
+    def _score_in_context_citations_excerpts(self, response: str, citations: Dict[str, str]) -> Dict[str, float]:
+        """
+        Score the response for presence of citations and associated excerpts.
+        The response is split into claims with associated citations and excerpts by an LLM.
+        The score is calculated as the fraction of claims that have an associated citation and the fraction of citations
+        that have an associated excerpt.
+        """
+        return score_in_context_citations(self.config.question, response, citations)
+        
+
+    def _score_citations_excerpts_inner(self, response: str) -> Dict[str, float]:
+        """
+        Score the response for presence of citations and associated excerpts.
+        The response is split into claims with associated citations and excerpts by an LLM.
+        The score is calculated as the fraction of claims that have an associated citation and the fraction of citations
+        that have an associated excerpt.
+        :param response:
+        :return: dict of scores for citations per claim and excerpts per citation
+        """
+        system_prompt = "You are a helpful assistant."
+        user_prompt = f"""Here is a response to a question that includes several claims and citations:
+Response: {response}
+
+Split the response into individual claims, citations, and excerpts from the citations, in JSON format: {{"claims": [{{"claim_text": "...", "citations": [{{"citation_text": "...", "excerpts": ["...", ...]}}, ...]}}, ...]}}
+
+If a claim is missing citations or a citation is not accompanied by excerpts, some lists may be empty in your output."""
+        
+        resp = run_llm_judge(
+            f"{system_prompt}\n\n{user_prompt}",
+            self.config.model_name,
+        )
+
+        extracted_json = extract_json_from_response(resp)
+        if not extracted_json:
+            return {"citations": 0.0, "excerpts": 0.0}
+        citation_score = sum(
+            1 for claim in extracted_json["claims"] if claim["citations"]
+        ) / max(len(extracted_json["claims"]), 1)
+
+        all_citations = list(
+            itertools.chain.from_iterable(
+                claim["citations"] for claim in extracted_json["claims"]
+            )
+        )
+        excerpt_score = sum(
+            1 for citation in all_citations if citation["excerpts"]
+        ) / max(len(all_citations), 1)
+
+        return {"citations": citation_score, "excerpts": excerpt_score}
+
+    def score_output(self, response: str, citations: Dict[str, str] = None) -> Dict[str, Any]:
+        """
+        Compute the cumulative weighted score for a system response such that the final score is between 0 and 1.
+        :param response:
+        :param citations:
+        :return: final weighted score with and without the static components
+        """
+        score_weights = {
+            "length": self.config.length_weight,
+            "expertise": self.config.expertise_weight,
+            "citations": self.config.citations_weight,
+            "excerpts": self.config.excerpts_weight,
+        }
+        score_weights.update(
+            {x.name: x.weight / (2.0 if x.evidence else 1.0) for x in self.config.other_properties if x.criterion})
+        score_weights.update(
+            {f"{x.name}_evidence": x.weight / (2.0 if x.criterion else 1.0) for x in self.config.other_properties if
+             x.evidence})
+        assert abs(sum(score_weights.values()) - 1.0) < 1e-6
+
+        score_components = dict()
+
+        score_components["length"] = self._score_length(
+            response,
+            low_length=self.config.low_length,
+            high_length=self.config.high_length,
+        )
+        score_components["expertise"] = self._score_property(
+            response,
+            self.config.question,
+            "The level of expertise required to understand the answer should be roughly aligned with the estimated expertise of a typical person who would ask the question.",
+        )
+        if citations:
+            score_components.update(self._score_in_context_citations_excerpts(response, citations))
+        else:
+            # TODO: only when ground-truth evidence is provided, use this.
+            score_components.update(self._score_citations_excerpts(response))
+
+        for x in self.config.other_properties:
+            if x.criterion:
+                score_components[x.name] = self._score_property(
+                    response, self.config.question, x.criterion
+                )
+            if x.evidence:
+                score_components[f"{x.name}_evidence"] = self._score_evidence(
+                    response, x.evidence) if not x.criterion or score_components.get(x.name) else 0.0
+
+        assert set(score_components.keys()) == set(score_weights.keys())
+        score = sum(score_weights[key] * score_components[key] for key in score_weights)
+        static_score_keys = {"length", "expertise", "citations", "excerpts"}
+        # Annotation rubrics are 60% of the total score, so divide by 0.6 to get score out of 1 without the static components
+        ann_score = sum(
+            score_weights[key] * score_components[key] for key in score_weights if key not in static_score_keys) / 0.6
+        return {"score": score, "ann_score": ann_score, **score_components}
+    

--- a/open_instruct/search_rewards/long_form_rewards.py
+++ b/open_instruct/search_rewards/long_form_rewards.py
@@ -1,0 +1,178 @@
+"""
+Output format design.
+
+Paper search related outputs:
+- Use <S2>pes2o_id</S2> to include the search results from S2 search.
+
+Example:
+
+
+"""
+
+import re
+import logging
+import hashlib
+import uuid
+from typing import Dict, Any, Optional
+
+from open_instruct.search_rewards.global_rewards_utils import RubricCorpusQaGenericMetric
+
+LOGGER = logging.getLogger(__name__)
+
+
+def generate_snippet_id() -> str:
+    """
+    Generate a unique random ID for snippets.
+    Should be used when inserting snippets into the context.
+    
+    Returns:
+        A unique string ID in format: '<hash>'
+    """
+    # Generate a random UUID and create a shorter hash
+    random_uuid = str(uuid.uuid4())
+    hash_object = hashlib.md5(random_uuid.encode())
+    short_hash = hash_object.hexdigest()[:8]  # Take first 8 characters
+    return f"{short_hash}"
+
+
+def extract_citations_from_context(context: str) -> Dict[str, str]:
+    """
+    Extract citations from the context.
+    
+    Citations are expected to be in the format:
+    <snippets id="a1b2c3d4" metadata='{"author": "smith", "source": "arxiv", "year": 2023}'>
+        Search result content here
+    </snippets>
+    
+    The id can be any string, including hash-like IDs (e.g., a1b2c3d4)
+    
+    Args:
+        context: The context string containing citations
+        
+    Returns:
+        Dictionary mapping id to search results content for all found citations
+    """
+    citations = {}
+    
+    # Pattern to match <snippets id="xxx" ...> content </snippets>
+    # Updated to handle quoted attributes in HTML-like format
+    pattern = r'<snippets\s+id=(["\'])([^"\']+)\1[^>]*>(.*?)</snippets>'
+    
+    matches = re.findall(pattern, context, re.DOTALL)
+    
+    for quote_char, snippet_id, search_results in matches:
+        # Clean up the id and search results (remove extra whitespace)
+        clean_id = snippet_id.strip()
+        clean_search_results = search_results.strip()
+        citations[clean_id] = clean_search_results
+    
+    return citations
+
+
+def compute_paper_reward(response: str, test_case: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Compute a reward score for a response based on a test case.
+    
+    This function:
+    1. Extracts citations from the context (content before <answer> tag)
+    2. Extracts the final answer from the response (content between <answer> and </answer> tags)
+    3. Applies the scoring function from paper_rubrics_utils.py using the test case configuration
+    
+    Args:
+        response: The full response text containing the answer
+        test_case: A test case dictionary containing metric configuration
+        
+    Returns:
+        Dictionary containing:
+        - 'reward': The computed reward score (0-1)
+        - 'citations': Dictionary mapping citation identifiers to text
+        - 'answer_extracted': The extracted answer text
+        - 'extraction_success': Boolean indicating if answer extraction was successful
+        - 'scoring_results': Full scoring results from the rubric metric
+        - 'error': Error message if any step failed
+    """
+    result = {
+        'reward': 0.0,
+        'citations': {},
+        'answer_extracted': None,
+        'extraction_success': False,
+        'scoring_results': None,
+        'error': None
+    }
+    
+    try:
+        # Step 1: Extract citations from the context (content before <answer> tag)
+        answer_pattern = r'<answer>'
+        answer_match = re.search(answer_pattern, response)
+        
+        if answer_match:
+            context_text = response[:answer_match.start()].strip()
+            extracted_citations = extract_citations_from_context(context_text)
+            result['citations'] = extracted_citations
+        else:
+            # If no <answer> tag found, extract citations from entire response
+            extracted_citations = extract_citations_from_context(response)
+            result['citations'] = extracted_citations
+        
+        # Step 2: Extract the answer from the response
+        # Pattern to match content between <answer> and </answer> tags
+        pattern = r'<answer>(.*?)</answer>'
+        match = re.search(pattern, response, re.DOTALL)
+        
+        if not match:
+            result['error'] = "Failed to extract answer from response - no <answer></answer> tags found"
+            LOGGER.warning("No <answer></answer> tags found in response")
+            return result
+        
+        extracted_answer = match.group(1).strip()
+        result['answer_extracted'] = extracted_answer
+        result['extraction_success'] = True
+        
+        # Step 3: Get the metric configuration from the test case
+        if 'metric_config' not in test_case or 'config' not in test_case['metric_config']:
+            result['error'] = "Invalid test case format - missing metric_config.config"
+            return result
+        
+        metric_config = test_case['metric_config']['config']
+        
+        # Step 4: Initialize the scoring metric
+        metric = RubricCorpusQaGenericMetric(metric_config)
+        
+        # Step 5: Apply the scoring function
+        scoring_results = metric.score_output(extracted_answer, extracted_citations)
+        
+        result['scoring_results'] = scoring_results
+        result['reward'] = scoring_results['score']  # Use the overall score as reward
+        
+        LOGGER.info(f"Successfully computed reward: {result['reward']:.4f}")
+        
+    except Exception as e:
+        import traceback
+        error_msg = f"Error computing reward: {str(e)}"
+        LOGGER.error(error_msg)
+        LOGGER.error(f"Full traceback: {traceback.format_exc()}")
+        result['error'] = error_msg
+    
+    return result
+
+
+def batch_compute_paper_rewards(responses: list, test_cases: list) -> list:
+    """
+    Compute rewards for multiple responses and test cases.
+    
+    Args:
+        responses: List of response strings
+        test_cases: List of test case dictionaries
+        
+    Returns:
+        List of reward result dictionaries
+    """
+    if len(responses) != len(test_cases):
+        raise ValueError("Number of responses must match number of test cases")
+    
+    results = []
+    for response, test_case in zip(responses, test_cases):
+        result = compute_paper_reward(response, test_case)
+        results.append(result)
+    
+    return results

--- a/open_instruct/search_rewards/run_utils.py
+++ b/open_instruct/search_rewards/run_utils.py
@@ -1,0 +1,189 @@
+import json
+import jsonlines
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import litellm
+from openai import AzureOpenAI
+
+LOGGER = logging.getLogger(__name__)
+
+
+def extract_json_from_response(response: str) -> Optional[Dict[str, Any]]:
+    json_start = response.find("{")
+    json_end = response.rfind("}") + 1
+    if json_start == -1 or json_end == -1:
+        return None
+
+    try:
+        return json.loads(response[json_start:json_end])
+    except json.JSONDecodeError:
+        try:
+            return json.loads(response[json_start:json_end]+"]}")
+        except json.JSONDecodeError:
+            LOGGER.warning(
+                f"Could not decode JSON from response: {response[json_start:json_end]}"
+            )
+        return None
+
+
+def run_chatopenai(
+    model_name: str,
+    system_prompt: Optional[str],
+    user_prompt: str,
+    json_mode: bool = False,
+    **chat_kwargs,
+) -> str:
+    chat_kwargs["temperature"] = chat_kwargs.get("temperature", 0)
+    if json_mode:
+        chat_kwargs["response_format"] = {"type": "json_object"}
+    msgs = (
+        [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+        if system_prompt is not None
+        else [{"role": "user", "content": user_prompt}]
+    )
+    resp = litellm.completion(
+        model=model_name,
+        messages=msgs,
+        **chat_kwargs,
+    )
+
+    return resp.choices[0].message.content
+
+def load_jsonlines(file):
+    with jsonlines.open(file, 'r') as jsonl_f:
+        lst = [obj for obj in jsonl_f]
+    return lst
+
+def save_file_jsonl(data, fp):
+    with jsonlines.open(fp, mode='w') as writer:
+        writer.write_all(data)
+
+
+
+
+def run_azure_openai(
+    model_name: str,
+    system_prompt: Optional[str],
+    user_prompt: str,
+    endpoint: Optional[str] = None,
+    deployment: Optional[str] = None,
+    api_version: str = "2024-12-01-preview",
+    **chat_kwargs,
+) -> str:
+    """
+    Run Azure OpenAI model with the given prompts.
+    
+    Args:
+        model_name: The model name (used as deployment if deployment not specified)
+        system_prompt: Optional system prompt
+        user_prompt: User prompt
+        endpoint: Azure OpenAI endpoint URL
+        deployment: Azure OpenAI deployment name (defaults to model_name if not specified)
+        api_version: Azure OpenAI API version
+        **chat_kwargs: Additional arguments to pass to the chat completion
+    
+    Returns:
+        The response content from the model
+    """
+    # Get Azure credentials from environment
+    subscription_key = os.environ.get("AZURE_OPENAI_API_KEY")
+    if not subscription_key:
+        raise ValueError("AZURE_OPENAI_API_KEY environment variable is required")
+    
+    # Use provided endpoint or get from environment
+    if endpoint is None:
+        endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+        if not endpoint:
+            raise ValueError("Azure OpenAI endpoint must be provided or set in AZURE_OPENAI_ENDPOINT environment variable")
+    
+    # Use provided deployment or default to model_name
+    if deployment is None:
+        deployment = model_name
+    
+    # Set default parameters
+    chat_kwargs["temperature"] = chat_kwargs.get("temperature", 0)
+    chat_kwargs["max_completion_tokens"] = chat_kwargs.get("max_completion_tokens", 800)
+    chat_kwargs["top_p"] = chat_kwargs.get("top_p", 1.0)
+    chat_kwargs["frequency_penalty"] = chat_kwargs.get("frequency_penalty", 0.0)
+    chat_kwargs["presence_penalty"] = chat_kwargs.get("presence_penalty", 0.0)
+    
+    # Create Azure OpenAI client
+    client = AzureOpenAI(
+        api_version=api_version,
+        azure_endpoint=endpoint,
+        api_key=subscription_key,
+    )
+    
+    # Prepare messages
+    msgs = (
+        [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
+        if system_prompt is not None
+        else [{"role": "user", "content": user_prompt}]
+    )
+    
+    # Create chat completion
+    response = client.chat.completions.create(
+        messages=msgs,
+        model=deployment,
+        **chat_kwargs,
+    )
+    
+    return response.choices[0].message.content
+
+
+
+if __name__ == "__main__":
+    # Simple test case for run_chatopenai function
+    def test_run_chatopenai():
+        """Test the run_chatopenai function with a simple prompt"""
+        try:
+            # Test with a simple prompt
+            system_prompt = "You are a helpful assistant."
+            user_prompt = "What is 2 + 2?"
+            
+            print("Testing run_chatopenai function...")
+            print(f"System prompt: {system_prompt}")
+            print(f"User prompt: {user_prompt}")
+            
+            # Note: This will require a valid model name and API credentials
+            # Uncomment the line below to actually test (requires OPENAI_API_KEY)
+            response = run_chatopenai("gpt-3.5-turbo", system_prompt, user_prompt)
+            print(f"Response: {response}")
+            
+            print("Test completed successfully!")
+            
+        except Exception as e:
+            print(f"Test failed with error: {e}")
+    
+    def test_run_azure():
+        """Test the run_azure_openai function with a simple prompt"""
+        try:
+            # Test with a simple prompt
+            system_prompt = "You are a helpful assistant."
+            user_prompt = "What is 2 + 2?"
+            
+            print("Testing run_azure_openai function...")
+            print(f"System prompt: {system_prompt}")
+            print(f"User prompt: {user_prompt}")
+            
+            # Note: This will require valid Azure OpenAI credentials
+            # Use the correct deployment name that matches test_azure_api.py
+            response = run_azure_openai("gpt-4.5-preview", system_prompt, user_prompt, deployment="gpt-4.5-preview-standard")
+            print(f"Response: {response}")
+            
+            print("Test completed successfully!")
+            
+        except Exception as e:
+            print(f"Test failed with error: {e}")
+    
+    # test_run_chatopenai()
+    test_run_azure()
+    

--- a/open_instruct/search_rewards/test_formatted_example.py
+++ b/open_instruct/search_rewards/test_formatted_example.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import logging
+
+# Add parent directory to path for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from open_instruct.search_rewards.long_form_rewards import compute_paper_reward
+
+# Import the example from formatted_test_answer.py
+from open_instruct.search_rewards.tests.formatted_test_answer import example_answer
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Create a simple test case for the Great Wall of China example
+test_case = {
+    "initial_prompt": "Tell me about the Great Wall of China",
+    "metric_config": {
+        "name": "rubric_corpusqa_generic",
+        "config": {
+            "question": "Tell me about the Great Wall of China",
+            "low_length": 200,
+            "high_length": 800,
+            "length_weight": 0.1,
+            "expertise_weight": 0.1,
+            "citations_weight": 0.3,
+            "excerpts_weight": 0.2,
+            "model_name": "gpt-4-turbo",
+            "other_properties": [
+                {
+                    "name": "most_important_item_0",
+                    "criterion": "The answer should provide historical context about when the Great Wall was built.",
+                    "weight": 0.1,
+                    "evidence": [
+                        "Construction of the Great Wall began during the 7th century BC under various warring states, but the most famous sections were built during the Ming Dynasty (1368-1644)."
+                    ]
+                },
+                {
+                    "name": "most_important_item_1", 
+                    "criterion": "The answer should explain the purpose and function of the Great Wall.",
+                    "weight": 0.1,
+                    "evidence": [
+                        "The wall was primarily constructed as a defensive fortification to protect Chinese states from invasions by nomadic groups from the north."
+                    ]
+                },
+                {
+                    "name": "nice_to_have_item_0",
+                    "criterion": "The answer should mention construction materials and methods.",
+                    "weight": 0.1,
+                    "evidence": [
+                        "The wall incorporates various materials including stone, brick, tamped earth, wood, and other materials, with different sections built using locally available resources."
+                    ]
+                }
+            ]
+        }
+    },
+    "case_id": "great_wall_test_001"
+}
+
+def test_formatted_example():
+    """Test the reward computation with the formatted example from formatted_test_answer.py"""
+    print("Testing reward computation with formatted example...")
+    print("=" * 60)
+    
+    # Use the example_answer directly
+    full_response = example_answer
+    
+    print("Test case info:")
+    print(f"Question: {test_case['metric_config']['config']['question']}")
+    print(f"Case ID: {test_case['case_id']}")
+    print()
+    
+    print("Response length:", len(full_response))
+    print()
+    
+    print("Computing reward...")
+    result = compute_paper_reward(full_response, test_case)
+    
+    print("Results:")
+    print("-" * 40)
+    print(f"Extraction success: {result['extraction_success']}")
+    print(f"Reward score: {result['reward']:.4f}")
+    
+    if result['error']:
+        print(f"Error: {result['error']}")
+        print("\nFull error details:")
+        print("-" * 20)
+        import traceback
+        traceback.print_exc()
+    else:
+        print("\nScoring components:")
+        scoring_results = result['scoring_results']
+        for key, value in scoring_results.items():
+            if key not in ['score', 'ann_score']:
+                print(f"  {key}: {value:.4f}")
+        print(f"\nOverall score: {scoring_results['score']:.4f}")
+        print(f"Annotation score: {scoring_results['ann_score']:.4f}")
+        
+        # Analyze the score
+        print("\nScore Analysis:")
+        print("-" * 20)
+        if scoring_results['score'] >= 0.8:
+            print("✅ Excellent score - Comprehensive and well-cited answer")
+        elif scoring_results['score'] >= 0.6:
+            print("✅ Good score - Addresses most criteria well")
+        elif scoring_results['score'] >= 0.4:
+            print("⚠️  Moderate score - Some criteria addressed but needs improvement")
+        else:
+            print("❌ Low score - Significant improvement needed")
+    
+    print("\nCitations extracted:")
+    print("-" * 20)
+    for citation_id, citation_text in result['citations'].items():
+        print(f"ID: {citation_id}")
+        print(f"Text: {citation_text[:100]}...")
+        print()
+    
+    print("=" * 60)
+
+if __name__ == "__main__":
+    test_formatted_example() 

--- a/open_instruct/search_rewards/tests/formatted_test_answer.py
+++ b/open_instruct/search_rewards/tests/formatted_test_answer.py
@@ -1,0 +1,40 @@
+
+{
+  "response": "The Great Wall of China, one of the most iconic structures in human history, stretches approximately 13,000 miles across northern China. <cite id=\"a1b2c3d4\">Construction of the Great Wall began during the 7th century BC under various warring states, but the most famous sections were built during the Ming Dynasty (1368-1644).</cite> The wall was primarily constructed as a defensive fortification to protect Chinese states from invasions by nomadic groups from the north. <cite id=\"e5f6g7h8\">The wall incorporates various materials including stone, brick, tamped earth, wood, and other materials, with different sections built using locally available resources.</cite> Contrary to popular belief, <cite id=\"i9j0k1l2\">the Great Wall is not visible from space with the naked eye, a myth that has been debunked by astronauts and satellite imagery.</cite>",
+  
+  "citations": [
+    {
+      "id": "a1b2c3d4",
+      "query": "Great Wall of China construction history Ming Dynasty",
+      "reason": "The user asked about the Great Wall's history, so I need to search for information about when and how it was built, particularly focusing on the most well-known construction periods.",
+      "snippet": "The Great Wall of China is a series of fortifications built across the historical northern borders of ancient Chinese states. While walls were built as early as the 7th century BC by various warring states, the most famous sections of the wall were constructed during the Ming Dynasty between 1368 and 1644. The Ming Dynasty rebuilt and extended earlier walls, creating the structure most tourists visit today. The wall served as protection against invasions from northern nomadic tribes and played a crucial role in Chinese military strategy for centuries."
+    },
+    {
+      "id": "e5f6g7h8", 
+      "query": "Great Wall China construction materials stone brick earth",
+      "reason": "To provide comprehensive information about the Great Wall, I should include details about its construction materials and methods, which would be important for understanding how such a massive structure was built.",
+      "snippet": "The Great Wall was constructed using a variety of materials depending on the local terrain and available resources. In mountainous areas, stone was the primary material, while in desert regions, tamped earth and sand were used. The Ming Dynasty sections predominantly used brick and stone, with the exterior walls faced with brick and the interior filled with earth and rubble. Wooden frameworks were used for support during construction, and in some areas, reeds and other organic materials were incorporated into the structure."
+    },
+    {
+      "id": "i9j0k1l2",
+      "query": "Great Wall China visible from space myth debunked",
+      "reason": "Since the Great Wall is often associated with the popular myth about being visible from space, I should address this misconception to provide accurate information and correct common misunderstandings.",
+      "snippet": "The claim that the Great Wall of China is visible from space with the naked eye is a widespread myth that has been repeatedly debunked. NASA and various astronauts, including those from the International Space Station, have confirmed that the Great Wall is not visible to the naked eye from low Earth orbit without aid. The myth likely originated from Richard Halliburton's 1938 book, but satellite imagery and astronaut testimony have definitively proven this claim false. The wall is too narrow and blends too well with the surrounding landscape to be distinguished from space."
+    }
+  ]
+}
+
+
+
+example_answer_info = {
+  "response": "The Great Wall of China, one of the most iconic structures in human history, stretches approximately 13,000 miles across northern China. <cite id=\"a1b2c3d4\">Construction of the Great Wall began during the 7th century BC under various warring states, but the most famous sections were built during the Ming Dynasty (1368-1644).</cite> The wall was primarily constructed as a defensive fortification to protect Chinese states from invasions by nomadic groups from the north. <cite id=\"e5f6g7h8\">The wall incorporates various materials including stone, brick, tamped earth, wood, and other materials, with different sections built using locally available resources.</cite> Contrary to popular belief, <cite id=\"i9j0k1l2\">the Great Wall is not visible from space with the naked eye, a myth that has been debunked by astronauts and satellite imagery.</cite>",
+  
+  "context": "<reason>The user asked about the Great Wall's history, so I need to search for information about when and how it was built, particularly focusing on the most well-known construction periods.</reason><query>Great Wall of China construction history Ming Dynasty</query><snippets id=a1b2c3d4>The Great Wall of China is a series of fortifications built across the historical northern borders of ancient Chinese states. While walls were built as early as the 7th century BC by various warring states, the most famous sections of the wall were constructed during the Ming Dynasty between 1368 and 1644. The Ming Dynasty rebuilt and extended earlier walls, creating the structure most tourists visit today. The wall served as protection against invasions from northern nomadic tribes and played a crucial role in Chinese military strategy for centuries.</snippets><reason>To provide comprehensive information about the Great Wall, I should include details about its construction materials and methods, which would be important for understanding how such a massive structure was built.</reason><query>Great Wall China construction materials stone brick earth</query><snippets id=e5f6g7h8>The Great Wall was constructed using a variety of materials depending on the local terrain and available resources. In mountainous areas, stone was the primary material, while in desert regions, tamped earth and sand were used. The Ming Dynasty sections predominantly used brick and stone, with the exterior walls faced with brick and the interior filled with earth and rubble. Wooden frameworks were used for support during construction, and in some areas, reeds and other organic materials were incorporated into the structure.</snippets><reason>Since the Great Wall is often associated with the popular myth about being visible from space, I should address this misconception to provide accurate information and correct common misunderstandings.</reason><query>Great Wall China visible from space myth debunked</query><snippets id=i9j0k1l2>The claim that the Great Wall of China is visible from space with the naked eye is a widespread myth that has been repeatedly debunked. NASA and various astronauts, including those from the International Space Station, have confirmed that the Great Wall is not visible to the naked eye from low Earth orbit without aid. The myth likely originated from Richard Halliburton's 1938 book, but satellite imagery and astronaut testimony have definitively proven this claim false. The wall is too narrow and blends too well with the surrounding landscape to be distinguished from space.</snippets>"
+}
+
+example_answer = example_answer_info["context"] + '\n\n' + "<answer>" + example_answer_info["response"] + "</answer>"
+
+
+
+
+

--- a/open_instruct/search_rewards/tests/test_answer.py
+++ b/open_instruct/search_rewards/tests/test_answer.py
@@ -1,0 +1,22 @@
+# Draft answer for testing the scoring function
+test_answer = """
+Type inference systems for programming languages aim to automatically deduce the most general type for each expression in code. This means the system can automatically infer types without requiring programmers to write explicit type annotations, while still providing all the benefits of static typing. The goal is to infer polymorphic types whenever possible, making code both safe and flexible.
+
+Python's dynamic type system, while convenient for rapid development, can lead to potential type errors at runtime. As software projects grow in complexity, maintaining consistent data types becomes increasingly challenging. This has led both industry and academia to develop automatic type inference tools and static type checkers for Python. These tools help address potential ambiguities that arise from Python's runtime type determination.
+
+To evaluate the effectiveness of different type inference systems, researchers and practitioners need standardized evaluation approaches. Several key metrics are commonly used: exact matches (comparing inferred types to ground truth), reports of missing types, accuracy assessments, performance measurements, and coverage analysis of different code constructs and libraries.
+
+Several publicly available datasets are used for evaluating type inference systems in Python:
+
+1. **ManyTypes4Py**: This is a large-scale dataset containing 5,382 Python projects with over 869,000 type annotations. It's specifically designed for machine learning-based type inference and includes a lightweight static analyzer pipeline to extract type information from abstract syntax trees (ASTs). The dataset is split into training, validation, and test sets by files.
+
+2. **TypeEvalPy**: A micro-benchmarking framework containing 154 code snippets with 845 type annotations across 18 categories targeting various Python features. It manages the execution of containerized tools, transforms inferred types into standardized formats, and produces meaningful assessment metrics.
+
+3. **Python-150K**: Published by Raychev et al. in 2016, this dataset contains 8,422 Python projects. However, it wasn't collected solely for ML-based type inference tasks, so many projects may lack type annotations.
+
+4. **BetterTypes4Py**: Constructed by selecting a high-quality subset from the ManyTypes4Py dataset, specifically used to train Type4Py.
+
+5. **InferTypes4Py**: A test set derived from the source code of Typilus, Type4Py, and other tools, none of which were used as CodeT5's pre-training data.
+
+Type inference approaches in Python can be categorized into three main groups: rule-based, supervised, and cloze-style approaches. Rule-based methods ensure accuracy but suffer from low coverage due to dynamic features and external calls. Supervised approaches are feature-agnostic and can mitigate coverage problems but require large, high-quality annotated datasets and are limited to pre-defined types. Cloze-style approaches reformulate type inference as a fill-in-the-blank problem using pre-trained code models, though they may ignore domain knowledge from static typing rules.
+""" 

--- a/open_instruct/search_rewards/tests/test_azure_api.py
+++ b/open_instruct/search_rewards/tests/test_azure_api.py
@@ -1,0 +1,46 @@
+import os
+from openai import AzureOpenAI
+
+endpoint = "https://ai-olmohub1163464654570.openai.azure.com/"
+model_name = "gpt-4.5-preview"
+deployment = "gpt-4.5-preview-standard"
+
+subscription_key = os.environ["AZURE_OPENAI_API_KEY"]
+# This is NOT the model version. You do not need to change this, but it needs to be passed when the client is instantiated. The model version is specified by the deployment name. Each deployment has a fixed model version.
+api_version = "2024-12-01-preview"
+
+client = AzureOpenAI(
+    api_version=api_version,
+    azure_endpoint=endpoint,
+    api_key=subscription_key,
+)
+
+response = client.chat.completions.create(
+    messages=[
+        {
+            "role": "system",
+            "content": "You are a helpful assistant.",
+        },
+        {
+            "role": "user",
+            "content": "I am going to Paris, what should I see?",
+        },
+        {
+            "role": "assistant",
+            "content": "Paris, the capital of France, is known for its stunning architecture, art museums, historical landmarks, and romantic atmosphere. Here are some of the top attractions to see in Paris:\n \n 1. The Eiffel Tower: The iconic Eiffel Tower is one of the most recognizable landmarks in the world and offers breathtaking views of the city.\n 2. The Louvre Museum: The Louvre is one of the world's largest and most famous museums, housing an impressive collection of art and artifacts, including the Mona Lisa.\n 3. Notre-Dame Cathedral: This beautiful cathedral is one of the most famous landmarks in Paris and is known for its Gothic architecture and stunning stained glass windows.\n \n These are just a few of the many attractions that Paris has to offer. With so much to see and do, it's no wonder that Paris is one of the most popular tourist destinations in the world.",
+        },
+        {
+            "role": "user",
+            "content": "What is so great about #1?",
+        }
+    ],
+    # chatHistory=10,
+    max_completion_tokens=800,
+    temperature=1.0,
+    top_p=1.0,
+    frequency_penalty=0.0,
+    presence_penalty=0.0,
+    model=deployment
+)
+
+print(response.choices[0].message.content)

--- a/open_instruct/search_rewards/tests/test_case.py
+++ b/open_instruct/search_rewards/tests/test_case.py
@@ -1,0 +1,81 @@
+
+
+
+test_case = [
+  {
+    "initial_prompt": "What publicly available datasets are typically used for evaluating type inference systems in python?",
+    "metric_config": {
+      "name": "rubric_corpusqa_generic",
+      "config": {
+        "question": "What publicly available datasets are typically used for evaluating type inference systems in python?",
+        "low_length": 300,
+        "high_length": 600,
+        "length_weight": 0.05,
+        "expertise_weight": 0.05,
+        "citations_weight": 0.2,
+        "excerpts_weight": 0.1,
+        "other_properties": [
+          {
+            "name": "most_important_item_0",
+            "criterion": "Near the beginning, the answer should briefly define what is the goal of using a type inference system for programming languages in general.",
+            "weight": 0.13333333333333333,
+            "evidence": [
+              "Goal of type inference: Automatically deduce the most general type for each expression. Two key points: 1. Automatically inferring types: This means the programmer has to write no types, but still gets all the benefit from static typing 2. Inferring the most general type: This means we want to infer polymorphic types whenever possible"
+            ]
+          },
+          {
+            "name": "most_important_item_1",
+            "criterion": "The answer should emphasize on the importance of an automatic type inference system for Python.",
+            "weight": 0.13333333333333333,
+            "evidence": [
+              " its dynamic type system can lead to potential type errors, leading researchers to explore automatic type inference approaches for Python programs.",
+              "In Python, which is dynamically typed, this determination takes place at runtime. To address potential ambiguities, developers can utilize type annotations, which explicitly specifies the expected data types of variables or function returns. As the complexity of software projects increases, programmers find it increasingly challenging to maintain consistent data types. In response to this challenge, both industry and academia have developed type inference tools and static type checkers."
+            ]
+          },
+          {
+            "name": "most_important_item_2",
+            "criterion": "The answer should discuss the need for a unified approach for evaluating different type inference systems and mention several evaluation metrics, including exact matches, report of missing types, accuracy, etc.",
+            "weight": 0.13333333333333333,
+            "evidence": [
+              "In light of the growing interest in type inference research for Python, both researchers and practitioners require a standardized process to assess the performance of various type inference techniques.",
+              "Exact matches: The number of inferred types that exactly match the ground truth. This metric is used widely used in the literature to evaluate type inference tools (Allamanis et al., 2020; Peng et al., 2022; Mir et al., 2022).",
+              "Report of missing types: List of types that are present in the ground truth but are unreported by the tools.",
+              "### **Accuracy** The correctness of the inferred types compared to the ground truth. ### **Performance** The computation resources and time required to run the type inference. ### **Coverage** The range and variety of code constructs and libraries handled by the inference system."
+            ]
+          },
+          {
+            "name": "most_important_item_3",
+            "criterion": "The answer should enumerate publicly available datasets used for evaluating type inference systems in Python and provide a brief description for each of them.",
+            "weight": 0.13333333333333333,
+            "evidence": [
+              "1. **ManyTypes4Py**: - **Description**: ManyTypes4Py is a large Python dataset for machine learning-based type inference. It contains 5,382 Python projects with over 869,000 type annotations. The dataset is split into training, validation, and test sets by files to facilitate the training and evaluation of machine learning models. - **Features**: The dataset includes a lightweight static analyzer pipeline to extract type information from abstract syntax trees (ASTs) and store the results in JSON-formatted files.",
+              "The Typilus model [8] is accompanied by a dataset that contains 600 Python projects. Moreover, the source code files of Typilus' dataset are converted to graph representations that are only suitable for training the Typilus model.",
+              "2. **TypeEvalPy**: - **Description**: TypeEvalPy is a micro-benchmarking framework for evaluating type inference tools. It contains 154 code snippets with 845 type annotations across 18 categories targeting various Python features. - **Features**: The framework manages the execution of containerized tools, transforms inferred types into a standardized format, and produces meaningful metrics for assessment.",
+              "3. **BigQuery Public Datasets**: - **Description**: BigQuery provides a range of public datasets that can be used for various purposes, including type inference. These datasets are accessible through the Google Cloud Public Dataset Program and can be queried using SQL or GoogleSQL. - **Features**: The datasets include a variety of data sources, such as weather information, GitHub repository data, and Wikipedia revision history.",
+              "Raychev et al. [16] published the Python-150K dataset in 2016, which contains 8,422 Python projects.",
+              "Python-150K dataset [16] is not collected solely for the ML-based type inference task, meaning that a large number of projects in the dataset may not have type annotations at all, especially given the time that the dataset was created.",
+              "Our main dataset, BetterTypes4Py, is constructed by selecting a high-quality subset from the ManyTypes4Py dataset (Mir et al., 2021), which was used to train Type4Py.",
+              "InferTypes4Py, a test set derived from the source code of Typilus, Type4Py, and our own tool, none of which were used as CodeT5's (pre-)training data"
+            ]
+          },
+          {
+            "name": "nice_to_have_item_0",
+            "criterion": "The answer could explain different categories of methods for type inference in Python such as rule-based and ML-based approaches.",
+            "weight": 0.06666666666666667,
+            "evidence": [
+              "Existing type inference approaches can be generally grouped into three categories, i.e., rule-based, supervised, and cloze-style approaches. The rule-based type inference approaches can ensure the accuracy of predicted variable types, but they suffer from low coverage problems caused by dynamic features and external calls. Supervised type inference approaches, while feature-agnostic and able to mitigate the low coverage problem, require large, high quality annotated datasets and are limited to pre-defined types. As zero-shot approaches, the cloze-style approaches reformulate the type inference problem into a fill-in-the-blank problem by leveraging the general knowledge in powerful pre-trained code models. However, their performance is limited since they ignore the domain knowledge from static typing rules which reflect the inference logic."
+            ]
+          }
+        ]
+      }
+    },
+    "case_id": "d44280651a6fb71d56ee96834e180fa6",
+    "annotator": "Annotator 1 Assignments",
+    "agreement": True
+  },
+]
+
+
+
+
+

--- a/open_instruct/search_rewards/tests/test_paper_rewards.py
+++ b/open_instruct/search_rewards/tests/test_paper_rewards.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+import logging
+
+# Add parent directory to path for imports
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from open_instruct.search_rewards.long_form_rewards import compute_paper_reward
+
+# Import test data directly
+test_case = [
+  {
+    "initial_prompt": "What publicly available datasets are typically used for evaluating type inference systems in python?",
+    "metric_config": {
+      "name": "rubric_corpusqa_generic",
+      "config": {
+        "question": "What publicly available datasets are typically used for evaluating type inference systems in python?",
+        "low_length": 300,
+        "high_length": 600,
+        "length_weight": 0.05,
+        "expertise_weight": 0.05,
+        "citations_weight": 0.2,
+        "excerpts_weight": 0.1,
+        "other_properties": [
+          {
+            "name": "most_important_item_0",
+            "criterion": "Near the beginning, the answer should briefly define what is the goal of using a type inference system for programming languages in general.",
+            "weight": 0.13333333333333333,
+            "evidence": [
+              "Goal of type inference: Automatically deduce the most general type for each expression. Two key points: 1. Automatically inferring types: This means the programmer has to write no types, but still gets all the benefit from static typing 2. Inferring the most general type: This means we want to infer polymorphic types whenever possible"
+            ]
+          },
+          {
+            "name": "most_important_item_1",
+            "criterion": "The answer should emphasize on the importance of an automatic type inference system for Python.",
+            "weight": 0.13333333333333333,
+            "evidence": [
+              " its dynamic type system can lead to potential type errors, leading researchers to explore automatic type inference approaches for Python programs.",
+              "In Python, which is dynamically typed, this determination takes place at runtime. To address potential ambiguities, developers can utilize type annotations, which explicitly specifies the expected data types of variables or function returns. As the complexity of software projects increases, programmers find it increasingly challenging to maintain consistent data types. In response to this challenge, both industry and academia have developed type inference tools and static type checkers."
+            ]
+          },
+          {
+            "name": "most_important_item_2",
+            "criterion": "The answer should discuss the need for a unified approach for evaluating different type inference systems and mention several evaluation metrics, including exact matches, report of missing types, accuracy, etc.",
+            "weight": 0.13333333333333333,
+            "evidence": [
+              "In light of the growing interest in type inference research for Python, both researchers and practitioners require a standardized process to assess the performance of various type inference techniques.",
+              "Exact matches: The number of inferred types that exactly match the ground truth. This metric is used widely used in the literature to evaluate type inference tools (Allamanis et al., 2020; Peng et al., 2022; Mir et al., 2022).",
+              "Report of missing types: List of types that are present in the ground truth but are unreported by the tools.",
+              "### **Accuracy** The correctness of the inferred types compared to the ground truth. ### **Performance** The computation resources and time required to run the type inference. ### **Coverage** The range and variety of code constructs and libraries handled by the inference system."
+            ]
+          },
+          {
+            "name": "most_important_item_3",
+            "criterion": "The answer should enumerate publicly available datasets used for evaluating type inference systems in Python and provide a brief description for each of them.",
+            "weight": 0.13333333333333333,
+            "evidence": [
+              "1. **ManyTypes4Py**: - **Description**: ManyTypes4Py is a large Python dataset for machine learning-based type inference. It contains 5,382 Python projects with over 869,000 type annotations. The dataset is split into training, validation, and test sets by files to facilitate the training and evaluation of machine learning models. - **Features**: The dataset includes a lightweight static analyzer pipeline to extract type information from abstract syntax trees (ASTs) and store the results in JSON-formatted files.",
+              "The Typilus model [8] is accompanied by a dataset that contains 600 Python projects. Moreover, the source code files of Typilus' dataset are converted to graph representations that are only suitable for training the Typilus model.",
+              "2. **TypeEvalPy**: - **Description**: TypeEvalPy is a micro-benchmarking framework for evaluating type inference tools. It contains 154 code snippets with 845 type annotations across 18 categories targeting various Python features. - **Features**: The framework manages the execution of containerized tools, transforms inferred types into a standardized format, and produces meaningful metrics for assessment.",
+              "3. **BigQuery Public Datasets**: - **Description**: BigQuery provides a range of public datasets that can be used for various purposes, including type inference. These datasets are accessible through the Google Cloud Public Dataset Program and can be queried using SQL or GoogleSQL. - **Features**: The datasets include a variety of data sources, such as weather information, GitHub repository data, and Wikipedia revision history.",
+              "Raychev et al. [16] published the Python-150K dataset in 2016, which contains 8,422 Python projects.",
+              "Python-150K dataset [16] is not collected solely for the ML-based type inference task, meaning that a large number of projects in the dataset may not have type annotations at all, especially given the time that the dataset was created.",
+              "Our main dataset, BetterTypes4Py, is constructed by selecting a high-quality subset from the ManyTypes4Py dataset (Mir et al., 2021), which was used to train Type4Py.",
+              "InferTypes4Py, a test set derived from the source code of Typilus, Type4Py, and our own tool, none of which were used as CodeT5's (pre-)training data"
+            ]
+          },
+          {
+            "name": "nice_to_have_item_0",
+            "criterion": "The answer could explain different categories of methods for type inference in Python such as rule-based and ML-based approaches.",
+            "weight": 0.06666666666666667,
+            "evidence": [
+              "Existing type inference approaches can be generally grouped into three categories, i.e., rule-based, supervised, and cloze-style approaches. The rule-based type inference approaches can ensure the accuracy of predicted variable types, but they suffer from low coverage problems caused by dynamic features and external calls. Supervised type inference approaches, while feature-agnostic and able to mitigate the low coverage problem, require large, high quality annotated datasets and are limited to pre-defined types. As zero-shot approaches, the cloze-style approaches reformulate the type inference problem into a fill-in-the-blank problem by leveraging the general knowledge in powerful pre-trained code models. However, their performance is limited since they ignore the domain knowledge from static typing rules which reflect the inference logic."
+            ]
+          }
+        ]
+      }
+    },
+    "case_id": "d44280651a6fb71d56ee96834e180fa6",
+    "annotator": "Annotator 1 Assignments",
+    "agreement": True
+  },
+]
+
+test_answer = """
+Type inference systems for programming languages aim to automatically deduce the most general type for each expression in code. This means the system can automatically infer types without requiring programmers to write explicit type annotations, while still providing all the benefits of static typing. The goal is to infer polymorphic types whenever possible, making code both safe and flexible.
+
+Python's dynamic type system, while convenient for rapid development, can lead to potential type errors at runtime. As software projects grow in complexity, maintaining consistent data types becomes increasingly challenging. This has led both industry and academia to develop automatic type inference tools and static type checkers for Python. These tools help address potential ambiguities that arise from Python's runtime type determination.
+
+To evaluate the effectiveness of different type inference systems, researchers and practitioners need standardized evaluation approaches. Several key metrics are commonly used: exact matches (comparing inferred types to ground truth), reports of missing types, accuracy assessments, performance measurements, and coverage analysis of different code constructs and libraries.
+
+Several publicly available datasets are used for evaluating type inference systems in Python:
+
+1. **ManyTypes4Py**: This is a large-scale dataset containing 5,382 Python projects with over 869,000 type annotations. It's specifically designed for machine learning-based type inference and includes a lightweight static analyzer pipeline to extract type information from abstract syntax trees (ASTs). The dataset is split into training, validation, and test sets by files.
+
+2. **TypeEvalPy**: A micro-benchmarking framework containing 154 code snippets with 845 type annotations across 18 categories targeting various Python features. It manages the execution of containerized tools, transforms inferred types into standardized formats, and produces meaningful assessment metrics.
+
+3. **Python-150K**: Published by Raychev et al. in 2016, this dataset contains 8,422 Python projects. However, it wasn't collected solely for ML-based type inference tasks, so many projects may lack type annotations.
+
+4. **BetterTypes4Py**: Constructed by selecting a high-quality subset from the ManyTypes4Py dataset, specifically used to train Type4Py.
+
+5. **InferTypes4Py**: A test set derived from the source code of Typilus, Type4Py, and other tools, none of which were used as CodeT5's pre-training data.
+
+Type inference approaches in Python can be categorized into three main groups: rule-based, supervised, and cloze-style approaches. Rule-based methods ensure accuracy but suffer from low coverage due to dynamic features and external calls. Supervised approaches are feature-agnostic and can mitigate coverage problems but require large, high-quality annotated datasets and are limited to pre-defined types. Cloze-style approaches reformulate type inference as a fill-in-the-blank problem using pre-trained code models, though they may ignore domain knowledge from static typing rules.
+"""
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def test_reward_computation():
+    """Test the reward computation function"""
+    print("Testing reward computation...")
+    print("=" * 50)
+    
+    # Create a response with the test answer wrapped in answer tags
+    response = f"<answer>{test_answer}</answer>"
+    
+    # Use the first test case
+    test_case_data = test_case[0]
+    
+    print("Test case info:")
+    print(f"Question: {test_case_data['metric_config']['config']['question']}")
+    print(f"Case ID: {test_case_data['case_id']}")
+    print()
+    
+    print("Computing reward...")
+    result = compute_paper_reward(response, test_case_data)
+    
+    print("Results:")
+    print("-" * 30)
+    print(f"Extraction success: {result['extraction_success']}")
+    print(f"Reward score: {result['reward']:.4f}")
+    
+    if result['error']:
+        print(f"Error: {result['error']}")
+    else:
+        print("Scoring components:")
+        scoring_results = result['scoring_results']
+        for key, value in scoring_results.items():
+            if key not in ['score', 'ann_score']:
+                print(f"  {key}: {value:.4f}")
+        print(f"Overall score: {scoring_results['score']:.4f}")
+        print(f"Annotation score: {scoring_results['ann_score']:.4f}")
+    
+    print()
+
+
+def test_error_handling():
+    """Test error handling scenarios"""
+    print("Testing error handling...")
+    print("=" * 50)
+    
+    # Test 1: Invalid test case format
+    invalid_test_case = {"invalid": "format"}
+    response = "<answer>Some answer</answer>"
+    
+    result = compute_paper_reward(response, invalid_test_case)
+    print(f"Test 1 - Invalid test case format:")
+    print(f"Error: {result['error']}")
+    print(f"Reward: {result['reward']}")
+    print()
+    
+    # Test 2: Response without answer tags
+    valid_test_case = test_case[0]
+    response_no_tags = "This response has no answer tags."
+    
+    result = compute_paper_reward(response_no_tags, valid_test_case)
+    print(f"Test 2 - Response without answer tags:")
+    print(f"Error: {result['error']}")
+    print(f"Reward: {result['reward']}")
+    print()
+
+
+if __name__ == "__main__":
+    print("Paper Rewards Test Suite")
+    print("=" * 60)
+    print()
+    
+    test_reward_computation()
+    test_error_handling()
+    
+    print("All tests completed!") 

--- a/open_instruct/search_rewards/tests/test_run_utils.py
+++ b/open_instruct/search_rewards/tests/test_run_utils.py
@@ -1,0 +1,151 @@
+import unittest
+from unittest.mock import patch, MagicMock
+import os
+import sys
+
+# Add parent directory to path to import run_utils
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from run_utils import run_chatopenai, extract_json_from_response
+
+
+class TestRunUtils(unittest.TestCase):
+    
+    def setUp(self):
+        """Set up test fixtures"""
+        self.system_prompt = "You are a helpful assistant."
+        self.user_prompt = "What is 2 + 2?"
+        self.model_name = "gpt-3.5-turbo"
+    
+    @patch('run_utils.litellm.completion')
+    def test_run_chatopenai_basic(self, mock_completion):
+        """Test basic functionality of run_chatopenai"""
+        # Mock the litellm completion response
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "2 + 2 equals 4."
+        mock_completion.return_value = mock_response
+        
+        # Test the function
+        result = run_chatopenai(
+            model_name=self.model_name,
+            system_prompt=self.system_prompt,
+            user_prompt=self.user_prompt
+        )
+        
+        # Assertions
+        self.assertEqual(result, "2 + 2 equals 4.")
+        mock_completion.assert_called_once()
+        
+        # Check that the correct messages were passed
+        call_args = mock_completion.call_args
+        self.assertEqual(call_args[1]['model'], self.model_name)
+        self.assertEqual(len(call_args[1]['messages']), 2)
+        self.assertEqual(call_args[1]['messages'][0]['role'], 'system')
+        self.assertEqual(call_args[1]['messages'][0]['content'], self.system_prompt)
+        self.assertEqual(call_args[1]['messages'][1]['role'], 'user')
+        self.assertEqual(call_args[1]['messages'][1]['content'], self.user_prompt)
+    
+    @patch('run_utils.litellm.completion')
+    def test_run_chatopenai_no_system_prompt(self, mock_completion):
+        """Test run_chatopenai without system prompt"""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Hello!"
+        mock_completion.return_value = mock_response
+        
+        result = run_chatopenai(
+            model_name=self.model_name,
+            system_prompt=None,
+            user_prompt=self.user_prompt
+        )
+        
+        self.assertEqual(result, "Hello!")
+        
+        # Check that only user message was passed
+        call_args = mock_completion.call_args
+        self.assertEqual(len(call_args[1]['messages']), 1)
+        self.assertEqual(call_args[1]['messages'][0]['role'], 'user')
+    
+    @patch('run_utils.litellm.completion')
+    def test_run_chatopenai_json_mode(self, mock_completion):
+        """Test run_chatopenai with JSON mode enabled"""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = '{"answer": "4"}'
+        mock_completion.return_value = mock_response
+        
+        result = run_chatopenai(
+            model_name=self.model_name,
+            system_prompt=self.system_prompt,
+            user_prompt=self.user_prompt,
+            json_mode=True
+        )
+        
+        self.assertEqual(result, '{"answer": "4"}')
+        
+        # Check that response_format was set
+        call_args = mock_completion.call_args
+        self.assertEqual(call_args[1]['response_format'], {"type": "json_object"})
+    
+    @patch('run_utils.litellm.completion')
+    def test_run_chatopenai_custom_temperature(self, mock_completion):
+        """Test run_chatopenai with custom temperature"""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Response"
+        mock_completion.return_value = mock_response
+        
+        result = run_chatopenai(
+            model_name=self.model_name,
+            system_prompt=self.system_prompt,
+            user_prompt=self.user_prompt,
+            temperature=0.7
+        )
+        
+        # Check that custom temperature was used
+        call_args = mock_completion.call_args
+        self.assertEqual(call_args[1]['temperature'], 0.7)
+    
+    def test_extract_json_from_response_valid(self):
+        """Test extract_json_from_response with valid JSON"""
+        response = "Here is the answer: {\"result\": \"success\", \"value\": 42}"
+        result = extract_json_from_response(response)
+        self.assertEqual(result, {"result": "success", "value": 42})
+    
+    def test_extract_json_from_response_invalid(self):
+        """Test extract_json_from_response with invalid JSON"""
+        response = "Here is the answer: {invalid json}"
+        result = extract_json_from_response(response)
+        self.assertIsNone(result)
+    
+    def test_extract_json_from_response_no_json(self):
+        """Test extract_json_from_response with no JSON"""
+        response = "Here is the answer without any JSON"
+        result = extract_json_from_response(response)
+        self.assertIsNone(result)
+
+
+class TestRunChatOpenAIIntegration(unittest.TestCase):
+    """Integration tests that require actual API calls (disabled by default)"""
+    
+    @unittest.skipUnless(
+        os.getenv('OPENAI_API_KEY'), 
+        "Skipping integration test - OPENAI_API_KEY not set"
+    )
+    def test_run_chatopenai_integration(self):
+        """Integration test with actual API call"""
+        # This test will only run if OPENAI_API_KEY is set
+        result = run_chatopenai(
+            model_name="gpt-3.5-turbo",
+            system_prompt="You are a helpful assistant.",
+            user_prompt="Say 'Hello, World!'",
+            temperature=0
+        )
+        
+        self.assertIsInstance(result, str)
+        self.assertIn("Hello", result)
+
+
+if __name__ == "__main__":
+    # Run the tests
+    unittest.main(verbosity=2) 

--- a/open_instruct/search_rewards/tests/test_scoring.py
+++ b/open_instruct/search_rewards/tests/test_scoring.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import sys
+import os
+# Add parent directory to path for paper_rubrics_utils
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Add current directory to path for test files
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from open_instruct.search_rewards.global_rewards_utils import RubricCorpusQaGenericMetric
+from test_case import test_case
+from test_answer import test_answer
+
+def test_scoring_function():
+    """
+    Test the scoring function with the provided test case and draft answer.
+    """
+    print("Testing the scoring function with the provided test case...")
+    print("=" * 80)
+    
+    # Extract the metric config from the test case
+    metric_config = test_case[0]["metric_config"]["config"]
+    
+    # Initialize the scoring metric
+    metric = RubricCorpusQaGenericMetric(metric_config)
+    
+    # Score the answer
+    print("Scoring the draft answer...")
+    print("-" * 40)
+    print("Draft Answer:")
+    print(test_answer)
+    print("-" * 40)
+    
+    try:
+        scores = metric.score_output(test_answer)
+        
+        print("\nSCORING RESULTS:")
+        print("=" * 50)
+        print(f"Overall Score: {scores['score']:.4f}")
+        print(f"Annotation Score: {scores['ann_score']:.4f}")
+        print("\nDetailed Component Scores:")
+        print("-" * 30)
+        
+        # Print individual component scores
+        for component, score in scores.items():
+            if component not in ['score', 'ann_score']:
+                print(f"{component}: {score:.4f}")
+        
+        print("\n" + "=" * 50)
+        print("ANALYSIS:")
+        print("-" * 20)
+        
+        # Analyze the scores
+        if scores['score'] >= 0.8:
+            print("✅ Excellent score - The answer comprehensively addresses the criteria")
+        elif scores['score'] >= 0.6:
+            print("✅ Good score - The answer addresses most criteria well")
+        elif scores['score'] >= 0.4:
+            print("⚠️  Moderate score - The answer addresses some criteria but needs improvement")
+        else:
+            print("❌ Low score - The answer needs significant improvement")
+        
+        # Check specific criteria
+        print(f"\nLength score: {scores.get('length', 'N/A'):.4f}")
+        print(f"Expertise score: {scores.get('expertise', 'N/A'):.4f}")
+        
+        # Check rubric criteria
+        rubric_scores = {k: v for k, v in scores.items() if k.startswith('most_important_item') or k.startswith('nice_to_have_item')}
+        print(f"\nRubric Criteria Scores:")
+        for criterion, score in rubric_scores.items():
+            status = "✅" if score >= 0.7 else "⚠️" if score >= 0.4 else "❌"
+            print(f"  {criterion}: {score:.4f} {status}")
+            
+    except Exception as e:
+        print(f"Error during scoring: {e}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    test_scoring_function() 


### PR DESCRIPTION
# Reward Design

### Global Rewards
* Rubric rewards. LLM-as-a-judge
    * For each training/test sample, we generate per-sample rubrics for evaluation. For example, the rubric could be “the starting of the answer should introduce the background of XXX”. We use LLM-as-a-judge for rubric evaluation, which outputs a scalar score. We (weighted) average over all rubrics as the final rubric reward.
* Global rubric rewards. LLM-as-a-judge
    * This is a placeholder for a general rubric evaluation prompt for all examples.
* Length rewards (optional).
    * We use this reward to steer the generation towards the ideal length.

### Citation Rewards.
* Citation rewards (F1, prompts adapted from [LongCite](https://arxiv.org/abs/2409.02897)).
    * Citation factuality.
        * Check if the generated citation id is a valid id present in context. Return #valid_ids / #total_ids as the reward.
    * Citation quality Avg(F1=2(R*P)/(R+P)) LLM-as-a-judge
            * For each claim, compute the recall and precision.
    * Recall.
        * When the claim has no citation:
            * Return 1 if the model thinks this sentence does not require citation; return 0 otherwise.
        * When the claim has citations:
            * Return 1 if the claim is fully supported by corresponding citations;
            * Return 0.5 if the claim is partially supported by corresponding citations;
            * Return 0 if the claim is not supported by the citations.
    * Precision.
        * For citations, return 1 if it is relevant, else 0.