### PR TITLE
Adds pytest-xdist for parallel tests, and only installs needed deps for quality.

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -26,4 +26,7 @@ jobs:
       - name: Install dependencies
         run: uv sync --only-group dev
       - name: Code quality
-        run: make style-check && make quality-check
+        run: |
+          ruff format --check --diff open_instruct
+          ruff check --exit-non-zero-on-fix open_instruct
+        

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -27,6 +27,7 @@ jobs:
         run: uv sync --only-group dev
       - name: Code quality
         run: |
+          source .venv/bin/activate
           ruff format --check --diff open_instruct
           ruff check --exit-non-zero-on-fix open_instruct
         

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Set up Python
         run: uv python install 3.10
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --only-group dev
       - name: Code quality
         run: make style-check && make quality-check

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Set up Python
         run: uv python install
       - name: Run unit tests
-        run: uv run pytest
+        run: uv run pytest -n auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "vllm==0.9.1",    
     "wandb==0.18.1",
     "langdetect==1.0.9",
-    "immutabledict==1.2.0"
+    "immutabledict==1.2.0",
+    "pytest-xdist==3.8.0",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -831,6 +831,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524, upload-time = "2024-04-08T09:04:19.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612, upload-time = "2024-04-08T09:04:17.414Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.115.12"
 source = { registry = "https://pypi.org/simple" }
@@ -2359,6 +2368,7 @@ dependencies = [
     { name = "nvitop" },
     { name = "packaging" },
     { name = "peft" },
+    { name = "pytest-xdist" },
     { name = "ray", extra = ["default"] },
     { name = "setuptools" },
     { name = "tensorboard" },
@@ -2396,6 +2406,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "parameterized" },
     { name = "pytest" },
+    { name = "rich" },
     { name = "ruff" },
 ]
 
@@ -2423,6 +2434,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=24.2" },
     { name = "peft", specifier = ">=0.13.2" },
     { name = "pydantic", marker = "extra == 'code'", specifier = ">=2.0.0" },
+    { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "ray", extras = ["default"], specifier = ">=2.44.1" },
     { name = "requests", marker = "extra == 'code'", specifier = ">=2.28.0" },
     { name = "setuptools", specifier = ">=75.6.0,<80.0.0" },
@@ -2447,6 +2459,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.6.8" },
     { name = "parameterized", specifier = ">=0.9.0" },
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
 
@@ -3245,6 +3258,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6", size = 1515232, upload-time = "2025-06-02T17:36:30.03Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e", size = 363797, upload-time = "2025-06-02T17:36:27.859Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Incremental quality of life improvement to the checks:

- Installing dependencies for `quality` goes from 1m to 10s ([quality runs](https://github.com/allenai/open-instruct/actions/workflows/quality.yml))
- Tests go from 4m to 3m ([test runs](https://github.com/allenai/open-instruct/actions/workflows/tests.yml)).