### PR TITLE
fix up old gtrl scripts

### DIFF
--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -336,6 +336,8 @@ class Args:
     """the model to use for the llm judge"""
     llm_judge_max_tokens: int = 2048
     """the max tokens to use for the llm judge"""
+    llm_judge_max_context_length: int = 8192
+    """the max context length to use for the llm judge"""
     llm_judge_temperature: float = 1.0
     """the temperature to use for the llm judge"""
     llm_judge_timeout: int = 60
@@ -1765,7 +1767,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig):
                 "model_type": "sft",
                 "datasets": dataset_list,
                 "base_model": model_config.model_name_or_path,
-                "wandb_path": wandb.run.get_url(),
+                "wandb_path": wandb.run.get_url() if args.with_tracking else None,
                 "beaker_experiment": beaker_config.beaker_experiment_url,
                 "beaker_datasets": beaker_config.beaker_dataset_id_urls,
             }

--- a/scripts/train/debug/grpo.sh
+++ b/scripts/train/debug/grpo.sh
@@ -32,6 +32,6 @@ python open_instruct/grpo_vllm_thread_ray_gtrl.py \
     --gradient_checkpointing \
     --single_gpu_mode \
     --vllm_sync_backend gloo \
-    --vllm_gpu_memory_utilization 0.5 \
+    --vllm_gpu_memory_utilization 0.3 \
     --vllm_enforce_eager \
     # --with_tracking

--- a/scripts/train/debug/grpo.sh
+++ b/scripts/train/debug/grpo.sh
@@ -6,7 +6,7 @@ python open_instruct/grpo_vllm_thread_ray_gtrl.py \
     --max_token_length 512 \
     --max_prompt_token_length 512 \
     --response_length 512 \
-    --model_name_or_path EleutherAI/pythia-14m \
+    --model_name_or_path Qwen/Qwen3-1.7B \
     --number_samples_per_prompt 4 \
     --non_stop_penalty \
     --stop_token eos \

--- a/scripts/train/debug/ppo.sh
+++ b/scripts/train/debug/ppo.sh
@@ -6,8 +6,8 @@ python open_instruct/ppo_vllm_thread_ray_gtrl.py \
     --max_token_length 512 \
     --max_prompt_token_length 512 \
     --response_length 512 \
-    --model_name_or_path EleutherAI/pythia-14m \
-    --reward_model_path EleutherAI/pythia-14m \
+    --model_name_or_path Qwen/Qwen3-1.7B \
+    --reward_model_path Qwen/Qwen3-1.7B \
     --non_stop_penalty \
     --stop_token eos \
     --temperature 1.0 \

--- a/scripts/train/debug/ppo.sh
+++ b/scripts/train/debug/ppo.sh
@@ -32,6 +32,6 @@ python open_instruct/ppo_vllm_thread_ray_gtrl.py \
     --gradient_checkpointing \
     --single_gpu_mode \
     --vllm_sync_backend gloo \
-    --vllm_gpu_memory_utilization 0.5 \
+    --vllm_gpu_memory_utilization 0.3 \
     --vllm_enforce_eager \
     # --with_tracking


### PR DESCRIPTION
Add args needed for GTRL scripts to run again without issues. Also update debug scripts to use qwen3, which usually behaves nicer (actually gets some reward), and lower vllm util (avoids oom).