### PR TITLE
remove_non_tensor_columns

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -44,6 +44,7 @@ import copy
 import hashlib
 import json
 import multiprocessing
+import warnings
 import os
 from dataclasses import asdict, dataclass, field
 from functools import cached_property
@@ -1819,6 +1820,13 @@ def get_cached_dataset_tulu(
         dataset_skip_cache,
         return_statistics=False,
     )[0]
+
+
+def remove_non_tensor_columns(dataset: Dataset) -> Dataset:
+    example = dataset[0]
+    cols_to_remove = [k for k, v in example.items() if not torch.is_tensor(v)]
+    warnings.warn(f"Removing non-tensor dataset colums {cols_to_remove}", stacklevel=1)
+    return dataset.remove_columns(cols_to_remove)
 
 
 def test_sft_dpo_same_tokenizer():

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -66,6 +66,7 @@ from open_instruct.dataset_transformation import (
     TokenizerConfig,
     get_cached_dataset_tulu,
     visualize_token,
+    remove_non_tensor_columns
 )
 from open_instruct.dpo_utils import (
     DataCollatorForSeq2SeqDPO,
@@ -692,6 +693,9 @@ def main(args: FlatArguments, tc: TokenizerConfig):
     else:
         collate_fn = DataCollatorForSeq2SeqDPO(tokenizer=tokenizer, model=model, padding="longest")
 
+    # The collators expect to act on tensor data, so remove any non-tensor entries now. The
+    # non-tensor entries are assumed to be non-crucial metadata like `DATASET_ORIGIN_KEY`
+    train_dataset = remove_non_tensor_columns(train_dataset)
     train_dataloader = DataLoader(
         train_dataset, shuffle=True, collate_fn=collate_fn, batch_size=args.per_device_train_batch_size
     )

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -57,7 +57,8 @@ from open_instruct.dataset_transformation import (
     TOKENIZED_SFT_DATASET_KEYS,
     TokenizerConfig,
     get_cached_dataset_tulu,
-    visualize_token,
+    visualize_token_label,
+    remove_non_tensor_columns
 )
 from open_instruct.model_utils import push_folder_to_hub, save_with_accelerate
 from open_instruct.padding_free_collator import TensorDataCollatorWithFlattening
@@ -620,6 +621,9 @@ def main(args: FlatArguments, tc: TokenizerConfig):
         collate_fn = DataCollatorForSeq2Seq(tokenizer=tokenizer, model=model, padding="longest")
 
     accelerator.print("Creating dataloader")
+    # The collators expect to act on tensor data, so remove any non-tensor entries now. The
+    # non-tensor entries are assumed to be non-crucial metadata like `DATASET_ORIGIN_KEY`
+    train_dataset = remove_non_tensor_columns(train_dataset)
     train_dataloader = DataLoader(
         train_dataset, shuffle=True, collate_fn=collate_fn, batch_size=args.per_device_train_batch_size
     )


### PR DESCRIPTION
In https://github.com/allenai/open-instruct/pull/765 additional string metadata was added to the dataset which conflicts with the application of the `DataCollatorForSeq2Seq` collator function, which expects only tensor data.   This makes `finetune.py` fail (when `--packing False`) with errors like:
```
Traceback (most recent call last):
  File "/proj/data-eng/swanand/sft_dpo/venv_sft_dpo/venv/venv_sft_dpo/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 767, in convert_to_tensors
    tensor = as_tensor(value)
  File "/proj/data-eng/swanand/sft_dpo/venv_sft_dpo/venv/venv_sft_dpo/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 729, in as_tensor
    return torch.tensor(value)
ValueError: too many dimensions 'str'
```
This error arises when trying to create a tensor from a list of strings, e.g. `torch.tensor(["hello"])`. 

This PR adds a utility for filtering non-tensor columns out of the dataset before using and uses the filter in both the sft and dpo scripts.

CC @hamishivi @jacob-morrison 

The issue specifically is the addition of the `DATASET_ORIGIN_KEY` [metadata here](https://github.com/garrett361/open-instruct/blob/a730b24f0c5929a69f3bb5116343e405fe4f76df/open_instruct/dataset_transformation.py?plain=1#L1459-L1463). 

I believe this wrapper is only needed for `finetune.py` and `dpo_cache_tune.py`, and not needed for `reward_modeling.py` or `reward_modeling_eval.py`, but have only tested `finetune.py` with these fixed e2e. 