### PR TITLE
Silences TORCH_CUDA_ARCH_LIST warning by passing the env var through.

### DIFF
--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -302,6 +302,23 @@ class LLMRayActor:
         return True
 
 
+def get_cuda_arch_list() -> str:
+    """Get CUDA compute capabilities and format them for TORCH_CUDA_ARCH_LIST."""
+    if not torch.cuda.is_available():
+        return ""
+    
+    cuda_capabilities = []
+    for i in range(torch.cuda.device_count()):
+        major, minor = torch.cuda.get_device_capability(i)
+        cuda_capabilities.append(f"{major}.{minor}")
+    
+    # Remove duplicates and sort
+    cuda_capabilities = sorted(set(cuda_capabilities))
+    cuda_arch_list = ";".join(cuda_capabilities)
+    print(f"Detected CUDA compute capabilities: {cuda_capabilities}, setting TORCH_CUDA_ARCH_LIST={cuda_arch_list}")
+    return cuda_arch_list
+
+
 def create_vllm_engines(
     num_engines: int,
     tensor_parallel_size: int,
@@ -377,7 +394,10 @@ def create_vllm_engines(
                 num_gpus=num_gpus,
                 scheduling_strategy=scheduling_strategy,
                 # VLLM v1 multiprocessing is required due to https://github.com/vllm-project/vllm/issues/15349
-                runtime_env=ray.runtime_env.RuntimeEnv(env_vars={"VLLM_ENABLE_V1_MULTIPROCESSING": "0"}),
+                runtime_env=ray.runtime_env.RuntimeEnv(env_vars={
+                    "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
+                    "TORCH_CUDA_ARCH_LIST": get_cuda_arch_list(),
+                }),
             ).remote(
                 model=pretrain,
                 revision=revision,

--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -306,12 +306,12 @@ def get_cuda_arch_list() -> str:
     """Get CUDA compute capabilities and format them for TORCH_CUDA_ARCH_LIST."""
     if not torch.cuda.is_available():
         return ""
-    
+
     cuda_capabilities = []
     for i in range(torch.cuda.device_count()):
         major, minor = torch.cuda.get_device_capability(i)
         cuda_capabilities.append(f"{major}.{minor}")
-    
+
     # Remove duplicates and sort
     cuda_capabilities = sorted(set(cuda_capabilities))
     cuda_arch_list = ";".join(cuda_capabilities)
@@ -394,10 +394,9 @@ def create_vllm_engines(
                 num_gpus=num_gpus,
                 scheduling_strategy=scheduling_strategy,
                 # VLLM v1 multiprocessing is required due to https://github.com/vllm-project/vllm/issues/15349
-                runtime_env=ray.runtime_env.RuntimeEnv(env_vars={
-                    "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
-                    "TORCH_CUDA_ARCH_LIST": get_cuda_arch_list(),
-                }),
+                runtime_env=ray.runtime_env.RuntimeEnv(
+                    env_vars={"VLLM_ENABLE_V1_MULTIPROCESSING": "0", "TORCH_CUDA_ARCH_LIST": get_cuda_arch_list()}
+                ),
             ).remote(
                 model=pretrain,
                 revision=revision,

--- a/scripts/train/debug/single_gpu_on_beaker.sh
+++ b/scripts/train/debug/single_gpu_on_beaker.sh
@@ -2,7 +2,7 @@
 
 # Get the Beaker username to construct the image name
 BEAKER_USER=$(beaker account whoami --format json | jq -r '.[0].name')
-BEAKER_IMAGE="${1:-${BEAKER_USER}/open-instruct-dev}"
+BEAKER_IMAGE="${1:-${BEAKER_USER}/open-instruct-integration-test}"
 
 echo "Using Beaker image: $BEAKER_IMAGE"
 

--- a/scripts/train/debug/single_gpu_on_beaker.sh
+++ b/scripts/train/debug/single_gpu_on_beaker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 beaker_image="${1:-finbarrt/open-instruct-dev}"
-python mason.py \
+uv run python mason.py \
        --cluster ai2/jupiter-cirrascale-2 \
        --cluster ai2/augusta-google-1 \
        --cluster ai2/saturn-cirrascale \


### PR DESCRIPTION
Before this PR, we saw lots of annoying warnings like this: 

```
2025-07-24T13:32:07.377Z (LLMRayActor pid=21608) /stage/.venv/lib/python3.12/site-packages/torch/utils/cpp_extension.py:2356: UserWarning: TORCH_CUDA_ARCH_LIST is not set, all archs for visible cards are included for compilation. 
2025-07-24T13:32:07.377Z (LLMRayActor pid=21608) If this is not desired, please set os.environ['TORCH_CUDA_ARCH_LIST'].
```
Now they're gone, as we set `TORCH_CUDA_ARCH_LIST` through to Ray. We are able to guarantee the correct value for `TORCH_CUDA_ARCH_LIST` as the main process loads torch.

[Example successful Beaker run without logs](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K1BCJ07WJ994BQB2SNM85FZ4?taskId=01K1BCJ083ZTSAB5NEDVBXBW91&jobId=01K1BCJ0BQ89BGB2R3A7B5F6X6).

