### PR TITLE
Adds --frozen flag to all calls to uv in CI.

### DIFF
--- a/.github/workflows/beaker-experiment.yml
+++ b/.github/workflows/beaker-experiment.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install dependencies
         run: |
           # Install development dependencies needed for mason.py
-          uv sync
+          uv sync --frozen
 
       - name: Delete huge unnecessary tools folder
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         run: uv python install 3.10
       - name: Install dependencies
-        run: uv sync --only-group dev
+        run: uv sync --frozen --only-group dev
       - name: Code quality
         run: |
           source .venv/bin/activate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,6 +87,6 @@ jobs:
         with:
           version: "0.8.6"
       - name: Set up Python
-        run: uv sync
+        run: uv sync --frozen
       - name: Run unit tests
-        run: uv run pytest -n auto
+        run: uv run --frozen pytest -n auto


### PR DESCRIPTION
`--frozen` makes sure that we only use the dependencies in the lock file, ensuring a reproducible build. It doesn't check if the lock file is up to date (`--locked` does that).