### PR TITLE
Add waiting time metric to Wandb

### DIFF
--- a/EVAL_WAIT_TIME_IMPLEMENTATION.md
+++ b/EVAL_WAIT_TIME_IMPLEMENTATION.md
@@ -1,0 +1,100 @@
+# Eval Wait Time Metric Implementation
+
+## Overview
+
+This implementation adds a new metric to track the time between eval jobs in the `grpo_fast.py` script. The metric measures how much time the eval job is waiting between runs, which helps identify potential bottlenecks in the evaluation pipeline.
+
+## Implementation Details
+
+### 1. Global Variable for Tracking
+
+Added a global variable to track the last eval finish time:
+
+```python
+# Global variable to track the last eval finish time
+# This is used to measure the time between when one eval job finishes and the next one is queued
+last_eval_finish_time = None
+```
+
+### 2. Recording Eval Finish Time
+
+Modified the `maybe_evaluate` function to record when an eval job finishes:
+
+```python
+# Record the time when eval job finishes
+# This timestamp is used to calculate the wait time for the next eval job
+global last_eval_finish_time
+last_eval_finish_time = time.time()
+logger.info("[Main Thread] 📊 Evaluation job finished")
+```
+
+### 3. Measuring Wait Time
+
+Modified the `vllm_generate_thread` function to measure and log the wait time when the next eval job is queued:
+
+```python
+# Record the time when eval job is queued and measure wait time since last eval finished
+global last_eval_finish_time
+current_time = time.time()
+if last_eval_finish_time is not None:
+    eval_wait_time = current_time - last_eval_finish_time
+    # Log the eval wait time to wandb if tracking is enabled
+    # This metric measures how much time the eval job was waiting between runs
+    if args.with_tracking and hasattr(wandb, 'run') and wandb.run is not None:
+        wandb.log({"eval/wait_time_between_evals": eval_wait_time}, step=training_step)
+        logger.info(f"[vLLM Thread] 📊 Eval wait time: {eval_wait_time:.2f}s")
+```
+
+### 4. Initialization
+
+Modified the `main` function to initialize the global variable:
+
+```python
+# Initialize global eval tracking variable
+global last_eval_finish_time
+last_eval_finish_time = None
+```
+
+## Metric Details
+
+- **Metric Name**: `eval/wait_time_between_evals`
+- **Type**: Scalar (float, seconds)
+- **Logged To**: Wandb (when `with_tracking=True`)
+- **Step**: Training step when eval is queued
+- **Description**: Time in seconds between when one eval job finishes and the next one is queued
+
+## Usage
+
+The metric will be automatically logged to Wandb when:
+1. `args.with_tracking` is `True`
+2. Wandb is properly initialized (`wandb.run` exists)
+3. There is a previous eval finish time to calculate from (not the first eval)
+
+## Benefits
+
+1. **Identify Bottlenecks**: Helps identify if eval jobs are waiting too long between runs
+2. **Optimize Pipeline**: Provides data to optimize the evaluation pipeline timing
+3. **Monitor Performance**: Tracks evaluation efficiency over time
+4. **Debug Issues**: Helps debug evaluation-related performance issues
+
+## Testing
+
+The implementation includes:
+- Logic tests to verify the timing calculations work correctly
+- Proper error handling for edge cases (first eval job)
+- Appropriate logging and metric naming conventions
+- Integration with existing Wandb tracking infrastructure
+
+## Files Modified
+
+- `open_instruct/grpo_fast.py`: Main implementation
+- `tests/test_eval_wait_time.py`: Unit tests (created)
+
+## Example Output
+
+When the metric is logged, you'll see output like:
+```
+[vLLM Thread] 📊 Eval wait time: 1.23s
+```
+
+And in Wandb, you'll see the metric `eval/wait_time_between_evals` plotted over training steps.

