### PR TITLE
logging oe eval results to wandb when using new oe-eval-interal

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -396,6 +396,8 @@ class Args:
     """the docker image for evaluation for oe-eval"""
     eval_priority: Literal["low", "normal", "high", "urgent"] = "normal"
     """the priority of auto-launched evaluation jobs"""
+    oe_eval_log_to_wandb: bool = False
+    """Whether to log oe-eval results to wandb as run.summary"""
 
     # Evaluation behavior
     eval_on_step_0: bool = False
@@ -1093,6 +1095,7 @@ class PolicyTrainerRayProcess(RayProcess):
                 args.gs_bucket_path,
                 args.eval_priority,
                 args.oe_eval_beaker_image,
+                args.oe_eval_log_to_wandb,
             )
 
 

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -1050,6 +1050,7 @@ def launch_ai2_evals_on_weka(
     gs_bucket_path: Optional[str] = None,
     eval_priority: Optional[str] = "normal",
     beaker_image: Optional[str] = None,
+    log_eval_to_wandb: bool = False,
 ) -> None:
     weka_cluster = "ai2/saturn-cirrascale ai2/neptune-cirrascale"
     gcp_cluster = "ai2/augusta-google-1"
@@ -1091,6 +1092,9 @@ python scripts/submit_eval_jobs.py \
 --skip_oi_evals"""
     if wandb_url is not None:
         command += f" --run_id {wandb_url}"
+        if log_eval_to_wandb:
+            wandb_run_path = wandb_url_to_run_path(wandb_url)
+            command += f" --wandb_run_path {wandb_run_path}"
     if oe_eval_max_length is not None:
         command += f" --oe_eval_max_length {oe_eval_max_length}"
     if training_step is not None:
@@ -1109,6 +1113,27 @@ python scripts/submit_eval_jobs.py \
     print(f"Submit jobs after model training is finished - Stdout:\n{stdout.decode()}")
     print(f"Submit jobs after model training is finished - Stderr:\n{stderr.decode()}")
     print(f"Submit jobs after model training is finished - process return code: {process.returncode}")
+
+
+def wandb_url_to_run_path(url):
+    """
+    Convert a wandb URL to a wandb run path.
+
+    Args:
+        url (str): wandb URL in format https://wandb.ai/entity/project/runs/run_id
+
+    Returns:
+        str: wandb run path in format entity/project/run_id
+    """
+    # Remove the base URL and split by '/'
+    path_parts = url.replace("https://wandb.ai/", "").split("/")
+
+    # Extract entity, project, and run_id
+    entity = path_parts[0]
+    project = path_parts[1]
+    run_id = path_parts[3]  # Skip 'runs' at index 2
+
+    return f"{entity}/{project}/{run_id}"
 
 
 # ----------------------------------------------------------------------------

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -70,6 +70,7 @@ while [[ "$#" -gt 0 ]]; do
         --evaluate_on_weka) EVALUATE_ON_WEKA="true" ;;
         --step) STEP="$2"; shift ;;
         --run-id) RUN_ID="$2"; shift ;;
+        --wandb-run-path) WANDB_RUN_PATH="$2"; shift ;;
         --stop-sequences) STOP_SEQUENCES="$2"; shift ;;
         --beaker-image) BEAKER_IMAGE="$2"; shift ;;
         --cluster) CLUSTER="$2"; shift ;;
@@ -98,6 +99,7 @@ TASK_SUITE="${TASK_SUITE:-NEXT_MODEL_DEV}"
 PRIORITY="${PRIORITY:normal}"
 EVALUATE_ON_WEKA="${EVALUATE_ON_WEKA:-false}"
 RUN_ID="${RUN_ID:-}"
+WANDB_RUN_PATH="${WANDB_RUN_PATH:-}"
 STEP="${STEP:-}"
 
 # Process stop sequences if provided
@@ -135,6 +137,14 @@ if [[ -n "$REVISION" ]]; then
     REVISION_ARG="--revision $REVISION"
 else
     REVISION_ARG=""
+fi
+
+# Set wandb run path to upload to wandb if available
+if [[ -n "$WANDB_RUN_PATH" ]]; then
+    beaker_user=$(beaker account whoami --format json | jq -r '.[0].name')
+    WANDB_ARG="--wandb-run-path $WANDB_RUN_PATH --gantry-secret-wandb-api-key ${beaker_user}_WANDB_API_KEY"
+else
+    WANDB_ARG=""
 fi
 
 # Define default tasks if no custom tasks provided
@@ -325,6 +335,7 @@ for TASK in "${TASKS[@]}"; do
             --gpus "$GPU_COUNT" \
             --gantry-args "$GANTRY_ARGS" \
             ${REVISION_ARG} \
+            ${WANDB_ARG} \
             --cluster "$CLUSTER" \
             --beaker-retries 2 \
             --beaker-image "$BEAKER_IMAGE" \
@@ -346,6 +357,7 @@ for TASK in "${TASKS[@]}"; do
         --gpus "$GPU_COUNT" \
         --gantry-args "$GANTRY_ARGS" \
         ${REVISION_ARG} \
+        ${WANDB_ARG} \
         --cluster ai2/augusta-google-1 \
         --beaker-retries 2 \
         --beaker-image "$BEAKER_IMAGE" \

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -11,10 +11,11 @@ import yaml
 
 # Helper functions.
 
+
 def adjust_batch_size(task_spec, model_name, batch_size_reduction):
     "Adjust batch size using heuristics that are good for A100-size GPUs."
     reduce_by_2 = ["13B"]
-    reduce_by_4 = ["30B",  "32B", "34B", "40B", "65B", "70B", "70b", "72B", "72b"]
+    reduce_by_4 = ["30B", "32B", "34B", "40B", "65B", "70B", "70b", "72B", "72b"]
     # If not given, choose a value based on the model name.
     if batch_size_reduction is None:
         if any([pattern in model_name for pattern in reduce_by_2]):
@@ -25,10 +26,14 @@ def adjust_batch_size(task_spec, model_name, batch_size_reduction):
             batch_size_reduction = 1
 
     # Reduce accordingly.
-    if "--eval_batch_size" in task_spec['arguments'][0]:
-        original_batch_size = re.search(r"--eval_batch_size (\d+)", task_spec['arguments'][0]).group(1)
+    if "--eval_batch_size" in task_spec["arguments"][0]:
+        original_batch_size = re.search(r"--eval_batch_size (\d+)", task_spec["arguments"][0]).group(1)
         new_batch_size = max(1, int(original_batch_size) // batch_size_reduction)
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--eval_batch_size {}".format(original_batch_size), "--eval_batch_size {}".format(new_batch_size))]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--eval_batch_size {}".format(original_batch_size), "--eval_batch_size {}".format(new_batch_size)
+            )
+        ]
 
     return task_spec
 
@@ -54,9 +59,9 @@ def adjust_gpus(task_spec, experiment_group, model_name, gpu_multiplier):
 
     # Increase accordingly.
     if "codex_eval" in experiment_group:
-        task_spec['resources']['gpuCount'] = codex_multiplier * task_spec['resources']['gpuCount']
+        task_spec["resources"]["gpuCount"] = codex_multiplier * task_spec["resources"]["gpuCount"]
     else:
-        task_spec['resources']['gpuCount'] = default_multiplier * task_spec['resources']['gpuCount']
+        task_spec["resources"]["gpuCount"] = default_multiplier * task_spec["resources"]["gpuCount"]
 
     return task_spec
 
@@ -64,15 +69,8 @@ def adjust_gpus(task_spec, experiment_group, model_name, gpu_multiplier):
 ########################################
 # Launcher
 
-WEKA_CLUSTERS = [
-    "ai2/jupiter-cirrascale-2",
-    "ai2/saturn-cirrascale",
-    "ai2/neptune-cirrascale",
-    "ai2/ceres-cirrascale"
-]
-GCP_CLUSTERS = [
-    "ai2/augusta-google-1"
-]
+WEKA_CLUSTERS = ["ai2/jupiter-cirrascale-2", "ai2/saturn-cirrascale", "ai2/neptune-cirrascale", "ai2/ceres-cirrascale"]
+GCP_CLUSTERS = ["ai2/augusta-google-1"]
 
 
 today = date.today().strftime("%m%d%Y")
@@ -82,36 +80,80 @@ parser.add_argument("--workspace", type=str, default="oe-adapt-general")
 parser.add_argument("--model_name", type=str, default="hf-opt-7B")
 parser.add_argument("--hf_revision", type=str, default=None)
 parser.add_argument("--location", type=str, default=None)
-parser.add_argument("--beaker_image", type=str, default="oe-eval-beaker/oe_eval_auto", help="If given, use this Beaker image.")
+parser.add_argument(
+    "--beaker_image", type=str, default="oe-eval-beaker/oe_eval_auto", help="If given, use this Beaker image."
+)
 # image refernece: https://github.com/allenai/oe-eval-internal/blob/493660aca07d05384c6bd1860c4180860ccc7d53/oe_eval_internal/utilities/launch_utils.py#L143
 # image: https://legacy.beaker.org/im/01JRZWRN4FSGK7FWKV1DRPP1R1/details
 parser.add_argument("--beaker_subfolder", type=str, default=None)
-parser.add_argument("--cluster", nargs='+', default=[
-    # "ai2/s2-cirrascale-l40",
-    "ai2/ceres-cirrascale",
-    "ai2/neptune-cirrascale",
-    "ai2/saturn-cirrascale",
-    "ai2/jupiter-cirrascale-2",
-])
+parser.add_argument(
+    "--cluster",
+    nargs="+",
+    default=[
+        # "ai2/s2-cirrascale-l40",
+        "ai2/ceres-cirrascale",
+        "ai2/neptune-cirrascale",
+        "ai2/saturn-cirrascale",
+        "ai2/jupiter-cirrascale-2",
+    ],
+)
 parser.add_argument("--is_tuned", action="store_true")
 parser.add_argument("--use_hf_tokenizer_template", action="store_true")
 parser.add_argument("--priority", type=str, default="low")
-parser.add_argument("--preemptible", action="store_true", default=False, help="for using preemtipble jobs (required on some instances)")
-parser.add_argument("--olmo", action="store_true", help="Pass this flag if evaluating an OLMo model and `olmo` isn't in the model name.")
-parser.add_argument("--experiments", type=str, nargs="+", default=None, help="Experiments to run, e.g., '--experiments mmlu_5shot gsm_cot'")
+parser.add_argument(
+    "--preemptible", action="store_true", default=False, help="for using preemtipble jobs (required on some instances)"
+)
+parser.add_argument(
+    "--olmo",
+    action="store_true",
+    help="Pass this flag if evaluating an OLMo model and `olmo` isn't in the model name.",
+)
+parser.add_argument(
+    "--experiments",
+    type=str,
+    nargs="+",
+    default=None,
+    help="Experiments to run, e.g., '--experiments mmlu_5shot gsm_cot'",
+)
 parser.add_argument("--batch_size_reduction", type=int, default=None, help="Reduce batch size by this factor.")
 parser.add_argument("--gpu_multiplier", type=int, default=None, help="Multiply the number of GPUs by this factor.")
-parser.add_argument("--gsm_stop_at_double_newline", action="store_true", help="Stop GSM generation at the first double newline.")
+parser.add_argument(
+    "--gsm_stop_at_double_newline", action="store_true", help="Stop GSM generation at the first double newline."
+)
 parser.add_argument("--no-nfs", action="store_true", help="Don't mount the NFS.")
-parser.add_argument("--add_stop_sequence", type=str, nargs="+", default=[], help="Additional stop sequences to use when generating completions.") # e.g. \"<|eot_id|>\" for llama 3
-parser.add_argument("--upload_to_hf", type=str, default=None, help="If given, upload the eval results to the Hugging Face model hub. Provide the HF dataset and path in form <hf dataset>//<hf path>.")
-parser.add_argument("--hf_upload_experiments", type=str, nargs="*", default=None, help="Upload given experiment to the Hugging Face model hub.")
+parser.add_argument(
+    "--add_stop_sequence",
+    type=str,
+    nargs="+",
+    default=[],
+    help="Additional stop sequences to use when generating completions.",
+)  # e.g. \"<|eot_id|>\" for llama 3
+parser.add_argument(
+    "--upload_to_hf",
+    type=str,
+    default=None,
+    help="If given, upload the eval results to the Hugging Face model hub. Provide the HF dataset and path in form <hf dataset>//<hf path>.",
+)
+parser.add_argument(
+    "--hf_upload_experiments",
+    type=str,
+    nargs="*",
+    default=None,
+    help="Upload given experiment to the Hugging Face model hub.",
+)
 parser.add_argument("--run_oe_eval_experiments", action="store_true", help="Run the OE eval tool and experiments too.")
 parser.add_argument("--run_safety_evaluations", action="store_true", help="Run the OE safety evaluations too.")
 parser.add_argument("--skip_oi_evals", action="store_true", help="Don't run open instruct evals.")
 parser.add_argument("--oe_eval_max_length", type=int, default=4096, help="Max length for OE eval.")
-parser.add_argument("--oe_eval_task_suite", type=str, default="NEXT_MODEL_DEV", help="Task suite for OE eval: NEXT_MODEL_DEV, NEXT_MODEL_UNSEEN, TULU_3_DEV, TULU_3_UNSEEN (default: NEXT_MODEL_DEV)")
-parser.add_argument("--use_alternate_safety_image", type=str, default=None, help="Use a different image for safety eval.")
+parser.add_argument(
+    "--oe_eval_task_suite",
+    type=str,
+    default="NEXT_MODEL_DEV",
+    help="Task suite for OE eval: NEXT_MODEL_DEV, NEXT_MODEL_UNSEEN, TULU_3_DEV, TULU_3_UNSEEN (default: NEXT_MODEL_DEV)",
+)
+parser.add_argument(
+    "--use_alternate_safety_image", type=str, default=None, help="Use a different image for safety eval."
+)
 parser.add_argument("--evaluate_on_weka", action="store_true", help="Evaluate OE eval on Beaker.")
 # NOTE: evaluate on weka is expected to be on by default. If not, the evals will run on the google augusta cluster.
 # TODO: fix this logic at a future date
@@ -119,48 +161,48 @@ parser.add_argument("--evaluate_on_weka", action="store_true", help="Evaluate OE
 parser.add_argument("--oe_eval_tasks", type=str, default=None, help="Evaluate OE eval on Beaker.")
 parser.add_argument("--step", type=int, default=None, help="Step number for postgresql logging.")
 parser.add_argument("--run_id", type=str, default=None, help="A unique run ID for postgresql logging.")
-parser.add_argument("--oe_eval_stop_sequences", type=str, default=None, help="Comma-separated list of stop sequences for OE eval.")
-parser.add_argument("--process_output", type=str, default="r1_style", help="Process output type for OE eval (e.g., 'r1_style'). Defaults to 'r1_style', which should work for most of our models, including non-thinking ones.")
+parser.add_argument("--wandb_run_path", type=str, default=None, help="A unique run ID for postgresql logging.")
+parser.add_argument(
+    "--oe_eval_stop_sequences", type=str, default=None, help="Comma-separated list of stop sequences for OE eval."
+)
+parser.add_argument(
+    "--process_output",
+    type=str,
+    default="r1_style",
+    help="Process output type for OE eval (e.g., 'r1_style'). Defaults to 'r1_style', which should work for most of our models, including non-thinking ones.",
+)
 args = parser.parse_args()
 
 
 workspace = args.workspace
 model_type = "vanilla_lm" if not args.is_tuned else "tuned_lm"
 
-with open("configs/beaker_configs/default_eval.yaml", 'r') as f:
+with open("configs/beaker_configs/default_eval.yaml", "r") as f:
     default_yaml = f.read()
 d1 = yaml.load(default_yaml, Loader=yaml.FullLoader)
 
 cluster = args.cluster
 if cluster[0] == "all":
     cluster = []  # empty list means all clusters
-d1['tasks'][0]['constraints']['cluster'] = cluster
-d1['tasks'][0]['context']['priority'] = args.priority
-d1['tasks'][0]['context']['preemptible'] = args.preemptible
-d1['tasks'][0]['resources']['gpuCount'] = 1
+d1["tasks"][0]["constraints"]["cluster"] = cluster
+d1["tasks"][0]["context"]["priority"] = args.priority
+d1["tasks"][0]["context"]["preemptible"] = args.preemptible
+d1["tasks"][0]["resources"]["gpuCount"] = 1
 
 # remove nfs if asked or jupiter in cluster list.
 weka_available = False
 if all(c in WEKA_CLUSTERS for c in cluster):
-    d1['tasks'][0]['datasets'].append({
-        'mountPath': "/weka/oe-adapt-default",
-        "source": {
-            "weka": "oe-adapt-default"
-        }
-    })
-    d1['tasks'][0]['datasets'].append({
-        'mountPath': "/weka/oe-training-default",
-        "source": {
-            "weka": "oe-training-default"
-        }
-    })
+    d1["tasks"][0]["datasets"].append({"mountPath": "/weka/oe-adapt-default", "source": {"weka": "oe-adapt-default"}})
+    d1["tasks"][0]["datasets"].append(
+        {"mountPath": "/weka/oe-training-default", "source": {"weka": "oe-training-default"}}
+    )
     weka_available = True
 
 
 # NOTE: Remove in the future, not sure if this effects oe-eval jobs
 # Use a different image if requested.
 if args.beaker_image is not None:
-    d1['tasks'][0]['image']['beaker'] = args.beaker_image
+    d1["tasks"][0]["image"]["beaker"] = args.beaker_image
 
 # modify here, or use "--experiments", for different set of experiments
 experiment_groups_default = [
@@ -208,10 +250,10 @@ for experiment_group in experiment_groups:
     task_spec = copy.deepcopy(d1["tasks"][0])
 
     name = f"open_instruct_eval_{experiment_group}_{model_name}_{today}"
-    task_spec['name'] = name
+    task_spec["name"] = name
 
     if experiment_group == "mmlu_0shot":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.mmlu.run_eval \
             --ntrain 0 \
             --data_dir /data/mmlu/ \
@@ -221,9 +263,9 @@ for experiment_group in experiment_groups:
             --eval_batch_size 4 \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "mmlu_5shot":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.mmlu.run_eval \
             --ntrain 5 \
             --data_dir /data/mmlu/ \
@@ -233,9 +275,9 @@ for experiment_group in experiment_groups:
             --eval_batch_size 4 \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "bbh_direct":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.bbh.run_eval \
             --data_dir /data/bbh \
             --save_dir /output/ \
@@ -246,9 +288,9 @@ for experiment_group in experiment_groups:
             --no_cot \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "bbh_cot":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.bbh.run_eval \
             --data_dir /data/bbh \
             --save_dir /output/ \
@@ -258,9 +300,9 @@ for experiment_group in experiment_groups:
             --max_num_examples_per_task 40 \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "gsm_direct":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.gsm.run_eval \
             --data_dir /data/gsm/ \
             --max_num_examples 200 \
@@ -272,13 +314,13 @@ for experiment_group in experiment_groups:
             --no_cot \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
         if args.gsm_stop_at_double_newline:
             # We need to final backslash in the command above so that there isn't a
             # newline between this argument and the prior part of the command.
-            task_spec['arguments'][0] += " --stop_at_double_newline"
+            task_spec["arguments"][0] += " --stop_at_double_newline"
     elif experiment_group == "gsm_cot":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.gsm.run_eval \
             --data_dir /data/gsm/ \
             --max_num_examples 200 \
@@ -289,11 +331,11 @@ for experiment_group in experiment_groups:
             --n_shot 8 \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
         if args.gsm_stop_at_double_newline:
-            task_spec['arguments'][0] += " --stop_at_double_newline"
+            task_spec["arguments"][0] += " --stop_at_double_newline"
     elif experiment_group == "MATH_cot":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.MATH.run_eval \
             --data_dir /data/MATH/ \
             --max_num_examples 200 \
@@ -304,9 +346,9 @@ for experiment_group in experiment_groups:
             --n_shot 4 \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "tydiqa_goldp_1shot":
-        task_spec["arguments"][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.tydiqa.run_eval \
             --data_dir /data/tydiqa/ \
             --n_shot 1 \
@@ -318,9 +360,9 @@ for experiment_group in experiment_groups:
             --tokenizer_name_or_path /model \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "tydiqa_no_context_1shot":
-        task_spec["arguments"][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.tydiqa.run_eval \
             --data_dir /data/tydiqa/ \
             --no_context \
@@ -333,9 +375,9 @@ for experiment_group in experiment_groups:
             --tokenizer_name_or_path /model \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "codex_eval_temp_0.1":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.codex_humaneval.run_eval \
             --data_file /data/codex_humaneval/HumanEval.jsonl.gz \
             --eval_pass_at_ks 1 5 10 20 \
@@ -345,9 +387,9 @@ for experiment_group in experiment_groups:
             --use_vllm \
             --model_name_or_path /model \
             --tokenizer_name_or_path /model \
-        '''
+        """
     elif experiment_group == "codex_eval_temp_0.8":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.codex_humaneval.run_eval \
             --data_file /data/codex_humaneval/HumanEval.jsonl.gz \
             --eval_pass_at_ks 1 5 10 20 \
