### PR TITLE
fix the URL for code api setup

### DIFF
--- a/configs/beaker_configs/code_api_setup.sh
+++ b/configs/beaker_configs/code_api_setup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Configuration
 TOTAL_CPUS=$(nproc)
 CODE_SERVER_CPUS=128
@@ -8,7 +10,7 @@ NGINX_PORT=8070
 API_BASE_PORT=1234
 
 # Get leader replica IP
-BEAKER_LEADER_REPLICA_IP=$(getent hosts ${BEAKER_LEADER_REPLICA_HOSTNAME} | awk '{print $1}')
+BEAKER_LEADER_REPLICA_IP=$(getent hosts ${BEAKER_LEADER_REPLICA_HOSTNAME} | head -n 1 | awk '{print $1}')
 
 # Set up environment
 export PYTHONPATH=$REPO_PATH


### PR DESCRIPTION
I think code problems don't work in the latest open instruct image

currently `code_api_setup.sh` gives the wrong CODE_API_URL:

```terminal
> source configs/beaker_configs/code_api_setup.sh
> echo $CODE_API_URL
http://127.0.0.1 127.0.0.1 172.17.0.4:8070
```

this is because `getent hosts` gives 3 different hosts

```
> getent hosts
127.0.0.1       localhost
127.0.0.1       localhost ip6-localhost ip6-loopback
172.17.0.4      9fac611fe4c1
```

But we only want the first one. So do `head -n 1` 

issue found and fix provided by @saurabh111233212


after fix 

```
> echo $CODE_API_URL
http://127.0.0.1:8070
```