--- a/tests/test_eval_wait_time.py
+++ b/tests/test_eval_wait_time.py
@@ -1,0 +1,136 @@
+import time
+from unittest.mock import Mock, patch
+from queue import Queue
+from typing import List
+
+# Import the functions we want to test
+from open_instruct.grpo_fast import maybe_evaluate, vllm_generate_thread
+
+
+class TestEvalWaitTime:
+    """Test the eval wait time tracking functionality."""
+    
+    def test_eval_wait_time_tracking(self):
+        """Test that eval wait time is properly tracked and logged."""
+        
+        # Mock wandb
+        with patch('open_instruct.grpo_fast.wandb') as mock_wandb:
+            mock_wandb.run = Mock()
+            mock_wandb.log = Mock()
+            
+            # Mock args
+            args = Mock()
+            args.with_tracking = True
+            args.num_training_steps = 10
+            args.eval_freq = 2
+            
+            # Mock other dependencies
+            tokenizer = Mock()
+            tokenizer.batch_decode.return_value = ["test response"]
+            tokenizer.pad_token = "<pad>"
+            
+            eval_prompt_token_ids: List[int] = [1, 2, 3]
+            eval_ground_truths = ["test ground truth"]
+            eval_dataset_names = ["test_dataset"]
+            
+            # Mock reward function
+            async def mock_reward_fn(*args, **kwargs):
+                return [1.0], {"test_metric": 1.0}
+            
+            reward_fn = Mock()
+            reward_fn.return_value = mock_reward_fn()
+            
+            # Mock writer
+            writer = Mock()
+            
+            # Create queues
+            evaluation_inference_results_Q = Queue()
+            
+            # Test that eval wait time is tracked
+            # First eval - should not log wait time since it's the first one
+            maybe_evaluate(
+                args=args,
+                training_step=2,
+                evaluation_inference_results_Q=evaluation_inference_results_Q,
+                tokenizer=tokenizer,
+                eval_prompt_token_ids=eval_prompt_token_ids,
+                eval_ground_truths=eval_ground_truths,
+                eval_dataset_names=eval_dataset_names,
+                reward_fn=reward_fn,
+                episode=1,
+                writer=writer,
+            )
+            
+            # Put some mock data in the queue for the eval
+            evaluation_inference_results_Q.put((
+                [[1, 2, 3, 4]],  # responses
+                ["stop"],  # finish_reasons
+                [[1, 1, 1, 1]],  # masks
+                ([0], [0], [""], [""], [0], [False])  # infos
+            ))
+            
+            # Call maybe_evaluate again to process the data
+            maybe_evaluate(
+                args=args,
+                training_step=2,
+                evaluation_inference_results_Q=evaluation_inference_results_Q,
+                tokenizer=tokenizer,
+                eval_prompt_token_ids=eval_prompt_token_ids,
+                eval_ground_truths=eval_ground_truths,
+                eval_dataset_names=eval_dataset_names,
+                reward_fn=reward_fn,
+                episode=1,
+                writer=writer,
+            )
+            
+            # Verify that the eval finish time was recorded
+            from open_instruct.grpo_fast import last_eval_finish_time
+            assert last_eval_finish_time is not None
+            
+            # Now test the vllm_generate_thread function
+            # Mock the generate_with_engines function
+            def mock_generate_with_engines(prompts, sampling_params):
+                return (
+                    [[1, 2, 3, 4]],  # response_ids
+                    ["stop"],  # finish_reasons
+                    [[1, 1, 1, 1]],  # masks
+                    ([0], [0], [""], [""], [0], [False])  # infos
+                )
+            
+            # Mock vLLM engines
+            mock_engines = [Mock()]
+            
+            # Mock generation config
+            generation_config = Mock()
+            eval_generation_config = Mock()
+            
+            # Create queues
+            inference_results_Q = Queue()
+            param_prompt_Q = Queue()
+            evaluation_inference_results_Q = Queue()
+            
+            # Put some data in the param_prompt_Q
+            param_prompt_Q.put((None, [[1, 2, 3]]))
+            
+            # Test that the eval wait time is logged when the next eval is queued
+            with patch('open_instruct.grpo_fast.generate_with_engines', mock_generate_with_engines):
+                # This should trigger an eval at step 2
+                vllm_generate_thread(
+                    vllm_engines=mock_engines,
+                    generation_config=generation_config,
+                    eval_generation_config=eval_generation_config,
+                    inference_results_Q=inference_results_Q,
+                    param_prompt_Q=param_prompt_Q,
+                    num_training_steps=5,
+                    eval_prompt_token_ids=eval_prompt_token_ids,
+                    evaluation_inference_results_Q=evaluation_inference_results_Q,
+                    eval_freq=2,
+                    resume_training_step=2,
+                    tool_use=False,
+                )
+            
+            # Verify that wandb.log was called with the eval wait time
+            mock_wandb.log.assert_called()
+            call_args = mock_wandb.log.call_args_list
+            eval_wait_time_calls = [call for call in call_args if "eval/wait_time_between_evals" in str(call)]
+            assert len(eval_wait_time_calls) > 0, "Eval wait time should be logged to wandb"


### PR DESCRIPTION
Add `eval/wait_time_between_evals` metric to Wandb to measure the idle time between evaluation runs.