### PR TITLE
Hf transformers <4.54.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "setuptools>=75.6.0,<80.0.0",
     "tensorboard>=2.18.0",
     "torch==2.7.0",
-    "transformers>=4.52.4",
+    "transformers>=4.52.4,<4.54.0", # see https://github.com/vllm-project/vllm-ascend/issues/2046
     "vllm==0.9.1",    
     "wandb==0.18.1",
     "langdetect==1.0.9",

--- a/uv.lock
+++ b/uv.lock
@@ -2435,7 +2435,7 @@ requires-dist = [
     { name = "tensorboard", specifier = ">=2.18.0" },
     { name = "torch", marker = "sys_platform != 'darwin'", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torch", marker = "sys_platform == 'darwin'", specifier = "==2.7.0" },
-    { name = "transformers", specifier = ">=4.52.4" },
+    { name = "transformers", specifier = ">=4.52.4,<4.54.0" },
     { name = "uvicorn", marker = "extra == 'code'", specifier = ">=0.20.0" },
     { name = "vllm", specifier = "==0.9.1" },
     { name = "wandb", specifier = "==0.18.1" },


### PR DESCRIPTION
Pin to < 4.54.0 due to ongoing vllm issue, see https://github.com/vllm-project/vllm-ascend/issues/2046
We should upgrade when we next upgrade vllm!