### PR TITLE
Switch to ray queues for LLMRayActor

### DIFF
--- a/open_instruct/CHANGES_SUMMARY.md
+++ b/open_instruct/CHANGES_SUMMARY.md
@@ -1,0 +1,75 @@
+# Changes Summary: Switching to Ray Queues
+
+## Overview
+Modified `grpo_fast.py` and `vllm_utils3.py` to use Ray Queues instead of regular Python Queues for `inference_results_Q` and `param_prompt_Q`, and updated `LLMRayActor` to work with queues directly.
+
+## Changes Made
+
+### 1. Modified `vllm_utils3.py`
+
+**Added new methods to `LLMRayActor` class:**
+
+- `process_queue_continuously()`: Continuously pulls prompts from the queue and processes them through the LLM
+- `generate_with_single_engine()`: Generates responses using a single engine instance
+
+**Key changes:**
+- LLMRayActor now takes queue references as input parameters
+- Each actor continuously pulls prompts from `param_prompt_Q` and puts results into `inference_results_Q`
+- Actors process prompts independently without needing a separate thread
+- Added support for evaluation results with special "EVAL" marker
+
+### 2. Modified `grpo_fast.py`
+
+**Queue Changes:**
+- Replaced `Queue` imports with `ray.util.queue.Queue`
+- Updated all queue type hints to remove explicit `Queue` typing
+- Changed queue creation in main function to use Ray Queues
+
+**Threading Changes:**
+- Replaced `vllm_generate_thread()` function with `start_queue_processing_on_actors()`
+- Removed threading approach for generation
+- Each LLMRayActor now handles its own queue processing
+- Updated cleanup to handle actor futures instead of threads
+
+**Function Updates:**
+- Updated `data_preparation_thread()` to handle new queue structure
+- Modified `sync_weights_and_prepare_prompts()` to work with Ray Queues
+- Updated `load_data_from_packing_thread()` and `maybe_evaluate()` function signatures
+- Added evaluation result handling in data preparation thread
+
+## Key Benefits
+
+1. **Direct Queue Integration**: LLMRayActor now directly pulls from and pushes to queues
+2. **No Separate Threading**: Eliminates the need for a separate generation thread
+3. **Better Resource Utilization**: Each actor processes independently
+4. **Ray Native**: Uses Ray's distributed queue system for better performance
+
+## Architecture Changes
+
+**Before:**
+```
+Main Thread → vllm_generate_thread → LLMRayActor.generate()
+```
+
+**After:**
+```
+Main Thread → LLMRayActor.process_queue_continuously() → Direct queue processing
+```
+
+## Usage
+
+The changes maintain the same external interface. The main function now:
+1. Creates Ray Queues instead of Python Queues
+2. Starts queue processing on all actors
+3. Sends prompts through the queue system
+4. Receives results through the queue system
+
+## Testing
+
+Created `test_queue_changes.py` to verify Ray Queue functionality (requires Ray installation).
+
+## Notes
+
+- Evaluation results are now handled through the same inference queue with a special "EVAL" marker
+- The data preparation thread filters out evaluation results for now
+- All queue operations are now Ray-native for better distributed performance


### PR DESCRIPTION
Switched `grpo_fast.py` to use Ray Queues and refactored `LLMRayActor` for direct queue-based inference, simplifying the generation flow and leveraging Ray's distributed capabilities.