### PR TITLE
Eval weka cluster logic

### DIFF
--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -86,9 +86,6 @@ EVALUATE_ON_WEKA="true"
 if [[ "$MODEL_LOCATION" == gs://* ]]; then
     EVALUATE_ON_WEKA="false"
 fi
-if [[ "$MODEL_LOCATION" == /weka/* ]]; then
-    EVALUATE_ON_WEKA="true"
-fi
 
 # Optional: Default number of GPUs if not specified
 NUM_GPUS="${NUM_GPUS:-1}"

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -80,7 +80,7 @@ while [[ "$#" -gt 0 ]]; do
 done
 
 # cluster/weka mount logic: default true (to use non-augusta)
-# if model starts with gs://, set evaluate_on_weka to false. if model starts with /weka/, set evaluate_on_weka to true.
+# if model starts with gs://, set evaluate_on_weka to false.
 # All the logic is now handled internally, the flag is useless but keeping for backwards compatibility since people have scripts with it
 EVALUATE_ON_WEKA="true"
 if [[ "$MODEL_LOCATION" == gs://* ]]; then

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -79,6 +79,16 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+# cluster/weka mount logic: default true (to use non-augusta)
+# if model starts with gs://, set evaluate_on_weka to false. if model starts with /weka/, set evaluate_on_weka to true.
+# All the logic is now handled internally, the flag is useless but keeping for backwards compatibility since people have scripts with it
+EVALUATE_ON_WEKA="true"
+if [[ "$MODEL_LOCATION" == gs://* ]]; then
+    EVALUATE_ON_WEKA="false"
+fi
+if [[ "$MODEL_LOCATION" == /weka/* ]]; then
+    EVALUATE_ON_WEKA="true"
+fi
 
 # Optional: Default number of GPUs if not specified
 NUM_GPUS="${NUM_GPUS:-1}"
@@ -305,7 +315,7 @@ for TASK in "${TASKS[@]}"; do
     # NOTE: For gantry args here and below, random numbers like #42 are added to the env variables because they need to be unique names. The numbers are ignored.
     # Build gantry args
     if [ "$EVALUATE_ON_WEKA" == "true" ]; then
-        GANTRY_ARGS="{\"env-secret\": \"OPENAI_API_KEY=openai_api_key\", \"weka\": \"oe-adapt-default:/weka/oe-adapt-default\", \"weka#44\": \"oe-training-default:/weka/oe-training-default\", \"env#132\":\"VLLM_ALLOW_LONG_MAX_MODEL_LEN=1\", \"env-secret#42\": \"AZURE_EVAL_API_KEY=azure_eval_api_key\"${MAX_TOKENS_ARG}}"
+        GANTRY_ARGS="{\"env-secret\": \"OPENAI_API_KEY=openai_api_key\", \"weka\": \"oe-adapt-default:/weka/oe-adapt-default\", \"weka#44\": \"oe-training-default:/weka/oe-training-default\", \"env-secret#2\":\"HF_TOKEN=HF_TOKEN\", \"env#132\":\"VLLM_ALLOW_LONG_MAX_MODEL_LEN=1\", \"env-secret#42\": \"AZURE_EVAL_API_KEY=azure_eval_api_key\"${MAX_TOKENS_ARG}}"
     else
         GANTRY_ARGS="{\"env-secret\": \"OPENAI_API_KEY=openai_api_key\", \"env-secret#43\": \"AZURE_EVAL_API_KEY=azure_eval_api_key\", \"env\":\"VLLM_ALLOW_LONG_MAX_MODEL_LEN=1\", \"env-secret#2\":\"HF_TOKEN=HF_TOKEN\", \"mount\": \"/mnt/filestore_1:/filestore\", \"env#111\": \"HF_HOME=/filestore/.cache/huggingface\", \"env#112\": \"HF_DATASETS_CACHE=/filestore/.cache/huggingface\", \"env#113\": \"HF_HUB_CACHE=/filestore/.cache/hub\"${MAX_TOKENS_ARG}}"
     fi


### PR DESCRIPTION
This PR makes two small changes to `oe-eval.sh`:
1. Adds `HF_TOKEN` to the evaluate_on_weka case — this is helpful for evaling gated models like gemma
2. Fix to handle weka/cluster routing logic rather than relying on user to pass/toggle `--evaluate_on_weka` flag to `submit_eval_jobs.py` which is not airtight and is annoying. The script routes to the gcs case (augusta cluster/gantry args) for models that start with gs://, defaults to weka case (non-augusta clusters and mounting weka) otherwise. This does render the `--evaluate_on_weka` flag useless since logic is handled internally, but I didn't want to delete the flag entirely mid olmo 3 dev in case people's scripts break. Will eventually transition this out, but open to suggestions.

Tested (canceled the jobs because we just care about cluster/HF_TOKEN for this PR):
- [here](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-3-results/work/01K326AWHYMKWKNZWVEM7AYEAD?taskId=01K326AWMCPTGJE0Y3JXBR9205&jobId=01K326AWR091Q3SJMB98VJFNV7) for /weka/ models
- [here](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-3-results/work/01K325YX8S6PQVQTT7JEB57NAQ?taskId=01K325YXBB1Z4F3S3XAGXBQ1KT&jobId=01K325YXFBT1HNKDHQEE0VMQN1) for hf- models
- [here](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-3-results/work/01K326PVMAZHE6Y7JDKMGHF1V5?taskId=01K326PVPS9SZN08SW2E9N3WY2&jobId=01K326PVTNA8KS01XDKSZ9MHZR) for gs:// models