### PR TITLE
Explicitly bind ray dashboard host

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,6 @@ RUN --mount=type=cache,target=${UV_CACHE_DIR} \
 
 RUN uv run --no-sync -m nltk.downloader punkt punkt_tab
 
-RUN uv pip install py-spy
-
 # Copy all application code at the end
 COPY eval eval
 COPY configs configs


### PR DESCRIPTION
Explicitly bind the ray dashboard host to `0.0.0.0` so it is accessible to us when running training jobs. Should make debugging nicer (and help me work out this olmo hanging issue....).

Example job with the change: https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01K39G8EK4SRFPJ0PK2VGH4X49?taskId=01K39G8EKAE12WTMFKXBKG59D6&jobId=01K39G8EPYHV56XM05XBBWPDYY

Currently stack trace only works on austin clusters (not augusta). Not sure where/if I should put this in documentation somewhere?