### PR TITLE
Fix UnboundLocalError where metrics weren't defined

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2636,7 +2636,7 @@ def run_training(
 
         for metrics_Q in [generate_metrics_Q, weight_sync_metrics_Q]:
             try:
-                data_thread_metrics |= metrics_Q.get_nowait() 
+                data_thread_metrics |= metrics_Q.get_nowait()
             except Empty:
                 logger.info("[Main Thread] didn't get train generation metrics")
 


### PR DESCRIPTION
I think that we weren't hitting this bug because we were never triggering the case where the queue was empty. 

Single GPU run: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K3RYST28QVYMQMTCD8AGJHSA?)