### PR TITLE
Update oe-eval.sh to set a default timeout of 48h.

### DIFF
--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -270,6 +270,7 @@ for TASK in "${TASKS[@]}"; do
             --model "$MODEL_NAME" \
             --beaker-workspace "ai2/tulu-3-results" \
             --beaker-budget ai2/oe-adapt \
+            --beaker-timeout 48h \
             --task "$TASK" \
             $MODEL_TYPE \
             --batch-size "$BATCH_SIZE" \
@@ -290,6 +291,7 @@ for TASK in "${TASKS[@]}"; do
         --model "$MODEL_NAME" \
         --beaker-workspace "ai2/tulu-3-results" \
         --beaker-budget ai2/oe-adapt \
+        --beaker-timeout 48h \
         --task "$TASK" \
         $MODEL_TYPE \
         --batch-size "$BATCH_SIZE" \


### PR DESCRIPTION
Currently, there's no default, so jobs can last for up to 2 weeks.