### PR TITLE
Switches `data_preparation_thread` to use a sentinel for shutdown instead of `stop_event`.

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -152,8 +152,6 @@ INVALID_LOGPROB = 1.0
 class ShutdownSentinel:
     """Sentinel value to signal thread shutdown via queue."""
 
-    pass
-
 
 @dataclass
 class Args:


### PR DESCRIPTION
The origins of the long, sordid tale of trying to figure out how to shut down our threads properly is lost to the mists of time, but an [earlier PR tried to use Threadpool Executor to shut all the threads down](https://github.com/allenai/open-instruct/pull/856). That PR introduced [a bug](https://allenai.slack.com/archives/C08A1L22QMQ/p1754660975264979), which was [fixed in a recent PR that increased the timeout](https://github.com/allenai/open-instruct/pull/869). 

This PR switches to use a sentinel to shut the thread down, avoiding the nasty try-except loop.

Experiments: 

1. ✅ Single GPU: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K2DEWVYWA762WDJCKTJZT263?taskId=01K2DEWVZ3T5R7X8CVY683KR85&jobId=01K2DEWW2TFA0J3GPRETKPGDSJ)
2. ✅ Multi GPU: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/oe-adapt-code/work/01K2DBMHJ918NYB6V0B5X0D32S?), [Wandb](https://wandb.ai/ai2-llm/open_instruct_internal/runs/rcqy2tuu?nw=nwuserfinbarrt)