### PR TITLE
Fix build by syncing all deps, not just dev.

### DIFF
--- a/.github/workflows/beaker-experiment.yml
+++ b/.github/workflows/beaker-experiment.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Install development dependencies needed for mason.py
-          uv sync --only-group dev
+          uv sync
 
       - name: Delete huge unnecessary tools folder
         run: |

--- a/scripts/train/build_image_and_launch.sh
+++ b/scripts/train/build_image_and_launch.sh
@@ -30,7 +30,7 @@ fi
 
 # Install Python dependencies
 echo "Installing dependencies with uv..."
-uv sync --only-group dev
+uv sync
 
 # Run the provided script
 bash $1 "$beaker_user/$image_name"


### PR DESCRIPTION
Currently, launching the integration test is [broken](https://github.com/allenai/open-instruct/actions/runs/16840175524/job/47709272608) as we only sync the `dev` deps. 

Now, that is fixed: [successful run](https://github.com/allenai/open-instruct/actions/runs/16882913620).