### PR TITLE
Update beaker-experiment.yml

### DIFF
--- a/.github/workflows/beaker-experiment.yml
+++ b/.github/workflows/beaker-experiment.yml
@@ -5,6 +5,7 @@ on:
     # Run this workflow anytime a push updates one of the files in the image's directory
     # (other than the README), and anytime there's a new release tag for this image.
     paths:
+      - 'mason.py'
       - 'open_instruct/**'
       - '!open_instruct/README.md'
       - 'requirements.txt'


### PR DESCRIPTION
Make sure that the beaker-experiment integration test also runs when you update `mason.py` as that could easily break things. 

E.g. we missed running when #849 was merged because changes to `mason.py` don't trigger the check. 