@@ -357,9 +399,9 @@ for experiment_group in experiment_groups:
             --use_vllm \
             --model_name_or_path /model \
             --tokenizer_name_or_path /model \
-        '''
+        """
     elif experiment_group == "codex_evalplus_temp_0.1":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.codex_humaneval.run_eval \
             --data_file /data/codex_humaneval/HumanEvalPlus-OriginFmt.jsonl.gz \
             --eval_pass_at_ks 1 5 10 20 \
@@ -371,9 +413,9 @@ for experiment_group in experiment_groups:
             --tokenizer_name_or_path /model \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
-        '''
+        """
     elif experiment_group == "codex_evalplus_temp_0.8":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.codex_humaneval.run_eval \
             --data_file /data/codex_humaneval/HumanEvalPlus-OriginFmt.jsonl.gz \
             --data_file_hep data/eval/codex_humaneval/humanevalpack.jsonl  \
@@ -386,9 +428,9 @@ for experiment_group in experiment_groups:
             --tokenizer_name_or_path /model \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
-        '''
+        """
     elif experiment_group == "mbpp_evalplus_temp_0.1":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             HF_ALLOW_CODE_EVAL=1 python -m eval.mbpp.run_eval \
             --eval_pass_at_ks 1 5 10 20 \
             --unbiased_sampling_size_n 20 \
