### PR TITLE
Fixes from last PR

### DIFF
--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -563,7 +563,11 @@ class SimpleGenerateCollatorWithGroundTruth:
         # datasets
         datasets = [x[VERIFIER_SOURCE_KEY] for x in batch]
 
-        return {INPUT_IDS_PROMPT_KEY: padded_sequences, GROUND_TRUTHS_KEY: ground_truths, VERIFIER_SOURCE_KEY: datasets}
+        return {
+            INPUT_IDS_PROMPT_KEY: padded_sequences,
+            GROUND_TRUTHS_KEY: ground_truths,
+            VERIFIER_SOURCE_KEY: datasets,
+        }
 
 
 if __name__ == "__main__":

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -52,7 +52,7 @@ ATTENTION_MASK_REJECTED_KEY = "attention_mask_rejected"
 INPUT_IDS_PROMPT_KEY = "input_ids_prompt"
 ATTENTION_MASK_PROMPT_KEY = "attention_mask_prompt"
 GROUND_TRUTHS_KEY = "ground_truth"
-DATASET_SOURCE_KEY = "dataset"
+VERIFIER_SOURCE_KEY = "dataset"
 
 # NOTE (Costa): the `INPUT_IDS_PROMPT_KEY` is just for visualization purposes only
 # also we don't really need `ATTENTION_MASK_CHOSEN_KEY` and `ATTENTION_MASK_REJECTED_KEY`
@@ -186,7 +186,7 @@ class DatasetConfig:
     ground_truths_key: str = GROUND_TRUTHS_KEY
 
     # columns name for dataset source
-    dataset_source_key: str = DATASET_SOURCE_KEY
+    dataset_source_key: str = VERIFIER_SOURCE_KEY
 
     # columns names for binary dataset
     binary_messages_key: str = SFT_MESSAGE_KEY
@@ -434,7 +434,7 @@ class SFTGroundTruthDatasetProcessor(DatasetProcessor):
                 labels[: len(row[INPUT_IDS_PROMPT_KEY])] = [-100] * len(row[INPUT_IDS_PROMPT_KEY])
             row[LABELS_KEY] = labels
             row[GROUND_TRUTHS_KEY] = row[self.config.ground_truths_key]
