### PR TITLE
Fix ray bundles indices, max len config.

### DIFF
--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -89,6 +89,11 @@ class VerificationResult:
     reasoning: Optional[str] = None
 
 
+@dataclass
+class MaxLengthVerifierConfig(VerifierConfig):
+    max_length_verifier_max_length: int
+
+
 class VerifierFunction(ABC):
     """
     Base class for all verifier functions that evaluate model predictions against ground truth.
@@ -540,8 +545,17 @@ class MaxLenVerifier(VerifierFunction):
         # return absolute difference between the length of the prediction and the max length
         # make sure to disallow negative rewards
         length_diff = abs(len(tokenized_prediction) - desired_length)
-        score = 1 - (length_diff / 8192)
+        score = 1 - (length_diff / self.verifier_config.max_length_verifier_max_length)
         return VerificationResult(score=score)
+
+    @classmethod
+    def get_config_class(cls) -> type:
+        """
+        Return the configuration class for this verifier.
+        Returns:
+            type: The VerifierConfig class or its subclass
+        """
+        return MaxLengthVerifierConfig
 
 
 class UpToMaxLenVerifier(VerifierFunction):
@@ -564,8 +578,17 @@ class UpToMaxLenVerifier(VerifierFunction):
             return VerificationResult(score=1.0)
         # if we were too long, return the difference
         # make sure to disallow negative rewards
-        score = 1 - (length_diff / 8192)
+        score = 1 - (length_diff / self.verifier_config.max_length_verifier_max_length)
         return VerificationResult(score=score)
+
+    @classmethod
+    def get_config_class(cls) -> type:
+        """
+        Return the configuration class for this verifier.
+        Returns:
+            type: The VerifierConfig class or its subclass
+        """
+        return MaxLengthVerifierConfig
 
 
 class LMJudgeVerifier(VerifierFunction):

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -310,6 +310,10 @@ class Args:
     code_apply_perf_penalty: bool = False
     """whether to apply a performance penalty to the code verifier"""
 
+    # -- max length verifier
+    max_length_verifier_max_length: int = 32768
+    """the max length to use for the max length verifier"""
+
     # -- non stop penalty
     non_stop_penalty: bool = False
     """whether to penalize responses which did not finish generation"""


### PR DESCRIPTION
Two changes:
1. Allow configurable max length for max len verifier. This makes running experiments easier.
2. Properly assign bundle indices for the vllm engines. This prevents unnecessary communication when TP>1. Turns out in the past we could be doing inter-node communication for this case!

Testing now (tested on a diff branch with some other changes before).