### PR TITLE
Fixes the ray double init error.

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1596,9 +1596,6 @@ def create_model_and_optimizer(
     evaluation_inference_results_Q: ray_queue.Queue,
 ) -> tuple[ModelGroup, list[LLMRayActor], dict, int, int]:
     """Create the model, optimizer, and vLLM engines."""
-    # Ray initialization
-    ray.init(dashboard_host="0.0.0.0")  # enable debugging from a different machine (e.g., phobos)
-
     # Create placement group
     bundles = [{"GPU": actor_num_gpus, "CPU": actor_num_gpus * 10} for actor_num_gpus in args.num_learners_per_node]
     pg = placement_group(bundles, strategy="STRICT_SPREAD")
@@ -2070,6 +2067,9 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_sa
         return
 
     pprint([args, model_config])
+
+    # Initialize Ray before creating Ray objects
+    ray.init(dashboard_host="0.0.0.0")  # enable debugging from a different machine (e.g., phobos)
 
     # Create Ray queues
     inference_results_Q = ray_queue.Queue(maxsize=args.async_steps)

--- a/open_instruct/test_grpo_fast.py
+++ b/open_instruct/test_grpo_fast.py
@@ -7,7 +7,7 @@ from ray.util import queue as ray_queue
 from transformers import AutoTokenizer
 from vllm import SamplingParams
 
-from open_instruct.grpo_fast import accumulate_inference_batches, split_and_insert_batch
+import open_instruct.grpo_fast as grpo_fast
 from open_instruct.vllm_utils3 import GenerationResult, PromptRequest, RequestInfo, create_vllm_engines
 
 
@@ -118,7 +118,7 @@ class TestGrpoFastVLLM(unittest.TestCase):
         dataset_indices = list(range(num_unique_prompts_rollout))
 
         # Use split_and_insert_batch to split and insert data
-        split_and_insert_batch(
+        grpo_fast.split_and_insert_batch(
             queries_next,
             ground_truths_next,
             datasets_next,
@@ -169,8 +169,10 @@ class TestGrpoFastVLLM(unittest.TestCase):
             inference_results_Q.put(result)
 
         # Use accumulate_inference_batches to combine results
-        combined_result, combined_queries, combined_ground_truths, combined_datasets = accumulate_inference_batches(
-            inference_results_Q, pending_queries_map, vllm_num_engines, training_step
+        combined_result, combined_queries, combined_ground_truths, combined_datasets = (
+            grpo_fast.accumulate_inference_batches(
+                inference_results_Q, pending_queries_map, vllm_num_engines, training_step
+            )
         )
 
         # Verify that the combined results match the original input


### PR DESCRIPTION
When we were calling Ray to start the queues, Ray was automatically initializing itself as the queues created a remote object. Consequently, the explicit call to `ray.init` would fail.