### PR TITLE
Better logging of errors in threads

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2564,9 +2564,8 @@ def run_training(
     )
 
     # setup health check function to check that everything is still alive
-    health_check_fn = lambda: [
-        f.result() for f in [packing_future, generation_future, weight_sync_thread_future] if f.done()
-    ]
+    def health_check_fn():
+        [f.result() for f in [packing_future, generation_future, weight_sync_thread_future] if f.done()]
 
     # Send initial data to ensure we have a N-step offset.
     for _ in range(args.async_steps):


### PR DESCRIPTION
Makes the healthcheck a function, and then adds a check in the loop where we check for a response from the data prep thread (since that would just hang infinitely before).

Adding a random ValueError into the data preparation thread, now this is correctly caught:
```
2025-08-29 18:42:52 - INFO - rl_utils2.py:32 - 🚀 [Data Preparation Thread] Getting response ids: 18.638 seconds
2025-08-29 18:42:52 - INFO - rl_utils2.py:32 - 🔥 Generation time: 18.643 seconds
(LLMRayActor pid=376109) 2025-08-29 18:42:52 - INFO - vllm_utils3.py:447 - [LLMRayActor] Terminating after 513 iterations with 8 outputs
2025-08-29 18:42:54 - INFO - rl_utils2.py:32 - [Weight Sync]: 8.825 seconds
(LLMRayActor pid=376109) 2025-08-29 18:42:54 - INFO - vllm_utils3.py:407 - [LLMRayActor] Processing request with 8 prompts, tools=False
2025-08-29 18:43:03 - INFO - rl_utils2.py:32 - 🔥 Generation time: 8.784 seconds
2025-08-29 18:43:03 - WARNING - grpo_fast.py:2157 - [Generate Thread] generate metrics queue full, skipping metric
(LLMRayActor pid=376109) 2025-08-29 18:43:03 - INFO - vllm_utils3.py:447 - [LLMRayActor] Terminating after 513 iterations with 8 outputs
2025-08-29 18:43:15 - INFO - rl_utils2.py:32 - [Main Thread] 📦 Getting packed sequences from thread: 30.001 seconds
2025-08-29 18:43:15 - INFO - grpo_fast.py:2476 - Signaling all actors to stop...
2025-08-29 18:43:15 - INFO - grpo_fast.py:2478 - ✅ Signaled all actors to stop
2025-08-29 18:43:15 - INFO - grpo_fast.py:2480 - Pushing shutdown sentinel to queues...
2025-08-29 18:43:15 - INFO - grpo_fast.py:2485 - Shutting down Ray queues...
2025-08-29 18:43:15 - INFO - rl_utils2.py:32 - 🔥 Generation time: 12.555 seconds
2025-08-29 18:43:15 - INFO - grpo_fast.py:2488 - Shutting down thread pool executor...
2025-08-29 18:43:16 - INFO - grpo_fast.py:2136 - [Weight Sync Thread] 🛑 Stopping weight sync thread
2025-08-29 18:43:16 - INFO - grpo_fast.py:2461 - ✅ LLM judge clients cleaned up
2025-08-29 18:43:20 - INFO - grpo_fast.py:2463 - ✅ Ray shut down
Traceback (most recent call last):
  File "/weka/oe-adapt-default/hamishi/open-instruct/open_instruct/grpo_fast.py", line 2069, in load_data_from_packing_thread
    packed_data = packed_sequences_Q.get(timeout=30.0)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/oe-adapt-default/hamishi/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/queue.py", line 179, in get
    raise Empty
_queue.Empty

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/weka/oe-adapt-default/hamishi/open-instruct/open_instruct/grpo_fast.py", line 2850, in <module>
    main(args, tokenizer_config, model_config)
  File "/weka/oe-adapt-default/hamishi/open-instruct/open_instruct/grpo_fast.py", line 2788, in main
    episode = run_training(
              ^^^^^^^^^^^^^
  File "/weka/oe-adapt-default/hamishi/open-instruct/open_instruct/grpo_fast.py", line 2641, in run_training
    collated_data, data_thread_metrics, num_total_tokens = load_data_from_packing_thread(
                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/oe-adapt-default/hamishi/open-instruct/open_instruct/grpo_fast.py", line 2073, in load_data_from_packing_thread
    health_check_fn()
  File "/weka/oe-adapt-default/hamishi/open-instruct/open_instruct/grpo_fast.py", line 2570, in health_check_fn
    [f.result() for f in [packing_future, generation_future, weight_sync_thread_future] if f.done()]
  File "/weka/oe-adapt-default/hamishi/open-instruct/open_instruct/grpo_fast.py", line 2570, in <listcomp>
    [f.result() for f in [packing_future, generation_future, weight_sync_thread_future] if f.done()]
     ^^^^^^^^^^
  File "/weka/oe-adapt-default/hamishi/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/weka/oe-adapt-default/hamishi/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/weka/oe-adapt-default/hamishi/uv/python/cpython-3.11.12-linux-x86_64-gnu/lib/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/weka/oe-adapt-default/hamishi/open-instruct/open_instruct/grpo_fast.py", line 1518, in data_preparation_thread
    raise ValueError("test")
ValueError: test
```

Succesful single-gpu debug job just to make sure nothing broke: https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K3VJDBV0GZQVRQBTGTDF68S7?taskId=01K3VJDBV2NKZYMS0MZ7W9V754&jobId=01K3VJDBYCPZDRGH7MAVERX887