### PR TITLE
add back global_step to maintain backwards compatibility

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1968,6 +1968,7 @@ def one_training_step(
         average_metrics = {k: sum(m[k] for m in metrics_list) / len(metrics_list) for k in metrics_list[0]}
         metrics = {
             "episode": episode,
+            "global_step": episode,
             "training_step": training_step,
             "val/num_total_tokens": num_total_tokens,
             "epoch": episode / args.num_samples_per_prompt_rollout / len(train_dataset),


### PR DESCRIPTION
previously we used "global_step" as our x axis in wandb this adds it back for backwards compatibility