### PR TITLE
Fix crash for debug script

### DIFF
--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -977,7 +977,7 @@ def maybe_update_beaker_description_with_wandb_url(wandb_url: str) -> None:
         spec = client.experiment.get(os.environ["BEAKER_WORKLOAD_ID"])
     except beaker.exceptions.ExperimentNotFound:
         print(f"Failed to update Beaker experiment description with wandb URL: {wandb_url}")
-        print("This might be fine if you are e.g. running in an interactive job.")
+        logger.warning("This might be fine if you are e.g. running in an interactive job.")
         return
     current_description = spec.description or ""
     client.experiment.set_description(os.environ["BEAKER_WORKLOAD_ID"], f"{current_description}\n{wandb_url}")

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -977,7 +977,7 @@ def maybe_update_beaker_description_with_wandb_url(wandb_url: str) -> None:
         spec = client.experiment.get(os.environ["BEAKER_WORKLOAD_ID"])
     except beaker.exceptions.ExperimentNotFound:
         print(f"Failed to update Beaker experiment description with wandb URL: {wandb_url}")
-        print(f"This might be fine if you are e.g. running in an interactive job.")
+        print("This might be fine if you are e.g. running in an interactive job.")
         return
     current_description = spec.description or ""
     client.experiment.set_description(os.environ["BEAKER_WORKLOAD_ID"], f"{current_description}\n{wandb_url}")

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -976,7 +976,7 @@ def maybe_update_beaker_description_with_wandb_url(wandb_url: str) -> None:
     try:
         spec = client.experiment.get(os.environ["BEAKER_WORKLOAD_ID"])
     except beaker.exceptions.ExperimentNotFound:
-        print(f"Failed to update Beaker experiment description with wandb URL: {wandb_url}")
+        logger.warning(f"Failed to update Beaker experiment description with wandb URL: {wandb_url}")
         logger.warning("This might be fine if you are e.g. running in an interactive job.")
         return
     current_description = spec.description or ""

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -973,13 +973,14 @@ def maybe_update_beaker_description_with_wandb_url(wandb_url: str) -> None:
         return
 
     client = beaker.Beaker.from_env()
-    spec = client.experiment.get(os.environ["BEAKER_WORKLOAD_ID"])
-    current_description = spec.description or ""
     try:
-        client.experiment.set_description(os.environ["BEAKER_WORKLOAD_ID"], f"{current_description}\n{wandb_url}")
-    except requests.exceptions.HTTPError:
+        spec = client.experiment.get(os.environ["BEAKER_WORKLOAD_ID"])
+    except beaker.exceptions.ExperimentNotFound:
         print(f"Failed to update Beaker experiment description with wandb URL: {wandb_url}")
         print(f"This might be fine if you are e.g. running in an interactive job.")
+        return
+    current_description = spec.description or ""
+    client.experiment.set_description(os.environ["BEAKER_WORKLOAD_ID"], f"{current_description}\n{wandb_url}")
 
 
 def live_subprocess_output(cmd: List[str]) -> str:

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -975,7 +975,11 @@ def maybe_update_beaker_description_with_wandb_url(wandb_url: str) -> None:
     client = beaker.Beaker.from_env()
     spec = client.experiment.get(os.environ["BEAKER_WORKLOAD_ID"])
     current_description = spec.description or ""
-    client.experiment.set_description(os.environ["BEAKER_WORKLOAD_ID"], f"{current_description}\n{wandb_url}")
+    try:
+        client.experiment.set_description(os.environ["BEAKER_WORKLOAD_ID"], f"{current_description}\n{wandb_url}")
+    except requests.exceptions.HTTPError:
+        print(f"Failed to update Beaker experiment description with wandb URL: {wandb_url}")
+        print(f"This might be fine if you are e.g. running in an interactive job.")
 
 
 def live_subprocess_output(cmd: List[str]) -> str:


### PR DESCRIPTION
In an interactive session, we can't find the experiment (I think because it requires a diff search) and the run crashes. This prevents that. Broke in #889 since there the beaker client searches for the experiment without a try-except guard.