### PR TITLE
Use the LLM judge tokenizer

### DIFF
--- a/open_instruct/context_window_checker.py
+++ b/open_instruct/context_window_checker.py
@@ -140,7 +140,7 @@ def check_context_window_limit(
 
     except Exception as e:
         logger.warning(f"Failed to load HuggingFace tokenizer for {model_name}: {e}. Falling back to tiktoken.")
-        
+
         # Fall back to tiktoken if HuggingFace tokenizer fails
         if not TIKTOKEN_AVAILABLE:
             logger.warning("tiktoken not available. Skipping context window check.")


### PR DESCRIPTION
Use the LLM judge tokenizer instead of `cl100k_base` for context window checker.

This resolve the issue we face with Chinese characters where there's a large discrepancy between the actual judge token count vs `cl100k_base` as encoding. 