### PR TITLE
Fix the way we do caching in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,15 +59,11 @@ RUN curl --silent \
 
 COPY --from=ghcr.io/astral-sh/uv:0.8.6 /uv /uvx /bin/
 
-# Install Beaker Gantry user-wide in an isolated venv
-RUN uv tool install --no-cache-dir beaker-gantry==3.0.0
+WORKDIR /stage/
 
 ENV UV_CACHE_DIR=/root/.cache/uv
-
 ENV HF_HUB_ENABLE_HF_TRANSFER=1
 ENV UV_COMPILE_BYTECODE=0
-
-WORKDIR /stage/
 
 # Install dependencies
 RUN --mount=type=cache,target=${UV_CACHE_DIR} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,16 +61,13 @@ COPY --from=ghcr.io/astral-sh/uv:0.8.6 /uv /uvx /bin/
 
 WORKDIR /stage/
 
-# Install Beaker Gantry user-wide in an isolated venv
-RUN uv tool install --no-cache-dir beaker-gantry==3.0.0
-
 ENV UV_CACHE_DIR=/root/.cache/uv
 
 ENV HF_HUB_ENABLE_HF_TRANSFER=1
 ENV UV_COMPILE_BYTECODE=0
 
 # Copy only dependency-related files first
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml ./
 
 # Install dependencies
 RUN --mount=type=cache,target=${UV_CACHE_DIR} \
@@ -78,7 +75,7 @@ RUN --mount=type=cache,target=${UV_CACHE_DIR} \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv sync --frozen --no-install-project --no-cache
 
-RUN uv run -m nltk.downloader punkt punkt_tab
+RUN uv run --no-sync -m nltk.downloader punkt punkt_tab
 
 # Copy all application code at the end
 COPY eval eval

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,9 @@ COPY --from=ghcr.io/astral-sh/uv:0.8.6 /uv /uvx /bin/
 
 WORKDIR /stage/
 
+# Install Beaker Gantry user-wide in an isolated venv
+RUN uv tool install --no-cache-dir beaker-gantry==3.0.0
+
 ENV UV_CACHE_DIR=/root/.cache/uv
 
 ENV HF_HUB_ENABLE_HF_TRANSFER=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,6 @@ RUN curl --silent \
 
 COPY --from=ghcr.io/astral-sh/uv:0.8.6 /uv /uvx /bin/
 
-WORKDIR /stage/
-
 # Install Beaker Gantry user-wide in an isolated venv
 RUN uv tool install --no-cache-dir beaker-gantry==3.0.0
 
@@ -69,8 +67,7 @@ ENV UV_CACHE_DIR=/root/.cache/uv
 ENV HF_HUB_ENABLE_HF_TRANSFER=1
 ENV UV_COMPILE_BYTECODE=0
 
-# Copy only dependency-related files first
-COPY pyproject.toml ./
+WORKDIR /stage/
 
 # Install dependencies
 RUN --mount=type=cache,target=${UV_CACHE_DIR} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN --mount=type=cache,target=${UV_CACHE_DIR} \
 RUN uv run --no-sync -m nltk.downloader punkt punkt_tab
 
 # Copy all application code at the end
+COPY pyproject.toml ./
 COPY eval eval
 COPY configs configs
 COPY scripts scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,12 +73,11 @@ WORKDIR /stage/
 RUN --mount=type=cache,target=${UV_CACHE_DIR} \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-cache
+    uv sync --frozen --no-cache
 
 RUN uv run --no-sync -m nltk.downloader punkt punkt_tab
 
 # Copy all application code at the end
-COPY pyproject.toml ./
 COPY eval eval
 COPY configs configs
 COPY scripts scripts


### PR DESCRIPTION
Makes a few clean up changes to the Dockerfile: 

1. Because we're using bind mounts, we don't need to copy `pyproject.toml` or `uv.lock` before running `uv sync`. By removing them, we get to avoid the (often spurious) cache invalidations that happen because of this. 
2. Removes the `uv tool install gantry` layer, which isn't needed, because no one should be running gantry inside of this container. 
3. Fixes a bug! Previously, we had `--no-install-project`, which didn't install the project, but then, we had a `uv run` command immediately after, which installed the project and downloaded a bunch of stuff, basically redoing `uv sync` (with different parameters). By removing `--no-install-project` and adding `--no-sync` to the `uv run` command, we avoid this and make the build faster. 

Single GPU run: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K34N87NB9P2BW5JP94QXMP6P?taskId=01K34N87NF898YJMJ2J8M9215X&jobId=01K34N87S30P630GB1Y0SNK0JP).