@@ -399,9 +441,9 @@ for experiment_group in experiment_groups:
             --tokenizer_name_or_path /model \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
-        '''
+        """
     elif experiment_group == "mbpp_evalplus_temp_0.8":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             HF_ALLOW_CODE_EVAL=1 python -m eval.mbpp.run_eval \
             --eval_pass_at_ks 1 5 10 20 \
             --unbiased_sampling_size_n 20 \
@@ -412,9 +454,9 @@ for experiment_group in experiment_groups:
             --tokenizer_name_or_path /model \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format
-        '''
+        """
     elif experiment_group == "ifeval":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
             python -m eval.ifeval.run_eval \
                 --data_dir /data/ifeval/ \
                 --save_dir /output/ \
@@ -423,9 +465,9 @@ for experiment_group in experiment_groups:
                 --use_chat_format \
                 --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
                 --use_vllm \
-        '''
+        """
     elif experiment_group == "truthfulqa":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
         python -m eval.truthfulqa.run_eval \
             --data_dir /data/truthfulqa \
             --save_dir /output/ \
@@ -438,9 +480,9 @@ for experiment_group in experiment_groups:
             --eval_batch_size 20 \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "toxigen":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
         python -m eval.toxigen.run_eval \
             --data_dir /data/toxigen/ \
             --save_dir /output/ \
