### PR TITLE
fix: chat template kwarg in save_with_accelerate

### DIFF
--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -988,7 +988,9 @@ def main(args: FlatArguments, tc: TokenizerConfig):
             accelerator.wait_for_everyone()
 
     if args.output_dir is not None:
-        save_with_accelerate(accelerator, model, tokenizer, args.output_dir, args.use_lora, tc.chat_template_name)
+        save_with_accelerate(
+            accelerator, model, tokenizer, args.output_dir, args.use_lora, chat_template_name=tc.chat_template_name
+        )
 
     # remove all checkpoints to save space
     if accelerator.is_local_main_process:

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -974,7 +974,9 @@ def main(args: FlatArguments, tc: TokenizerConfig):
             accelerator.wait_for_everyone()
 
     if args.output_dir is not None:
-        save_with_accelerate(accelerator, model, tokenizer, args.output_dir, args.use_lora, tc.chat_template_name)
+        save_with_accelerate(
+            accelerator, model, tokenizer, args.output_dir, args.use_lora, chat_template_name=tc.chat_template_name
+        )
 
     # remove all checkpoints to save space
     if args.clean_checkpoints_at_end and accelerator.is_local_main_process:

--- a/open_instruct/reward_modeling.py
+++ b/open_instruct/reward_modeling.py
@@ -424,7 +424,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig):
 
     # save model
     os.makedirs(os.path.dirname(args.output_dir), exist_ok=True)
-    save_with_accelerate(accelerator, model, tokenizer, args.output_dir, tc.chat_template_name)
+    save_with_accelerate(accelerator, model, tokenizer, args.output_dir, chat_template_name=tc.chat_template_name)
     if args.push_to_hub:
         push_folder_to_hub(accelerator, args.output_dir, args.hf_repo_id, args.hf_repo_revision)
 


### PR DESCRIPTION
The `chat_template_name` arg in `save_with_accelerate` is currently passed in as the `model_attribute_to_save` positional arg. This PR fixes this by using the explicit kwarg. 

CC @hamishivi 