### PR TITLE
Minor fix to scripts.

### DIFF
--- a/scripts/train/build_image_and_launch.sh
+++ b/scripts/train/build_image_and_launch.sh
@@ -15,7 +15,8 @@ docker build \
 
 beaker_user=$(beaker account whoami --format json | jq -r '.[0].name')
 
-beaker image rename $beaker_user/$image_name ""
+
+beaker image rename $beaker_user/$image_name "" || echo "Image not found, skipping rename."
 
 # Create the image in the same workspace used for jobs
 beaker image create $image_name -n $image_name -w ai2/$beaker_user


### PR DESCRIPTION
Fixes two issues:

1. `run_single_gpu.sh` wasn't properly accepting the image name argument.
2. Renaming would fail if the image didn't exist.