-            row[DATASET_SOURCE_KEY] = row[self.config.dataset_source_key]
+            row[VERIFIER_SOURCE_KEY] = row[self.config.dataset_source_key]
             return row
 
         return dataset.map(
@@ -561,9 +561,9 @@ class SimpleGenerateCollatorWithGroundTruth:
         ground_truths = [x[GROUND_TRUTHS_KEY] for x in batch]
 
         # datasets
-        datasets = [x[DATASET_SOURCE_KEY] for x in batch]
+        datasets = [x[VERIFIER_SOURCE_KEY] for x in batch]
 
-        return {INPUT_IDS_PROMPT_KEY: padded_sequences, GROUND_TRUTHS_KEY: ground_truths, DATASET_SOURCE_KEY: datasets}
+        return {INPUT_IDS_PROMPT_KEY: padded_sequences, GROUND_TRUTHS_KEY: ground_truths, VERIFIER_SOURCE_KEY: datasets}
 
 
 if __name__ == "__main__":

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -77,7 +77,7 @@ from transformers.integrations import HfDeepSpeedConfig
 from vllm import SamplingParams
 
 from open_instruct.dataset_transformation import (
-    DATASET_SOURCE_KEY,
+    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
     TokenizerConfig,
@@ -1729,7 +1729,7 @@ def sync_weights_and_prepare_prompts(
         data_next = train_dataset[dataset_indices]
         queries_next = data_next[INPUT_IDS_PROMPT_KEY]
         ground_truths_next = data_next[GROUND_TRUTHS_KEY]
-        datasets_next = data_next[DATASET_SOURCE_KEY]
+        datasets_next = data_next[VERIFIER_SOURCE_KEY]
         with Timer(
             "[Main Thread] 🔄 Loading weights using shared memory"
             if args.async_mode
@@ -2119,7 +2119,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_sa
     if eval_dataset is not None:
         eval_prompt_token_ids = eval_dataset[:num_eval_samples][INPUT_IDS_PROMPT_KEY]
         eval_ground_truths = eval_dataset[:num_eval_samples][GROUND_TRUTHS_KEY]
-        eval_dataset_names = eval_dataset[:num_eval_samples][DATASET_SOURCE_KEY]
+        eval_dataset_names = eval_dataset[:num_eval_samples][VERIFIER_SOURCE_KEY]
     reward_fn = make_reward_fn(args)
 
     # Start vLLM engines to process from queues
@@ -2153,7 +2153,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_sa
     data_next = train_dataset[dataset_indices]
     queries_next = data_next[INPUT_IDS_PROMPT_KEY]
     ground_truths_next = data_next[GROUND_TRUTHS_KEY]
-    datasets_next = data_next[DATASET_SOURCE_KEY]
+    datasets_next = data_next[VERIFIER_SOURCE_KEY]
 
     # Split the initial batch using the split_and_insert_batch function
     split_and_insert_batch(

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -64,7 +64,6 @@ import ray
 import torch
 import torch.utils
 import torch.utils.data
-import wandb
 from huggingface_hub import HfApi
 from peft import PeftModel, get_peft_model_state_dict
 from ray.util import queue as ray_queue
@@ -76,10 +75,11 @@ from transformers import AutoModelForCausalLM, PreTrainedModel, PreTrainedTokeni
 from transformers.integrations import HfDeepSpeedConfig
 from vllm import SamplingParams
 
+import wandb
 from open_instruct.dataset_transformation import (
-    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
+    VERIFIER_SOURCE_KEY,
     TokenizerConfig,
     get_cached_dataset_tulu,
     visualize_token,

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -63,6 +63,7 @@ import ray
 import torch
 import torch.utils
 import torch.utils.data
+import wandb
 from huggingface_hub import HfApi
 from peft import PeftModel, get_peft_model_state_dict
 from ray.util import queue as ray_queue
@@ -74,7 +75,6 @@ from transformers import AutoModelForCausalLM, PreTrainedModel, PreTrainedTokeni
 from transformers.integrations import HfDeepSpeedConfig
 from vllm import SamplingParams
 
-import wandb
 from open_instruct.dataset_transformation import (
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -41,7 +41,6 @@ try:
 except Exception:
     pass
 # isort: on
-
 import asyncio
 import json
 import logging

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -88,9 +88,9 @@ from vllm import SamplingParams
 
 from open_instruct.dataset_processor import SimpleGenerateCollatorWithGroundTruth
 from open_instruct.dataset_transformation import (
-    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
+    VERIFIER_SOURCE_KEY,
     TokenizerConfig,
     get_cached_dataset_tulu,
     visualize_token,

--- a/open_instruct/grpo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/grpo_vllm_thread_ray_gtrl.py
@@ -88,7 +88,7 @@ from vllm import SamplingParams
 
 from open_instruct.dataset_processor import SimpleGenerateCollatorWithGroundTruth
 from open_instruct.dataset_transformation import (
-    DATASET_SOURCE_KEY,
+    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
     TokenizerConfig,
@@ -1027,7 +1027,7 @@ class PolicyTrainerRayProcess(RayProcess):
         ].tolist()  # can be simplified since we `remove_padding` later anyway
         queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
         ground_truths_next = data[GROUND_TRUTHS_KEY]
-        datasets_next = data[DATASET_SOURCE_KEY]
+        datasets_next = data[VERIFIER_SOURCE_KEY]
         if self.rank == 0:
             param_prompt_Q.put((None, remove_padding(global_queries, tokenizer.pad_token_id)))
 
@@ -1066,7 +1066,7 @@ class PolicyTrainerRayProcess(RayProcess):
                     global_queries = data_collator(global_data)[INPUT_IDS_PROMPT_KEY].tolist()
                     queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
                     ground_truths_next = data[GROUND_TRUTHS_KEY]
-                    datasets_next = data[DATASET_SOURCE_KEY]
+                    datasets_next = data[VERIFIER_SOURCE_KEY]
                     with Timer("🔥🔥🔥 Loading weights using shared memory", noop=self.rank != 0):
                         broadcast_to_vllm()
                 if self.rank == 0:
@@ -1084,7 +1084,7 @@ class PolicyTrainerRayProcess(RayProcess):
                     global_queries = data_collator(global_data)[INPUT_IDS_PROMPT_KEY].tolist()
                     queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
                     ground_truths_next = data[GROUND_TRUTHS_KEY]
-                    datasets_next = data[DATASET_SOURCE_KEY]
+                    datasets_next = data[VERIFIER_SOURCE_KEY]
                     with Timer("🔥🔥🔥 Loading weights using shared memory", noop=self.rank != 0):
                         broadcast_to_vllm()
                     if self.rank == 0:

--- a/open_instruct/ppo2.py
+++ b/open_instruct/ppo2.py
@@ -92,7 +92,7 @@ from vllm import SamplingParams
 
 from open_instruct.dataset_processor import SimpleGenerateCollatorWithGroundTruth
 from open_instruct.dataset_transformation import (
-    DATASET_SOURCE_KEY,
+    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
     TokenizerConfig,
@@ -1022,7 +1022,7 @@ class PolicyTrainerRayProcess(RayProcess):
         ].tolist()  # can be simplified since we `remove_padding` later anyway
         queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
         ground_truths_next = data[GROUND_TRUTHS_KEY]
-        datasets_next = data[DATASET_SOURCE_KEY]
+        datasets_next = data[VERIFIER_SOURCE_KEY]
         if self.rank == 0:
             param_prompt_Q.put((None, remove_padding(global_queries, tokenizer.pad_token_id)))
 
@@ -1060,7 +1060,7 @@ class PolicyTrainerRayProcess(RayProcess):
                 global_queries = data_collator(global_data)[INPUT_IDS_PROMPT_KEY].tolist()
                 queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
                 ground_truths_next = data[GROUND_TRUTHS_KEY]
-                datasets_next = data[DATASET_SOURCE_KEY]
+                datasets_next = data[VERIFIER_SOURCE_KEY]
                 with Timer("🔥🔥🔥 Loading weights using shared memory", noop=self.rank != 0):
                     broadcast_to_vllm()
             if self.rank == 0:

--- a/open_instruct/ppo2.py
+++ b/open_instruct/ppo2.py
@@ -92,9 +92,9 @@ from vllm import SamplingParams
 
 from open_instruct.dataset_processor import SimpleGenerateCollatorWithGroundTruth
 from open_instruct.dataset_transformation import (
-    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
+    VERIFIER_SOURCE_KEY,
     TokenizerConfig,
     get_cached_dataset_tulu,
     visualize_token,

--- a/open_instruct/ppo_fast.py
+++ b/open_instruct/ppo_fast.py
@@ -84,7 +84,7 @@ from transformers.integrations import HfDeepSpeedConfig
 from vllm import SamplingParams
 
 from open_instruct.dataset_transformation import (
-    DATASET_SOURCE_KEY,
+    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
     TokenizerConfig,
@@ -1685,7 +1685,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
     if eval_dataset is not None:
         eval_prompt_token_ids = eval_dataset[:num_eval_samples][INPUT_IDS_PROMPT_KEY]
         eval_ground_truths = eval_dataset[:num_eval_samples][GROUND_TRUTHS_KEY]
-        eval_dataset_names = eval_dataset[:num_eval_samples][DATASET_SOURCE_KEY]
+        eval_dataset_names = eval_dataset[:num_eval_samples][VERIFIER_SOURCE_KEY]
     thread = threading.Thread(
         target=vllm_generate_thread,
         args=(
@@ -1723,7 +1723,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
     data_next = train_dataset[next(iter_dataloader)]
     queries_next = data_next[INPUT_IDS_PROMPT_KEY]
     ground_truths_next = data_next[GROUND_TRUTHS_KEY]
-    datasets_next = data_next[DATASET_SOURCE_KEY]
+    datasets_next = data_next[VERIFIER_SOURCE_KEY]
     queries_prompt_Q.put((queries_next, ground_truths_next, datasets_next))
     param_prompt_Q.put((None, queries_next))
 
@@ -1743,7 +1743,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
                     data_next = train_dataset[next(iter_dataloader)]
                     queries_next = data_next[INPUT_IDS_PROMPT_KEY]
                     ground_truths_next = data_next[GROUND_TRUTHS_KEY]
-                    datasets_next = data_next[DATASET_SOURCE_KEY]
+                    datasets_next = data_next[VERIFIER_SOURCE_KEY]
                     with Timer("[Main Thread] 🔄 Loading weights using shared memory"):
                         ray.get([m.broadcast_to_vllm.remote() for m in policy_group.models])
                 queries_prompt_Q.put((queries_next, ground_truths_next, datasets_next))
@@ -1755,7 +1755,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, reward_fn: 
                     data_next = train_dataset[next(iter_dataloader)]
                     queries_next = data_next[INPUT_IDS_PROMPT_KEY]
                     ground_truths_next = data_next[GROUND_TRUTHS_KEY]
-                    datasets_next = data_next[DATASET_SOURCE_KEY]
+                    datasets_next = data_next[VERIFIER_SOURCE_KEY]
                     with Timer("🔄 Loading weights using shared memory"):
                         ray.get([m.broadcast_to_vllm.remote() for m in policy_group.models])
                     queries_prompt_Q.put((queries_next, ground_truths_next, datasets_next))

--- a/open_instruct/ppo_fast.py
+++ b/open_instruct/ppo_fast.py
@@ -84,9 +84,9 @@ from transformers.integrations import HfDeepSpeedConfig
 from vllm import SamplingParams
 
 from open_instruct.dataset_transformation import (
-    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
+    VERIFIER_SOURCE_KEY,
     TokenizerConfig,
     get_cached_dataset_tulu,
     visualize_token,

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -86,9 +86,9 @@ from vllm import SamplingParams
 
 from open_instruct.dataset_processor import SimpleGenerateCollatorWithGroundTruth
 from open_instruct.dataset_transformation import (
-    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
+    VERIFIER_SOURCE_KEY,
     TokenizerConfig,
     get_cached_dataset_tulu,
     visualize_token,

--- a/open_instruct/ppo_vllm_thread_ray_gtrl.py
+++ b/open_instruct/ppo_vllm_thread_ray_gtrl.py
@@ -86,7 +86,7 @@ from vllm import SamplingParams
 
 from open_instruct.dataset_processor import SimpleGenerateCollatorWithGroundTruth
 from open_instruct.dataset_transformation import (
-    DATASET_SOURCE_KEY,
+    VERIFIER_SOURCE_KEY,
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
     TokenizerConfig,
@@ -1064,7 +1064,7 @@ class PolicyTrainerRayProcess(RayProcess):
         ].tolist()  # can be simplified since we `remove_padding` later anyway
         queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
         ground_truths_next = data[GROUND_TRUTHS_KEY]
-        datasets_next = data[DATASET_SOURCE_KEY]
+        datasets_next = data[VERIFIER_SOURCE_KEY]
         if self.rank == 0:
             param_prompt_Q.put((None, remove_padding(global_queries, tokenizer.pad_token_id)))
 
@@ -1103,7 +1103,7 @@ class PolicyTrainerRayProcess(RayProcess):
                     global_queries = data_collator(global_data)[INPUT_IDS_PROMPT_KEY].tolist()
                     queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
                     ground_truths_next = data[GROUND_TRUTHS_KEY]
-                    datasets_next = data[DATASET_SOURCE_KEY]
+                    datasets_next = data[VERIFIER_SOURCE_KEY]
                     with Timer("🔥🔥🔥 Loading weights using shared memory", noop=self.rank != 0):
                         broadcast_to_vllm()
                 if self.rank == 0:
@@ -1121,7 +1121,7 @@ class PolicyTrainerRayProcess(RayProcess):
                     global_queries = data_collator(global_data)[INPUT_IDS_PROMPT_KEY].tolist()
                     queries_next = data[INPUT_IDS_PROMPT_KEY].to(device)
                     ground_truths_next = data[GROUND_TRUTHS_KEY]
-                    datasets_next = data[DATASET_SOURCE_KEY]
+                    datasets_next = data[VERIFIER_SOURCE_KEY]
                     with Timer("🔥🔥🔥 Loading weights using shared memory", noop=self.rank != 0):
                         broadcast_to_vllm()
                     if self.rank == 0:

--- a/scripts/data/convert_sft_data_for_olmocore.py
+++ b/scripts/data/convert_sft_data_for_olmocore.py
@@ -48,7 +48,7 @@ from tqdm import tqdm
 
 from open_instruct.dataset_transformation import (
     ATTENTION_MASK_KEY,
-    DATASET_SOURCE_KEY,
+    DATASET_ORIGIN_KEY,
     INPUT_IDS_KEY,
     LABELS_KEY,
     TOKENIZED_SFT_DATASET_KEYS,
@@ -214,7 +214,7 @@ def main(args: ConvertSFTDataArguments, tc: TokenizerConfig):
         sample_length = len(sample[INPUT_IDS_KEY])
         sample_tokens = sample[INPUT_IDS_KEY]
         sample_labels = sample[LABELS_KEY]
-        dataset_source = sample.get(DATASET_SOURCE_KEY, "unknown")
+        dataset_source = sample.get(DATASET_ORIGIN_KEY, "unknown")
         
         # Initialize counters for new datasets
         if dataset_source not in per_dataset_counts:

--- a/scripts/data/convert_sft_data_for_olmocore.py
+++ b/scripts/data/convert_sft_data_for_olmocore.py
@@ -54,7 +54,7 @@ from open_instruct.dataset_transformation import (
     TOKENIZED_SFT_DATASET_KEYS,
     TOKENIZED_SFT_DATASET_KEYS_WITH_SOURCE,
     TokenizerConfig,
-    get_cached_dataset_tulu,
+    get_cached_dataset_tulu_with_statistics,
     visualize_token,
 )
 from open_instruct.utils import ArgumentParserPlus, is_beaker_job
@@ -161,7 +161,7 @@ def main(args: ConvertSFTDataArguments, tc: TokenizerConfig):
         ("sft_tulu_filter_v1", {}),  # remove examples that don't have any labels
     ]
 
-    result = get_cached_dataset_tulu(
+    result = get_cached_dataset_tulu_with_statistics(
         dataset_mixer_list=args.dataset_mixer_list,
         dataset_mixer_list_splits=args.dataset_mixer_list_splits,
         tc=tc,


### PR DESCRIPTION
#765 had some issues I realised after approving it.
- rename "DATASET_SOURCE_KEY" to "VERIFIER_SOURCE_KEY" to better reflect its usage, and rename the added "DATASET_SOURCE_KEY" to "DATASET_ORIGIN_KEY" to be safe (#765 added a second constant with the same name, and this broke things). This required renaming stuff across files, hopefully I didn't miss anything!
- Don't use mutating return types for load_or_transform_dataset, get_cached_dataset_tulu.
- dataset source name clashes with the verifier name column we use ("dataset").

Given it a quick test locally but running some RLVR stuff with these changes now.

Not sure why lint is failing, it passes locally for me...