### PR TITLE
Fixes open_instruct/grpo_fast.py so that when there's an error in the main thread, everything dies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,12 +60,14 @@ RUN curl --silent \
 COPY --from=ghcr.io/astral-sh/uv:0.8.6 /uv /uvx /bin/
 
 # Install Beaker Gantry user-wide in an isolated venv
-RUN uv tool install --no-cache-dir beaker-gantry
+RUN uv tool install --no-cache-dir beaker-gantry==3.0.0
 
 ENV UV_CACHE_DIR=/root/.cache/uv
 
 ENV HF_HUB_ENABLE_HF_TRANSFER=1
 ENV UV_COMPILE_BYTECODE=0
+
+WORKDIR /stage/
 
 # Copy only dependency-related files first
 COPY pyproject.toml uv.lock ./
@@ -77,8 +79,6 @@ RUN --mount=type=cache,target=${UV_CACHE_DIR} \
     uv sync --frozen --no-install-project --link-mode=copy
 
 RUN uv run -m nltk.downloader punkt punkt_tab
-
-WORKDIR /stage/
 
 # Copy all application code at the end
 COPY eval eval

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2579,7 +2579,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_sa
         )
     finally:
         cleanup_training_resources(
-            stop_event, executor, [inference_results_Q, param_prompt_Q, evaluation_inference_results_Q]
+            stop_event, executor, [inference_results_Q, param_prompt_Q, evaluation_inference_results_Q], actor_manager
         )
 
     # Ai2 logic: we use /output to store the artifacts of the job, so we

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2588,7 +2588,6 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_sa
 
     # Check for runtime leaks before exiting
     logger.info("Checking for runtime leaks...")
-    from open_instruct import utils
 
     leak_report = utils.check_runtime_leaks()
     if not leak_report.is_clean:

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2354,6 +2354,150 @@ def cleanup_training_resources(
     cleanup_judge_clients()
 
 
+def run_training(
+    args,
+    tokenizer,
+    train_dataset,
+    eval_batch,
+    policy_group,
+    vllm_engines,
+    generation_configs,
+    iter_dataloader,
+    reward_fn,
+    resume_training_step,
+    episode,
+    wandb_url,
+    tc,
+    stop_event,
+    executor,
+    inference_results_Q,
+    param_prompt_Q,
+    evaluation_inference_results_Q,
+    packed_sequences_Q,
+    pending_queries_map,
+    eval_pending_queries_map,
+    generate_metrics_Q,
+):
+    """Run the main training loop with worker threads."""
+    logger.info("======== ✅ data preparation thread starts =========")
+    packing_future = executor.submit(
+        data_preparation_thread,
+        reward_fn,
+        inference_results_Q,
+        packed_sequences_Q,
+        pending_queries_map,
+        args,
+        tokenizer,
+        args.num_training_steps,
+        generation_configs["train"],
+    )
+
+    logger.info("======== ✅ generation thread starts =========")
+    generation_future = executor.submit(
+        generate_thread,
+        vllm_engines,
+        args.local_eval_every,
+        args.num_training_steps,
+        resume_training_step,
+        stop_event,
+        generate_metrics_Q,
+    )
+
+    # Send initial data to ensure we have a N-step offset.
+    for _ in range(args.async_steps):
+        dataset_indices = next(iter_dataloader)
+        batch = next_batch(dataset_indices, train_dataset)
+        split_and_insert_batch(
+            batch,
+            1,  # training_step
+            args.vllm_num_engines,
+            pending_queries_map,
+            param_prompt_Q,
+            generation_configs["train"],
+        )
+    num_total_tokens = 0
+    for training_step in range(resume_training_step, args.num_training_steps + 1):
+        start_time = time.perf_counter()
+        check_threads_healthy(
+            [packing_future, generation_future],
+            stop_event,
+            executor,
+            [inference_results_Q, param_prompt_Q, evaluation_inference_results_Q],
+        )
+
+        episode += args.num_unique_prompts_rollout * args.num_samples_per_prompt_rollout
+        batch = sync_weights_and_prepare_prompts(
+            training_step,
+            args,
+            train_dataset,
+            iter_dataloader,
+            policy_group,
+            pending_queries_map,
+            param_prompt_Q,
+            generation_configs,
+        )
+        if (
+            training_step % args.local_eval_every == 0
+            and eval_batch is not None
+            and (args.eval_on_step_0 or training_step > 1)
+        ):
+            split_and_insert_batch(
+                eval_batch,
+                training_step,
+                args.vllm_num_engines,
+                eval_pending_queries_map,
+                param_prompt_Q,
+                generation_configs["eval"],
+                is_eval=True,
+            )
+
+        # The generate_thread is now handling vLLM processing asynchronously
+        collated_data, data_thread_metrics, num_total_tokens = load_data_from_packing_thread(
+            packed_sequences_Q, num_total_tokens
+        )
+        if collated_data is None:
+            continue
+
+        generate_metrics = {}
+        try:
+            generate_metrics = generate_metrics_Q.get_nowait()
+        except Empty:
+            logging.info("[Main Thread] didn't get generation metrics")
+
+        data_thread_metrics = {**data_thread_metrics, **generate_metrics}
+
+        one_training_step(
+            args,
+            policy_group,
+            collated_data,
+            tokenizer,
+            data_thread_metrics,
+            episode,
+            training_step,
+            num_total_tokens,
+            start_time,
+            train_dataset,
+            wandb_url,
+            tc.chat_template_name,
+        )
+
+        maybe_evaluate(
+            args,
+            training_step,
+            evaluation_inference_results_Q,
+            tokenizer,
+            eval_batch,
+            reward_fn,
+            episode,
+            eval_pending_queries_map,
+            generation_configs["eval"],
+            generate_metrics_Q,
+        )
+
+    save_final_model(args, policy_group, tokenizer, training_step, wandb_url, tc.chat_template_name)
+    return episode  # Return episode for later use
+
+
 def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_samples: int = 32):
     tokenizer = make_tokenizer(tc, model_config)
     args = setup_runtime_variables(args)
