### PR TITLE
Another attempt at fixing the experiment.

### DIFF
--- a/scripts/train/build_image_and_launch.sh
+++ b/scripts/train/build_image_and_launch.sh
@@ -3,7 +3,10 @@ set -euo pipefail
 
 git_hash=$(git rev-parse --short HEAD)
 git_branch=$(git rev-parse --abbrev-ref HEAD)
-image_name=open-instruct-integration-test-${git_branch}
+# Sanitize the branch name to remove invalid characters for Beaker names
+# Beaker names can only contain letters, numbers, -_. and may not start with -
+sanitized_branch=$(echo "$git_branch" | sed 's/[^a-zA-Z0-9._-]/-/g' | sed 's/^-//')
+image_name=open-instruct-integration-test-${sanitized_branch}
 
 # Build the Docker image exactly like push-image.yml does, passing git info as build args
 docker build --platform=linux/amd64 \


### PR DESCRIPTION
The Beaker experiment integration test is [still failing](https://github.com/allenai/open-instruct/actions/runs/17163817464/job/48699292650) due to a silly naming error: 

`Error: "open-instruct-integration-test-gh-readonly-queue/main/pr-938-2938bd66598d87f630271c32e6b365c804cd3aaa" is not a valid name; names may contain letters, numbers, the characters -_. and may not start with -`

This has been fixed.