### PR TITLE
Fixing dataset statistics

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -902,7 +902,7 @@ TOKENIZED_SFT_DATASET_KEYS = [INPUT_IDS_KEY, ATTENTION_MASK_KEY, LABELS_KEY]
 TOKENIZED_SFT_DATASET_KEYS_WITH_SOURCE = [INPUT_IDS_KEY, ATTENTION_MASK_KEY, LABELS_KEY, DATASET_ORIGIN_KEY]
 
 
-def _remove_dataset_source_field(dataset: Dataset) -> Dataset:
+def remove_dataset_source_field(dataset: Dataset) -> Dataset:
     """Remove dataset_source field from dataset if it exists.
 
     This should be called after statistics collection but before returning
@@ -1734,6 +1734,7 @@ def get_cached_dataset_tulu_with_statistics(
     hf_entity: Optional[str] = None,
     dataset_local_cache_dir: str = "local_dataset_cache",
     dataset_skip_cache: bool = False,
+    drop_dataset_source: bool = True,
 ) -> Union[Dataset, Tuple[Dataset, Dict[str, Any]]]:
     dcs = []
     if dataset_config_hash is None:
@@ -1789,7 +1790,10 @@ def get_cached_dataset_tulu_with_statistics(
 
     dataset, statistics = cache.load_or_transform_dataset(dcs, tc, dataset_skip_cache=dataset_skip_cache)
 
-    return _remove_dataset_source_field(dataset), statistics
+    if drop_dataset_source:
+        dataset = remove_dataset_source_field(dataset)
+
+    return dataset, statistics
 
 
 def get_cached_dataset_tulu(

--- a/scripts/data/convert_sft_data_for_olmocore.py
+++ b/scripts/data/convert_sft_data_for_olmocore.py
@@ -55,6 +55,7 @@ from open_instruct.dataset_transformation import (
     TOKENIZED_SFT_DATASET_KEYS_WITH_SOURCE,
     TokenizerConfig,
     get_cached_dataset_tulu_with_statistics,
+    remove_dataset_source_field,
     visualize_token,
 )
 from open_instruct.utils import ArgumentParserPlus, is_beaker_job
@@ -172,6 +173,7 @@ def main(args: ConvertSFTDataArguments, tc: TokenizerConfig):
         dataset_config_hash=args.dataset_config_hash,
         dataset_local_cache_dir=args.dataset_local_cache_dir,
         dataset_skip_cache=args.dataset_skip_cache,
+        drop_dataset_source=False,
     )
 
     train_dataset = train_dataset.shuffle()
@@ -240,6 +242,8 @@ def main(args: ConvertSFTDataArguments, tc: TokenizerConfig):
         assert all(mask == 1 for mask in sample[ATTENTION_MASK_KEY]), (
             f"Expected all attention mask values to be 1, but found: {sample[ATTENTION_MASK_KEY]}"
         )
+    
+    train_dataset = remove_dataset_source_field(train_dataset)
 
     # Calculate final statistics
     total_instances = len(train_dataset)


### PR DESCRIPTION
Accidentally deleted dataset source too early. Now we optionally delete the dataset source during data mixing, and save it for the tokenization script, where it's then deleted after tokenization.

Example:

`python scripts/data/convert_sft_data_for_olmocore.py --dataset_mixer_list finbarr/tulu-3-sft-personas-instruction-following-o3 5000 ai2-adapt-dev/tulu_v3.9_synthetic_finalresp_wildguardmixtrain_decontaminated_50k 1000 ai2-adapt-dev/tulu_v3.9_table_gpt_5k 500 --tokenizer_name_or_path /weka/oe-training-default/ai2-llm/checkpoints/dustins/lc_7b_cont_pretrain_final_anneal/step11921-hf --output_dir /weka/oe-training-default/ai2-llm/jacobm/data/sft/usable-tulu-16k/test-dataset-statistics-1 --visualize True --chat_template_name olmo --max_seq_length 16384 `

Dataset statistics (text file):

(miniconda3-3.9-24.1.2-0/envs/open-instruct) [beaker] root /weka/oe-adapt-default/jacobm/open-instruct $ cat  /weka/oe-training-default/ai2-llm/jacobm/data/sft/usable-tulu-16k/test-dataset-statistics-1/dataset_statistics.txt
Dataset Statistics Report
================================================================================
Generated: 2025-07-29 23:54:27
Output Directory: /weka/oe-training-default/ai2-llm/jacobm/data/sft/usable-tulu-16k/test-dataset-statistics-1

Configuration:
----------------------------------------
- Tokenizer: /weka/oe-training-default/ai2-llm/checkpoints/dustins/lc_7b_cont_pretrain_final_anneal/step11921-hf
- Max Sequence Length: 16384
- Chat Template: olmo

Per-Dataset Statistics:
================================================================================

Dataset: finbarr/tulu-3-sft-personas-instruction-following-o3
- Split: train

Pre-transformation:
  - Instances loaded: 5000
  - Instances after transformation: 5000
  - Instances filtered during transformation: 0
  - Sample count: 5000

Final output statistics (after shuffling):
  - Instances in output: 5,000
  - Total tokens: 2,918,369
  - Trainable tokens: 2,264,027
  - Instances with no labels: 0
  - Average tokens per instance: 583.7
  - Percentage of total tokens: 80.9%
  - Percentage of total instances: 76.9%

Dataset: ai2-adapt-dev/tulu_v3.9_table_gpt_5k
- Split: train

Pre-transformation:
  - Instances loaded: 500
  - Instances after transformation: 500
  - Instances filtered during transformation: 0
  - Sample count: 500

Final output statistics (after shuffling):
  - Instances in output: 500
  - Total tokens: 433,417
  - Trainable tokens: 38,144
  - Instances with no labels: 0
  - Average tokens per instance: 866.8
  - Percentage of total tokens: 12.0%
  - Percentage of total instances: 7.7%

Dataset: ai2-adapt-dev/tulu_v3.9_synthetic_finalresp_wildguardmixtrain_decontaminated_50k
- Split: train

Pre-transformation:
  - Instances loaded: 1000
  - Instances after transformation: 1000
  - Instances filtered during transformation: 0
  - Sample count: 1000

Final output statistics (after shuffling):
  - Instances in output: 1,000
  - Total tokens: 255,236
  - Trainable tokens: 86,769
  - Instances with no labels: 0
  - Average tokens per instance: 255.2
  - Percentage of total tokens: 7.1%
  - Percentage of total instances: 15.4%

================================================================================
Overall Statistics:
================================================================================
- Total datasets: 3
- Total instances: 6,500
- Total tokens: 3,607,022
- Trainable tokens: 2,388,940 (66.2%)
- Instances filtered out: 0
- Average sequence length: 554.9

Json:

(miniconda3-3.9-24.1.2-0/envs/open-instruct) [beaker] root /weka/oe-adapt-default/jacobm/open-instruct $ cat  /weka/oe-training-default/ai2-llm/jacobm/data/sft/usable-tulu-16k/test-dataset-statistics-1/dataset_statistics.json
{
  "timestamp": "2025-07-29 23:54:27",
  "output_directory": "/weka/oe-training-default/ai2-llm/jacobm/data/sft/usable-tulu-16k/test-dataset-statistics-1",
  "configuration": {
    "tokenizer": "/weka/oe-training-default/ai2-llm/checkpoints/dustins/lc_7b_cont_pretrain_final_anneal/step11921-hf",
    "max_sequence_length": 16384,
    "chat_template": "olmo"
  },
  "per_dataset_statistics": [
    {
      "dataset_name": "finbarr/tulu-3-sft-personas-instruction-following-o3",
      "dataset_split": "train",
      "initial_instances": 5000,
      "instances_after_transformation": 5000,
      "instances_filtered_during_transformation": 0,
      "frac_or_num_samples": 5000,
      "original_dataset_size": 29930,
      "is_upsampled": false,
      "upsampling_factor": 0.1670564650851988,
      "final_instances_in_output": 5000,
      "final_tokens_in_output": 2918369,
      "final_trainable_tokens_in_output": 2264027,
      "instances_filtered_after_tokenization": 0,
      "avg_tokens_per_instance": 583.6738,
      "percentage_of_total_tokens": 80.90799002612127,
      "percentage_of_total_instances": 76.92307692307693
    },
    {
      "dataset_name": "ai2-adapt-dev/tulu_v3.9_table_gpt_5k",
      "dataset_split": "train",
      "initial_instances": 500,
      "instances_after_transformation": 500,
      "instances_filtered_during_transformation": 0,
      "frac_or_num_samples": 500,
      "original_dataset_size": 5000,
      "is_upsampled": false,
      "upsampling_factor": 0.1,
      "final_instances_in_output": 500,
      "final_tokens_in_output": 433417,
      "final_trainable_tokens_in_output": 38144,
      "instances_filtered_after_tokenization": 0,
      "avg_tokens_per_instance": 866.834,
      "percentage_of_total_tokens": 12.015923384997375,
      "percentage_of_total_instances": 7.6923076923076925
    },
    {
      "dataset_name": "ai2-adapt-dev/tulu_v3.9_synthetic_finalresp_wildguardmixtrain_decontaminated_50k",
      "dataset_split": "train",
      "initial_instances": 1000,
      "instances_after_transformation": 1000,
      "instances_filtered_during_transformation": 0,
      "frac_or_num_samples": 1000,
      "original_dataset_size": 50000,
      "is_upsampled": false,
      "upsampling_factor": 0.02,
      "final_instances_in_output": 1000,
      "final_tokens_in_output": 255236,
      "final_trainable_tokens_in_output": 86769,
      "instances_filtered_after_tokenization": 0,
      "avg_tokens_per_instance": 255.236,
      "percentage_of_total_tokens": 7.0760865888813544,
      "percentage_of_total_instances": 15.384615384615385
    }
  ],
  "overall_statistics": {
    "total_datasets": 3,
    "total_instances": 6500,
    "total_tokens": 3607022,
    "trainable_tokens": 2388940,
    "trainable_percentage": 66.23025864549759,
    "instances_filtered": 0,
    "average_sequence_length": 554.9264615384616
  }
}

Confirmed it doesn't break SFT: https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K1CA1TPNYC4BY93987VEGN45?taskId=01K1CA1TPWPZQN5HDXD4XT87CF&jobId=01K1CA1TTV7YYPBA4M565199NH or GRPO fast: https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K1CGYZZ1TWHFJ3VHJNV8XD1D?taskId=01K1CGYZZ5KJ6YRX2T5GRX9YBA&jobId=01K1CGZ02SF7BT67TB2YWX1WJD