### PR TITLE
Prevent duplicate runs in Github Actions.

### DIFF
--- a/.github/workflows/beaker-experiment.yml
+++ b/.github/workflows/beaker-experiment.yml
@@ -41,6 +41,8 @@ jobs:
     name: Launch Beaker Experiment
     runs-on: ubuntu-latest
     timeout-minutes: 35
+    # Skip push events from merge queue (they'll be handled by merge_group trigger)
+    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/beaker-experiment.yml
+++ b/.github/workflows/beaker-experiment.yml
@@ -41,7 +41,11 @@ jobs:
     name: Launch Beaker Experiment
     runs-on: ubuntu-latest
     timeout-minutes: 35
-    # Skip push events from merge queue (they'll be handled by merge_group trigger)
+    # Prevent duplicate runs when using merge queue:
+    # - When a PR is merged via merge queue, GitHub triggers both 'push' and 'merge_group' events
+    # - The merge queue creates temporary branches like 'refs/heads/gh-readonly-queue/main/pr-123-abc123'
+    # - This condition skips the 'push' trigger for merge queue branches (identified by the gh-readonly-queue prefix)
+    # - The 'merge_group' trigger will handle these instead, preventing duplicate runs
     if: github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')
 
     steps:

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -43,8 +43,12 @@ jobs:
     name: open_instruct
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # Skip push events from merge queue (they'll be handled by merge_group trigger)
-    if: (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')) && ((github.event_name != 'workflow_run') || (github.event.workflow_run.conclusion == 'success'))
+    # Prevent duplicate runs when using merge queue:
+    # - When a PR is merged via merge queue, GitHub triggers both 'push' and 'merge_group' events
+    # - The merge queue creates temporary branches like 'refs/heads/gh-readonly-queue/main/pr-123-abc123'
+    # - This condition skips the 'push' trigger for merge queue branches (identified by the gh-readonly-queue prefix)
+    # - The 'merge_group' trigger will handle these instead, preventing duplicate runs
+    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -43,7 +43,8 @@ jobs:
     name: open_instruct
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: (github.event_name != 'workflow_run') || (github.event.workflow_run.conclusion == 'success')
+    # Skip push events from merge queue (they'll be handled by merge_group trigger)
+    if: (github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')) && ((github.event_name != 'workflow_run') || (github.event.workflow_run.conclusion == 'success'))
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Previously, we would see duplicate Build and Beaker Experiment runs because both the `merge_group` and `push` triggers were triggering. E.g. on any merged PR ([example](https://github.com/allenai/open-instruct/commit/a916940b87dd83a5ef526e774e9e548b51a12f23)).