### PR TITLE
Autoset RAY CGRAPH timeout if not explicitly set

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -264,6 +264,9 @@ def get_env_vars(pure_docker_mode: bool, cluster: List[str], beaker_secrets: Lis
     if "VLLM_ATTENTION_BACKEND" not in additional_env_vars:
         env_vars.append(beaker.EnvVar(name="VLLM_ATTENTION_BACKEND",
                                       value="FLASHINFER"))
+    if "RAY_CGRAPH_get_timeout" not in additional_env_vars:
+        env_vars.append(beaker.EnvVar(name="RAY_CGRAPH_get_timeout",
+                                      value="300"))
     # Add user-specified environment variables first
     for env_var in additional_env_vars:
         env_vars.append(


### PR DESCRIPTION
Running with tp > 1, we swap the vllm backend to use ray to manage nodes, and the vllm generation usually crashes. With some debugging, I found it was because of a bug in vLLM where the cgraph timeout gets set to 10s, which is too low (see https://github.com/vllm-project/vllm/pull/19725). This is fixed in newer vllms, but luckily for us an even simpler fix is just to explicitly set the env var ourselves.

This PR sets the appropriate variable by default in mason.py.

Currently testing!
TP 1, 16 engines: https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K3761DEBKJEFQA8TT8WWF3V6?taskId=01K3761DEG94WTZY85180A22GC&jobId=01K3761DJJFTR9G26PV10PYEJK
TP 2, 8 engines: https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K3763PQ6NMH5G5BSBQZZ3ZBN?taskId=01K3763PQETEB22F0WV0JSN7RC&jobId=01K3763PVETKTPJ4F243GFM8GE
TP 8, 2 engines: https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K376624V2SENDQFKRAHRHYVB?taskId=01K3766252QET8EPW0B8YS6H5C&jobId=01K376628YZDHJ13P3EPKTDECK
TP 16, 1 engine: https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K3768GQ5G6AWZ42KPY5SXGDC?taskId=01K3768GQ8HBRT0RMP05T21DNR&jobId=01K3768GV063DRX77BMRFWZVT3