### PR TITLE
Fixes batching bug. 

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -430,8 +430,7 @@ class Args:
         # Ensure we have enough prompts for all VLLM engines
         if self.num_unique_prompts_rollout < self.vllm_num_engines:
             raise ValueError(
-                f"num_unique_prompts_rollout ({self.num_unique_prompts_rollout}) must be >= "
-                f"vllm_num_engines ({self.vllm_num_engines}) to avoid empty batches."
+                f"{self.num_unique_prompts_rollout=} must be >= {self.vllm_num_engines=} to avoid empty batches."
             )
         # Initialize stop_strings if None
         if self.stop_strings is None:
@@ -1897,7 +1896,6 @@ def split_and_insert_batch(
     is_eval: bool = False,
 ) -> None:
     """Split a batch into multiple inference batches and insert individual prompts into queues and mapping."""
-    # Calculate batch size, ensuring it's at least 1
     inference_batch_size = max(1, len(batch.queries) // vllm_num_engines)
 
     for batch_idx in range(vllm_num_engines):

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1896,7 +1896,9 @@ def split_and_insert_batch(
     is_eval: bool = False,
 ) -> None:
     """Split a batch into multiple inference batches and insert individual prompts into queues and mapping."""
-    inference_batch_size = max(1, len(batch.queries) // vllm_num_engines)
+    import math
+
+    inference_batch_size = max(1, math.ceil(len(batch.queries) / vllm_num_engines))
 
     for batch_idx in range(vllm_num_engines):
         start_idx = batch_idx * inference_batch_size

--- a/open_instruct/test_grpo_fast.py
+++ b/open_instruct/test_grpo_fast.py
@@ -644,6 +644,110 @@ class GrpoIntegrationTests(TestGrpoFastBase):
 class TestStreamingAccumulation(TestGrpoFastBase):
     """Test the new streaming accumulation functionality."""
 
+    def test_more_engines_than_queries(self):
+        """Test that split_and_insert_batch handles gracefully when engines > queries."""
+        # More engines than queries - should handle gracefully with single-prompt batches
+        num_engines = 8
+        num_queries = 4
+
+        queries, ground_truths, datasets, indices = self.create_test_data(num_queries)
+        param_prompt_Q = ray_queue.Queue(maxsize=num_engines * 2)
+        pending_queries_map = grpo_fast.PendingQueriesMap()
+
+        # Track queue for cleanup
+        self._ray_queues.append(param_prompt_Q)
+
+        batch = model_utils.Batch(queries=queries, ground_truths=ground_truths, datasets=datasets, indices=indices)
+
+        # Create a mock generation_config
+        from unittest.mock import MagicMock
+
+        mock_generation_config = MagicMock()
+        mock_generation_config.n = 1
+
+        # Capture logs to verify warning
+        import logging
+
+        with self.assertLogs(level=logging.WARNING) as log_context:
+            grpo_fast.split_and_insert_batch(
+                batch,
+                training_step=1,
+                vllm_num_engines=num_engines,
+                pending_queries_map=pending_queries_map,
+                param_prompt_Q=param_prompt_Q,
+                generation_config=mock_generation_config,
+            )
+
+        # Check that warning was logged
+        self.assertTrue(
+            any("less than number of engines" in msg for msg in log_context.output),
+            "Should log warning about fewer queries than engines",
+        )
+
+        # Should have 4 batches (one for each query)
+        self.assertEqual(
+            param_prompt_Q.qsize(), num_queries, f"Should have {num_queries} batches for {num_queries} queries"
+        )
+
+        # Each batch should have exactly 1 prompt
+        batch_sizes = []
+        while not param_prompt_Q.empty():
+            request = param_prompt_Q.get()
+            self.assertIsInstance(request, PromptRequest)
+            self.assertEqual(len(request.prompts), 1, "Each batch should have exactly 1 prompt")
+            batch_sizes.append(len(request.prompts))
+
+        # All queries should be in the pending map
+        self.assertEqual(len(pending_queries_map), num_queries)
+
+    def test_uneven_distribution_no_empty_batches(self):
+        """Test that uneven query distribution doesn't create empty batches."""
+        num_engines = 3
+        num_queries = 7  # 7/3 = 2 remainder 1, so distribution should be [3, 2, 2]
+
+        queries, ground_truths, datasets, indices = self.create_test_data(num_queries)
+        param_prompt_Q = ray_queue.Queue(maxsize=num_engines * 2)
+        pending_queries_map = grpo_fast.PendingQueriesMap()
+
+        # Track queue for cleanup
+        self._ray_queues.append(param_prompt_Q)
+
+        batch = model_utils.Batch(queries=queries, ground_truths=ground_truths, datasets=datasets, indices=indices)
+
+        # Create a mock generation_config
+        from unittest.mock import MagicMock
+
+        mock_generation_config = MagicMock()
+        mock_generation_config.n = 1
+
+        grpo_fast.split_and_insert_batch(
+            batch,
+            training_step=1,
+            vllm_num_engines=num_engines,
+            pending_queries_map=pending_queries_map,
+            param_prompt_Q=param_prompt_Q,
+            generation_config=mock_generation_config,
+        )
+
+        # Verify all batches have content and check distribution
+        batch_sizes = []
+        while not param_prompt_Q.empty():
+            request = param_prompt_Q.get()
+            self.assertGreater(len(request.prompts), 0, "Found empty batch in queue!")
+            batch_sizes.append(len(request.prompts))
+
+        # Check the expected distribution
+        self.assertEqual(sum(batch_sizes), num_queries, "Total queries should match")
+        self.assertEqual(len(batch_sizes), num_engines, "Should have one batch per engine")
+
+        # The distribution should be [3, 2, 2] for 7 queries across 3 engines
+        expected_distribution = [3, 2, 2]
+        self.assertEqual(
+            sorted(batch_sizes, reverse=True),
+            expected_distribution,
+            f"Expected distribution {expected_distribution}, got {sorted(batch_sizes, reverse=True)}",
+        )
+
     def test_streaming_accumulation_basic(self):
         """Test basic streaming accumulation with in-order results."""
         num_engines = 2


### PR DESCRIPTION
Previously, if the number of prompts was less than the number of engines, we'd insert empty prompts, which would cause the actor to [fail](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K2ZKBDSHZRHC6K3N6AH0YWKN?taskId=01K2ZKBDSQNWWYEN0XZF6AE51Q&jobId=01K2ZKBDXVZ0EKZH4VJPZ6NGMB). 

Now, in that case, we log a warning and skip inserting the empty prompts. 

I have also added tests to cover that edge case to make sure we don't insert empty prompts. 

Runs:

1. Single GPU run, standard config: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K31X5WN30WZ7D5JEEH8GTBRC?taskId=01K31X5WN7AAK0XRN90157B30D&jobId=01K31X5WZJ39P2B973JVAFM76B)
2. Multi-GPU run, using less eval queries than engines: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K31X7DMKMG4FP0M13561ECW4?taskId=01K31X7DMV3M8EDTWT136SM19N&jobId=01K31X7DRQ7RY0WKQMD7600HEB)