### PR TITLE
Remove duplicate olmo-instruct templates

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -448,7 +448,7 @@ CHAT_TEMPLATES = {
         "The user asks a question, and the Assistant solves it. "
         "The assistant first thinks about the reasoning process in "
         "the mind and then provides the user with the answer. "
-        "The reasoning process and answer is enclosed within <think> </think> "
+        "The reasoning process and answer are enclosed within <think> </think> "
         "and <answer> </answer> tags, respectively, "
         "i.e., <think> reasoning process here </think> "
         "<answer> answer here </answer>."


### PR DESCRIPTION
We had two olmo_thinker / olmo_thinker_r1_templates in the codebase for some reason. This removes one set. They were identical minus one minor typo in thinker_r1, which I have fixed.