### PR TITLE
Makes pytest ignore oe-eval-internal.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,10 @@ dev = [
 	"parameterized>=0.9.0",
 ]
 
+[tool.pytest.ini_options]
+addopts = "--ignore=oe-eval-internal/"
+
+
 [tool.black]
 line-length = 119
 target-version = ['py310']


### PR DESCRIPTION
Currently, especially when running locally, we get a bunch of spurious errors due to `oe-eval-internal` being present.