### PR TITLE
Update action.yaml so that we rename old images instead of deleting them

### DIFF
--- a/.github/actions/push/action.yaml
+++ b/.github/actions/push/action.yaml
@@ -23,8 +23,7 @@ runs:
         # Push release to Beaker.
         SHORT_SHA=$(git rev-parse --short HEAD)
         beaker image create --name "${{ inputs.beaker }}-${SHORT_SHA}-${{ github.run_id }}" ${{ inputs.image }}
-        # We delete the previous version. This doesn't actually delete the backing Docker image, so
-        # we'll still benefit from layer caching when we push new version. The image might not exist
-        # yet, so it's ok if this fails.
-        beaker image delete nathanl/${{ inputs.beaker }} || true
+        # We can't delete the old image because it might be used by a running job. Instead, we rename it to an empty 
+        # string, so it will not be resolved by the Beaker client.
+        beaker image rename nathanl/${{ inputs.beaker }} "" || true
         beaker image create --name ${{ inputs.beaker }} ${{ inputs.image }}


### PR DESCRIPTION
I [ran into a bug](https://beaker.allen.ai/orgs/ai2/workspaces/oe-eval/work/01JZXM7K7FFHEJF5FPGHC7R1KH?taskId=01JZXM7K7M66F2YHC4WTK4Q96S&jobId=01JZY0V1K1T4FDXGQRGJPAKVHF) where my Beaker job would die with
`image 01JZTYZEQPDZ1T7PTQD0FP9A24: image "01JZTYZEQPDZ1T7PTQD0FP9A24" not found`.

Following [advice from Sam Skjonsberg](https://allenai.slack.com/archives/C6MN19S05/p1752508778120889?thread_ts=1752284078.864779&cid=C6MN19S05), if we change to _rename_ instead of _delete_, we can avoid the bug. 

In this PR, I update our workflow to match [what is done for the Beaker base image](https://github.com/allenai/docker-images/blob/main/.github/actions/push/action.yml#L61-L66).