@@ -2419,125 +2563,32 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_sa
     executor = futures.ThreadPoolExecutor(max_workers=2, thread_name_prefix="grpo")
 
     try:
-        logger.info("======== ✅ data preparation thread starts =========")
-        packing_future = executor.submit(
-            data_preparation_thread,
-            reward_fn,
-            inference_results_Q,
-            packed_sequences_Q,
-            pending_queries_map,
+        episode = run_training(
             args,
             tokenizer,
-            args.num_training_steps,
-            generation_configs["train"],
-        )
-
-        logger.info("======== ✅ generation thread starts =========")
-        generation_future = executor.submit(
-            generate_thread,
+            train_dataset,
+            eval_batch,
+            policy_group,
             vllm_engines,
-            args.local_eval_every,
-            args.num_training_steps,
+            generation_configs,
+            iter_dataloader,
+            reward_fn,
             resume_training_step,
+            episode,
+            wandb_url,
+            tc,
             stop_event,
+            executor,
+            inference_results_Q,
+            param_prompt_Q,
+            evaluation_inference_results_Q,
+            packed_sequences_Q,
+            pending_queries_map,
+            eval_pending_queries_map,
             generate_metrics_Q,
         )
-
-        # Send initial data to ensure we have a N-step offset.
-        for _ in range(args.async_steps):
-            dataset_indices = next(iter_dataloader)
-            batch = next_batch(dataset_indices, train_dataset)
-            split_and_insert_batch(
-                batch,
-                1,  # training_step
-                args.vllm_num_engines,
-                pending_queries_map,
-                param_prompt_Q,
-                generation_configs["train"],
-            )
-        num_total_tokens = 0
-        for training_step in range(resume_training_step, args.num_training_steps + 1):
-            start_time = time.perf_counter()
-            check_threads_healthy(
-                [packing_future, generation_future],
-                stop_event,
-                executor,
-                [inference_results_Q, param_prompt_Q, evaluation_inference_results_Q],
-            )
-
-            episode += args.num_unique_prompts_rollout * args.num_samples_per_prompt_rollout
-            batch = sync_weights_and_prepare_prompts(
-                training_step,
-                args,
-                train_dataset,
-                iter_dataloader,
-                policy_group,
-                pending_queries_map,
-                param_prompt_Q,
-                generation_configs,
-            )
-            if (
-                training_step % args.local_eval_every == 0
-                and eval_batch is not None
-                and (args.eval_on_step_0 or training_step > 1)
-            ):
-                split_and_insert_batch(
-                    eval_batch,
-                    training_step,
-                    args.vllm_num_engines,
-                    eval_pending_queries_map,
-                    param_prompt_Q,
-                    generation_configs["eval"],
-                    is_eval=True,
-                )
-
-            # The generate_thread is now handling vLLM processing asynchronously
-            collated_data, data_thread_metrics, num_total_tokens = load_data_from_packing_thread(
-                packed_sequences_Q, num_total_tokens
-            )
-            if collated_data is None:
-                continue
-
-            generate_metrics = {}
-            try:
-                generate_metrics = generate_metrics_Q.get_nowait()
-            except Empty:
-                logging.info("[Main Thread] didn't get generation metrics")
-
-            data_thread_metrics = {**data_thread_metrics, **generate_metrics}
-
-            one_training_step(
-                args,
-                policy_group,
-                collated_data,
-                tokenizer,
-                data_thread_metrics,
-                episode,
-                training_step,
-                num_total_tokens,
-                start_time,
-                train_dataset,
-                wandb_url,
-                tc.chat_template_name,
-            )
-
-            maybe_evaluate(
-                args,
-                training_step,
-                evaluation_inference_results_Q,
-                tokenizer,
-                eval_batch,
-                reward_fn,
-                episode,
-                eval_pending_queries_map,
-                generation_configs["eval"],
-                generate_metrics_Q,
-            )
-
-        save_final_model(args, policy_group, tokenizer, training_step, wandb_url, tc.chat_template_name)
-
     except Exception as e:
-        logger.error(f"Main thread encountered error: {e}")
+        logger.error(f"Training failed with error: {e}")
         raise
     finally:
         # Clean up resources - this will happen whether the code succeeds or fails


### PR DESCRIPTION
This has the nice side effect of consolidating all of our error code into the main thread, so it's a lot cleaner and simpler, and all cleanup goes through one central call to `cleanup_training_resources`.

Runs:

- Single GPU training run: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K31DK95FZY6AW27S15AH4AG2?taskId=01K31DK95PWTV57RHPBY26P3DF&jobId=01K31DK99EVF36NR95W4D3NANA)
- Multi-GPU training run: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K2YZNXM8T689VVS9Z4QY07RM?taskId=01K2YZNXMB4FYWRX5C42W3HQHQ&jobId=01K2YZNXR3F43MW3AC9WB4Q5NG)