@@ -450,9 +492,9 @@ for experiment_group in experiment_groups:
             --use_vllm \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "xstest":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
         python -m eval.xstest.run_eval \
             --data_dir /data/xstest/ \
             --save_dir /output/ \
@@ -462,9 +504,9 @@ for experiment_group in experiment_groups:
             --use_vllm \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "alpaca_eval":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
         IS_ALPACA_EVAL_2=False python -m eval.alpaca_farm.run_eval \
             --use_vllm \
             --model_name_or_path /model \
@@ -472,9 +514,9 @@ for experiment_group in experiment_groups:
             --save_dir /output/ \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
     elif experiment_group == "alpaca_eval_2":
-        task_spec['arguments'][0] = '''
+        task_spec["arguments"][0] = """
         IS_ALPACA_EVAL_2=True python -m eval.alpaca_farm.run_eval \
             --use_vllm \
             --model_name_or_path /model \
@@ -482,43 +524,57 @@ for experiment_group in experiment_groups:
             --save_dir /output/ \
             --use_chat_format \
             --chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format \
-        '''
+        """
         # OLMo models can only output 2048 new tokens at most; default is 8192.
         if "olmo" in model_info[0] or args.olmo:
-            task_spec['arguments'][0] += " --max_new_tokens 4096" # nol increased hardcode to 4096
+            task_spec["arguments"][0] += " --max_new_tokens 4096"  # nol increased hardcode to 4096
 
     else:
         raise ValueError("experiment_group not supported")
 
     if model_info[0].startswith("hf-"):  # if it's a huggingface model, load it from the model hub
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--model_name_or_path /model", f"--model_name_or_path {model_info[1]} --hf_revision {args.hf_revision}")]
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--tokenizer_name_or_path /model", f"--tokenizer_name_or_path {model_info[1]}")]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--model_name_or_path /model", f"--model_name_or_path {model_info[1]} --hf_revision {args.hf_revision}"
+            )
+        ]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--tokenizer_name_or_path /model", f"--tokenizer_name_or_path {model_info[1]}"
+            )
+        ]
     elif model_info[1].startswith("/"):  # if it's a local model, load it from the local directory
         assert weka_available, "NFS / Weka is required for path-based models."  # to be safe.
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--model_name_or_path /model", f"--model_name_or_path {model_info[1]}")]
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--tokenizer_name_or_path /model", f"--tokenizer_name_or_path {model_info[1]}")]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace("--model_name_or_path /model", f"--model_name_or_path {model_info[1]}")
+        ]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--tokenizer_name_or_path /model", f"--tokenizer_name_or_path {model_info[1]}"
+            )
+        ]
     else:  # if it's a beaker model, mount the beaker dataset to `/model`
-        task_spec['datasets'][1]['source']['beaker'] = model_info[1]
+        task_spec["datasets"][1]["source"]["beaker"] = model_info[1]
 
     # if a specific checkpoint is specified, load model from that checkpoint
     if model_info[2] is not None:
         # extract existing model path
-        model_name_or_path = re.search(r"--model_name_or_path (\S+)", task_spec['arguments'][0]).group(1)
+        model_name_or_path = re.search(r"--model_name_or_path (\S+)", task_spec["arguments"][0]).group(1)
         # replace the model path with the checkpoint subfolder.
-        task_spec['arguments'] = [task_spec['arguments'][0].replace(model_name_or_path, model_name_or_path+"/"+model_info[2], 1)]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(model_name_or_path, model_name_or_path + "/" + model_info[2], 1)
+        ]
         # NOTE: We don't change the tokenizer subfolder, because by default the
         # tokenizer is only saved to the top-level output dir. That's why we call
         # `str.replace(..., 1)` above; this only replaces the first match.
 
     # for vanilla_lm, remove the chat formatting function
     if model_info[3] == "vanilla_lm":
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--use_chat_format", "")]
+        task_spec["arguments"] = [task_spec["arguments"][0].replace("--use_chat_format", "")]
 
     # Adjust batch size and gpus.
     task_spec = adjust_batch_size(
-        task_spec=task_spec,
-        model_name=model_info[0],
-        batch_size_reduction=args.batch_size_reduction,
+        task_spec=task_spec, model_name=model_info[0], batch_size_reduction=args.batch_size_reduction
     )
     task_spec = adjust_gpus(
         task_spec=task_spec,
@@ -530,47 +586,61 @@ for experiment_group in experiment_groups:
     # if using huggingface tokenizer template, replace the chat formatting function with hf tokenizer one
     # otherwise, try to guess what template to use based on model name
     if args.use_hf_tokenizer_template:
-        task_spec['arguments'] = [task_spec['arguments'][0].replace(
-            "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
-            "--chat_formatting_function eval.templates.create_prompt_with_huggingface_tokenizer_template")
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
+                "--chat_formatting_function eval.templates.create_prompt_with_huggingface_tokenizer_template",
+            )
         ]
     elif "llama2-chat" in model_info[0]:
-        task_spec['arguments'] = [task_spec['arguments'][0].replace(
-            "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
-            "--chat_formatting_function eval.templates.create_prompt_with_llama2_chat_format")
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
+                "--chat_formatting_function eval.templates.create_prompt_with_llama2_chat_format",
+            )
         ]
     elif "code_llama_instruct" in model_info[0]:
-        task_spec['arguments'] = [task_spec['arguments'][0].replace(
-            "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
-            "--chat_formatting_function eval.templates.create_prompt_with_llama2_chat_format")
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
+                "--chat_formatting_function eval.templates.create_prompt_with_llama2_chat_format",
+            )
         ]
     elif "zephyr" in model_info[0]:
-        task_spec['arguments'] = [task_spec['arguments'][0].replace(
-            "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
-            "--chat_formatting_function eval.templates.create_prompt_with_zephyr_chat_format")
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
+                "--chat_formatting_function eval.templates.create_prompt_with_zephyr_chat_format",
+            )
         ]
     elif "xwin" in model_info[0]:
-        task_spec['arguments'] = [task_spec['arguments'][0].replace(
-            "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
-            "--chat_formatting_function eval.templates.create_prompt_with_xwin_chat_format")
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
+                "--chat_formatting_function eval.templates.create_prompt_with_xwin_chat_format",
+            )
         ]
     elif "olmo" in model_info[0] or args.olmo:
-        task_spec['arguments'] = [task_spec['arguments'][0].replace(
-            "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
-            "--chat_formatting_function eval.templates.create_prompt_with_olmo_chat_format")
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--chat_formatting_function eval.templates.create_prompt_with_tulu_chat_format",
+                "--chat_formatting_function eval.templates.create_prompt_with_olmo_chat_format",
+            )
         ]
 
     if any([x in model_info[0] for x in ["opt", "pythia", "falcon", "olmoe"]]):
-        if "--use_vllm" in task_spec['arguments'][0]:
+        if "--use_vllm" in task_spec["arguments"][0]:
             if not args.skip_oi_evals:
                 print(f"Removing --use_vllm for {model_info[0]}")
-            task_spec['arguments'] = [task_spec['arguments'][0].replace("--use_vllm", "")]
+            task_spec["arguments"] = [task_spec["arguments"][0].replace("--use_vllm", "")]
 
     # Add additional stop sequences if needed.
     # mainly for llama-3-instruct eot.
     tasks_without_addition_stop = ["mmlu_0shot", "mmlu_5shot", "truthfulqa"]
     if args.add_stop_sequence and experiment_group not in tasks_without_addition_stop:
-        task_spec['arguments'] = [task_spec['arguments'][0] + " --additional_stop_sequence " + " ".join(args.add_stop_sequence)]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0] + " --additional_stop_sequence " + " ".join(args.add_stop_sequence)
+        ]
 
     # add HF hub upload if specified
     if args.upload_to_hf:
@@ -578,7 +648,7 @@ for experiment_group in experiment_groups:
             # by default, we dont upload oi-evals, only safety and oe-evals.
             args.hf_upload_experiments = []
         if experiment_group not in args.hf_upload_experiments:
-            if not args.skip_oi_evals: 
+            if not args.skip_oi_evals:
                 print(f"Skipping HF upload for {experiment_group}")
         else:
             hf_dataset = args.upload_to_hf
@@ -586,14 +656,16 @@ for experiment_group in experiment_groups:
             # if we prepended hf- to the model name, remove it.
             if model_name.startswith("hf-"):
                 model_name = model_name[3:]
-            task_spec['arguments'] = [task_spec['arguments'][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name results/{model_name}"]
+            task_spec["arguments"] = [
+                task_spec["arguments"][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name results/{model_name}"
+            ]
 
     eval_task_specs.append(task_spec)
 
 
 # Create an experiment that runs all the eval tasks.
 
-model_name = model_name[:100] # beaker doesn't like names longer than 128 characters, here we save for some headroom.
+model_name = model_name[:100]  # beaker doesn't like names longer than 128 characters, here we save for some headroom.
 if not args.skip_oi_evals:
     experiment_name = f"open_instruct_eval_{model_name}_{today}"
     d["description"] = experiment_name
@@ -631,10 +703,12 @@ if args.run_oe_eval_experiments:
         oe_eval_cmd += f" --tasks {args.oe_eval_tasks}"
     if args.run_id:
         oe_eval_cmd += f" --run-id {args.run_id}"
+    if args.wandb_run_path:
+        oe_eval_cmd += f" --wandb-run-path {args.wandb_run_path}"
     if args.step:
         oe_eval_cmd += f" --step {args.step}"
     # add string with number of gpus
-    num_gpus = task_spec['resources']['gpuCount']
+    num_gpus = task_spec["resources"]["gpuCount"]
     # if num_gpus > 1, double it again for oe-eval configs
     # open_instruct GPT adjustment wasn't quite enough
     # adjusted here so the GPU configs in open-instruct eval are not impacted by the change
@@ -675,7 +749,9 @@ if args.run_oe_eval_experiments:
 if args.run_safety_evaluations:
     # just take the original spec we had, modify it for safety eval.
     experiment_name = f"oi_safety_{model_name}"
-    experiment_name = experiment_name.replace('β', '').replace(r"{", "").replace(r"}", "") # hack: remove characters beaker doesn't like
+    experiment_name = (
+        experiment_name.replace("β", "").replace(r"{", "").replace(r"}", "")
+    )  # hack: remove characters beaker doesn't like
     d["description"] = experiment_name
     # specific image for safety eval
     d["tasks"][0]["image"]["beaker"] = "hamishivi/open-safety"
@@ -684,25 +760,43 @@ if args.run_safety_evaluations:
     d["tasks"] = [d["tasks"][0]]
     task_spec = d["tasks"][0]
     task_spec["name"] = experiment_name
-    task_spec["arguments"][0] = '''
+    task_spec["arguments"][0] = """
 VLLM_WORKER_MULTIPROC_METHOD=spawn PYTHONPATH=. python evaluation/run_all_generation_benchmarks.py \
     --model_name_or_path /model \
     --model_input_template_path_or_name hf \
     --report_output_path /output/metrics.json \
     --save_individual_results_path /output/all.json \
