### PR TITLE
Adds try/except to guard against beaker errors, and adds comment describing compile issue.

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -503,6 +503,8 @@ def get_env_vars(pure_docker_mode: bool, cluster: List[str], beaker_secrets: Lis
         ])
 
     # by default, we turn off vllm compile cache
+    # torch compile caching seems consistently broken, but the actual compiling isn't.
+    # Not sure why, for now we have disabled the caching (VLLM_DISABLE_COMPILE_CACHE=1).
     env_vars.extend([
         beaker.EnvVar(
             name="VLLM_DISABLE_COMPILE_CACHE",

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -1036,8 +1036,12 @@ def maybe_update_beaker_description(
         if len(new_description) > 200
         else f"Setting new Beaker description: {new_description}"
     )
-    client.experiment.set_description(experiment_id, new_description)
-    logger.info("Successfully updated Beaker description")
+    try:
+        client.experiment.set_description(experiment_id, new_description)
+        logger.info("Successfully updated Beaker description")
+    except requests.exceptions.HTTPError as e:
+        logger.warning(f"Failed to update Beaker description due to HTTP error: {e}")
+        logger.warning("Continuing without updating description - this is likely a temporary Beaker service issue")
 
 
 def live_subprocess_output(cmd: List[str]) -> str:

--- a/scripts/train/debug/full_integration_test.sh
+++ b/scripts/train/debug/full_integration_test.sh
@@ -20,6 +20,8 @@ for split_var in split_int_mix_3; do
         --preemptible \
         --num_nodes 2 \
         --max_retries 0 \
+        # torch compile caching seems consistently broken, but the actual compiling isn't.
+        # Not sure why, for now we have disabled the caching (VLLM_DISABLE_COMPILE_CACHE=1).
         --env VLLM_DISABLE_COMPILE_CACHE=1 \
         --env HOSTED_VLLM_API_BASE=http://saturn-cs-aus-253.reviz.ai2.in:8001/v1 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \


### PR DESCRIPTION
The try/except is to prevent Beaker service issues from taking down experiments. 

The comment is to prevent future us from enabling the cache if it's still broken. 