### PR TITLE
Update logging in accumulate_inference_batches

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1235,6 +1235,7 @@ def accumulate_inference_batches(
         total=args.vllm_num_engines,
         desc=f"Accumulating results from {args.vllm_num_engines} engines ({timeout=})",
         bar_format="{l_bar}{bar}{r_bar}\n",
+        miniters=1,
     ):
         result = inference_results_Q.get(timeout=timeout)
         dataset_indices = result.dataset_index


### PR DESCRIPTION
Only lets accumulate_inference_batches update when there's at least one iteration done.