-'''
+"""
     # some copied logic
-    if model_info[0].startswith("hf-"):  # if it's a huggingface model, load it from the model hub and delete mount `/model`
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--model_name_or_path /model", f"--model_name_or_path {model_info[1]} --hf_revision {args.hf_revision}")]
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--tokenizer_name_or_path /model", f"--tokenizer_name_or_path {model_info[1]}")]
-        del task_spec['datasets'][1]
-    elif model_info[1].startswith("/"):  # if it's a local model, load it from the local directory and delete mount `/model`
+    if model_info[0].startswith(
+        "hf-"
+    ):  # if it's a huggingface model, load it from the model hub and delete mount `/model`
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--model_name_or_path /model", f"--model_name_or_path {model_info[1]} --hf_revision {args.hf_revision}"
+            )
+        ]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--tokenizer_name_or_path /model", f"--tokenizer_name_or_path {model_info[1]}"
+            )
+        ]
+        del task_spec["datasets"][1]
+    elif model_info[1].startswith(
+        "/"
+    ):  # if it's a local model, load it from the local directory and delete mount `/model`
         assert weka_available, "NFS / Weka is required for path-based models."  # to be safe.
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--model_name_or_path /model", "--model_name_or_path "+model_info[1])]
-        task_spec['arguments'] = [task_spec['arguments'][0].replace("--tokenizer_name_or_path /model", "--tokenizer_name_or_path "+model_info[1])]
-        del task_spec['datasets'][1]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace("--model_name_or_path /model", "--model_name_or_path " + model_info[1])
+        ]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0].replace(
+                "--tokenizer_name_or_path /model", "--tokenizer_name_or_path " + model_info[1]
+            )
+        ]
+        del task_spec["datasets"][1]
     else:  # if it's a beaker model, mount the beaker dataset to `/model`
-        task_spec['datasets'][1]['source']['beaker'] = model_info[1]
+        task_spec["datasets"][1]["source"]["beaker"] = model_info[1]
 
     task_spec = adjust_gpus(
         task_spec=task_spec,
@@ -714,9 +808,9 @@ VLLM_WORKER_MULTIPROC_METHOD=spawn PYTHONPATH=. python evaluation/run_all_genera
     # add gpu information.
     # we just assume you want to use all the gpus for one task at a time
     if "70B" in model_info[0]:
-        task_spec['resources']['gpuCount'] = 8
-    num_gpus = task_spec['resources']['gpuCount']
-    task_spec["arguments"][0]+= f" --min_gpus_per_task {num_gpus}"
+        task_spec["resources"]["gpuCount"] = 8
+    num_gpus = task_spec["resources"]["gpuCount"]
+    task_spec["arguments"][0] += f" --min_gpus_per_task {num_gpus}"
 
     if args.upload_to_hf:
         hf_dataset = args.upload_to_hf
@@ -725,7 +819,9 @@ VLLM_WORKER_MULTIPROC_METHOD=spawn PYTHONPATH=. python evaluation/run_all_genera
         # if model_name.startswith("hf-"):
         #     model_name = model_name[3:]
         # Above is no longer the case, oe-eval includes hf- again
-        task_spec['arguments'] = [task_spec['arguments'][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name results/{model_name}"]
+        task_spec["arguments"] = [
+            task_spec["arguments"][0] + f" --upload_to_hf {hf_dataset} --hf_upload_name results/{model_name}"
+        ]
 
     d["tasks"] = [task_spec]
     if not os.path.exists("configs/beaker_configs/auto_created"):


### PR DESCRIPTION
requires PR https://github.com/allenai/oe-eval-internal/pull/636 but only locally so you can update your local ./oe-eval-internal with it and it'll work fine

its put behind a flag `--oe_eval_log_to_wandb` because it requires adding your beaker secret to `user_WANDB_API_KEY`. Ideally, we should check that this beaker secret exists for the user if this flag is set and throw an error otherwise

results are logged to wandb.run.summary currently e.g. https://wandb.ai/ai2-llm/open_instruct_internal/runs/hw5ish22/overview