### PR TITLE
Update grpo_fast debug script

### DIFF
--- a/scripts/train/debug/grpo_fast.sh
+++ b/scripts/train/debug/grpo_fast.sh
@@ -10,7 +10,7 @@ python open_instruct/grpo_fast.py \
     --per_device_train_batch_size 1 \
     --num_unique_prompts_rollout 16 \
     --num_samples_per_prompt_rollout 4 \
-    --model_name_or_path HuggingFaceTB/SmolLM2-135M \
+    --model_name_or_path Qwen/Qwen3-1.7B \
     --stop_strings "</answer>" \
     --apply_r1_style_format_reward \
     --apply_verifiable_reward true \
@@ -27,7 +27,7 @@ python open_instruct/grpo_fast.py \
     --seed 3 \
     --num_evals 20 \
     --vllm_sync_backend gloo \
-    --vllm_gpu_memory_utilization 0.5 \
+    --vllm_gpu_memory_utilization 0.3 \
     --save_traces \
     --vllm_enforce_eager \
     --gradient_checkpointing \


### PR DESCRIPTION
- Using Qwen means we usually actually get some reward
- lower vllm usage % to make it not oom