### PR TITLE
Increase backend timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ We use [uv](https://docs.astral.sh/uv/) for installation and running code. You c
 ```bash
 docker build . \
     --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) \
-	--build-arg GIT_BRANCH=$(git rev-parse abbrev-ref HEAD) \
+	--build-arg GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
 	-t open_instruct_dev
 
 # if you are internally at AI2, you can create a beaker image like this:

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -563,7 +563,8 @@ class PolicyTrainerRayProcess(RayProcess):
         self.wandb_url = wandb_url
         torch.cuda.set_device(self.local_rank)
         self.device = torch.device(self.local_rank)
-        deepspeed.init_distributed()
+        from datetime import timedelta
+        deepspeed.init_distributed(timeout=timedelta(hours=2))
 
         ds_config = get_train_ds_config(offload=False, adam_offload=False, stage=args.deepspeed_stage, bf16=True)
         ds_config["train_micro_batch_size_per_gpu"] = args.per_device_train_batch_size

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2161,9 +2161,10 @@ def maybe_evaluate(
             "eval/sequence_lengths_min": eval_sequence_lengths.min(),
             "eval/sequence_lengths_max": eval_sequence_lengths.max(),
             "eval/stop_rate": eval_stop_rate,
-            "eval/generation_time": eval_generate_metrics["time/generation"],
             **eval_reward_metrics,
         }
+        if "time/generation" in eval_generate_metrics:
+            eval_metrics["eval/generation_time"] = eval_generate_metrics["time/generation"]
         print_rich_single_line_metrics(eval_metrics)
 
         table = {}

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2132,6 +2132,7 @@ def maybe_evaluate(
 
         logger.info("[Main Thread] 📊 Evaluation responses received")
 
+        eval_generate_metrics = {}
         try:
             eval_generate_metrics = generate_metrics_Q.get_nowait()
         except Empty:

--- a/open_instruct/search_utils/search_actor.py
+++ b/open_instruct/search_utils/search_actor.py
@@ -196,11 +196,11 @@ class LLMSearchRayActor:
         return generation_outputs
 
     def init_process_group(
-        self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray=False
+        self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray=False, timeout=120
     ):
         return self.llm.collective_rpc(
             "init_process_group",
-            args=(master_address, master_port, rank_offset, world_size, group_name, backend, use_ray),
+            args=(master_address, master_port, rank_offset, world_size, group_name, backend, use_ray, timeout),
         )
 
     def update_weight(self, name, dtype, shape, empty_cache=False):

--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -90,8 +90,7 @@ def init_process_group(
         backend = Backend("undefined")
 
     if timeout is None:
-        # timeout = default_pg_timeout
-        timeout = timedelta(hours=2)
+        timeout = default_pg_timeout
 
     # backward compatible API
     if store is None:
@@ -244,11 +243,11 @@ class LLMRayActor:
         )
 
     def init_process_group(
-        self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray=False
+        self, master_address, master_port, rank_offset, world_size, group_name, backend, use_ray=False, timeout=120
     ):
         return self.llm.collective_rpc(
             "init_process_group",
-            args=(master_address, master_port, rank_offset, world_size, group_name, backend, use_ray),
+            args=(master_address, master_port, rank_offset, world_size, group_name, backend, use_ray, timeout),
         )
 
     def update_weight(self, name, dtype, shape, empty_cache=False):

--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -90,7 +90,8 @@ def init_process_group(
         backend = Backend("undefined")
 
     if timeout is None:
-        timeout = default_pg_timeout
+        # timeout = default_pg_timeout
+        timeout = timedelta(hours=2)
 
     # backward compatible API
     if store is None:

--- a/open_instruct/vllm_utils_workerwrap.py
+++ b/open_instruct/vllm_utils_workerwrap.py
@@ -1,6 +1,14 @@
 class WorkerWrap:
     def init_process_group(
-        self, master_address, master_port, rank_offset, world_size, group_name, backend="nccl", use_ray=False, timeout=120
+        self,
+        master_address,
+        master_port,
+        rank_offset,
+        world_size,
+        group_name,
+        backend="nccl",
+        use_ray=False,
+        timeout=120,
     ):
         """Init torch process group for model weights update"""
         from datetime import timedelta

--- a/open_instruct/vllm_utils_workerwrap.py
+++ b/open_instruct/vllm_utils_workerwrap.py
@@ -1,8 +1,9 @@
 class WorkerWrap:
     def init_process_group(
-        self, master_address, master_port, rank_offset, world_size, group_name, backend="nccl", use_ray=False
+        self, master_address, master_port, rank_offset, world_size, group_name, backend="nccl", use_ray=False, timeout=120
     ):
         """Init torch process group for model weights update"""
+        from datetime import timedelta
         import torch
 
         from open_instruct.vllm_utils3 import init_process_group
@@ -25,6 +26,7 @@ class WorkerWrap:
                 world_size=world_size,
                 rank=rank,
                 group_name=group_name,
+                timeout=timedelta(minutes=timeout),
             )
         self._model_update_with_ray = use_ray
         print(

--- a/scripts/train/debug/grpo_fast.sh
+++ b/scripts/train/debug/grpo_fast.sh
@@ -32,4 +32,5 @@ uv run python open_instruct/grpo_fast.py \
     --vllm_enforce_eager \
     --gradient_checkpointing \
     --single_gpu_mode \
+    --push_to_hub false \
     # --with_tracking


### PR DESCRIPTION
We've had these issues with OLMo 2 LC SFT experiments crashing. It seems that this is due to generation taking longer than the default NCCL timeouts. For example, you can see in [these](https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K2P9F05PK36D51KA3HGXAEA0?taskId=01K2P9F05TCXW792QFSZ1KKKWN&jobId=01K2P9F0DVYXTJ7T9XD6XNP2NN) [jobs](https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K2P9HD5ZJRFWQ8XP85HWH9YG?taskId=01K2P9HD62QX6C7JKWBHC85K2K&jobId=01K2P9HDCARCM6T9T005SZHAD9) that when "🔥 Generation time" is over 30 minutes, we crash on the broadcast. The default NCCL timeout is 30 minutes.

This PR fixes this by just upping the default timeout for our process groups to 2 hours. It's also configurable via `backend_timeout` if you want to use a larger or smaller timeout.

Tests are [here](https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K2TDZRTKFBPXPH1SXNTXM5WG?taskId=01K2TDZRTTMQ5WG30QBS2WJEYY&jobId=01K2TDZRYT5AVY3FR0RHF2WRY2) and [here](https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K2TE0Y0G3AR4FD8KDPN0X4ZV?taskId=01K2TE0Y0PM1NRPP34PVECGB0Q&jobId=01K2TE0Y4CY8JZ8E2NAX46XJT1). We can see that we get generations that take over 30 minute and we don't crash!