### PR TITLE
Adds git hash to description.

### DIFF
--- a/.github/actions/push/action.yaml
+++ b/.github/actions/push/action.yaml
@@ -22,8 +22,13 @@ runs:
       run: |
         # Push release to Beaker.
         SHORT_SHA=$(git rev-parse --short HEAD)
-        beaker image create --name "${{ inputs.beaker }}-${SHORT_SHA}-${{ github.run_id }}" ${{ inputs.image }}
+        DESCRIPTION="Created from commit: ${SHORT_SHA}"
+        beaker image create \
+               --name "${{ inputs.beaker }}-${SHORT_SHA}-${{ github.run_id }}" ${{ inputs.image }} \
+               --description "$DESCRIPTION"
         # We can't delete the old image because it might be used by a running job. Instead, we rename it to an empty 
         # string, so it will not be resolved by the Beaker client.
         beaker image rename nathanl/${{ inputs.beaker }} "" || true
-        beaker image create --name ${{ inputs.beaker }} ${{ inputs.image }}
+        beaker image create \
+               --name ${{ inputs.beaker }} ${{ inputs.image }} \
+               --description "$DESCRIPTION"


### PR DESCRIPTION
Right now, it's non-trivial (impossible?) to find the exact commit used to create an image. Now, we add a description containing that info. 

