### PR TITLE
Div zero fixes

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -753,7 +753,8 @@ class PolicyTrainerRayProcess(RayProcess):
         to_device_inplace(collated_position_ids, self.device)
         to_device_inplace(collated_advantages, self.device)
         to_device_inplace(collated_response_masks, self.device)
-        accumulation_steps = math.ceil(len(collated_query_responses) / num_mini_batches - 0.5)
+        # accumulation steps should always be at least 1
+        accumulation_steps = max(math.ceil(len(collated_query_responses) / num_mini_batches - 0.5), 1)
         leftover = len(collated_query_responses) % accumulation_steps
         if leftover > 0:
             collated_query_responses = collated_query_responses[0:-leftover]
@@ -762,6 +763,7 @@ class PolicyTrainerRayProcess(RayProcess):
             collated_position_ids = collated_position_ids[0:-leftover]
             collated_advantages = collated_advantages[0:-leftover]
             collated_response_masks = collated_response_masks[0:-leftover]
+            print(f"Warning: {leftover} samples are dropped due to batch size {num_mini_batches}")
 
         # Calculate the logprob of the reference policy
         collated_ref_logprobs = []
@@ -1323,7 +1325,7 @@ def data_preparation_thread(
             "scores": np.array(scores).mean(),
             "real_batch_size_ratio": real_batch_size_ratio,
             "unsolved_batch_size_ratio": unsolved_batch_size_ratio,
-            "packed_ratio": len(packed_sequences.query_responses) / len(responses),
+            "packed_ratio": len(packed_sequences.query_responses) / len(responses) if len(responses) > 0 else 0,
             "val/sequence_lengths": sequence_lengths.mean(),
             "val/sequence_lengths_min": sequence_lengths.min(),
             "val/sequence_lengths_max": sequence_lengths.max(),
@@ -1362,6 +1364,9 @@ def data_preparation_thread(
             with open(f"{args.output_dir}/traces_{args.run_name}.jsonl", "a") as f:
                 json.dump(traces, f)
                 f.write("\n")
+
+        if len(responses) == 0:
+            print(f"Warning: no responses in batch {training_step}.")
 
         # Put the packed sequences and metrics into the output queue
         packed_sequences_Q.put(


### PR DESCRIPTION
Two fixes:
1. grad accumulation steps could hit zero if you asked for more minibatches than we had batch sizes after packing. This guards against that so we always just at least do one batch. If you ask for multiple minibatches but we have 1 batch, we just do one batch.
2. guards against a division by zero error in the packing code. If you have a batch with all 0/1 reward, we filter everything out. This actually runs fine until the metrics call, which errors since len(responses) is 0 and we try to divide by it. Later in the code, we do handle the case where the packing is empty fine (B == 0, we skip the batch or do world padding).