### PR TITLE
Fix progress update so that it doesn't duplicate components.

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -355,6 +355,8 @@ class Args:
     # Experiment tracking
     verbose: bool = False
     """If toggled, debug output will be shown"""
+    update_progress_every: int = 10
+    """How often to update the progress bar (in steps)."""
     with_tracking: bool = False
     """If toggled, this experiment will be tracked with Weights and Biases"""
     wandb_project_name: str = "open_instruct_internal"
@@ -1857,7 +1859,6 @@ def setup_experiment_tracking(args: Args, tc: TokenizerConfig, model_config: Mod
             tags=[args.exp_name] + get_wandb_tags(),
         )
         wandb_url = wandb.run.get_url()
-        logger.info(f"Initial Beaker description update with wandb_url: {wandb_url}")
         maybe_update_beaker_description(wandb_url=wandb_url)
 
     return beaker_config, wandb_url
@@ -2641,10 +2642,9 @@ def run_training(
 
         if (
             training_step == resume_training_step
-            or training_step % 10 == 0
+            or training_step % args.update_progress_every == 0
             or training_step == args.num_training_steps
         ):
-            logger.info(f"Progress update for Beaker description: step {training_step}/{args.num_training_steps}")
             maybe_update_beaker_description(
                 current_step=training_step,
                 total_steps=args.num_training_steps,

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Copied from https://github.com/huggingface/alignment-handbook/blob/main/tests/test_data.py
-import os
 import time
 import unittest
 from unittest import mock
@@ -103,11 +102,15 @@ def _setup_beaker_mocks(mock_beaker_from_env, mock_is_beaker_job, initial_descri
 class TestBeakerDescription(unittest.TestCase):
     """Test the beaker description update function."""
 
-    @mock.patch.dict(os.environ, {"BEAKER_WORKLOAD_ID": "test-id-123", "GIT_COMMIT": "abc123", "GIT_BRANCH": "main"})
+    @mock.patch("os.environ.get")
     @mock.patch("beaker.Beaker.from_env")
     @mock.patch("open_instruct.utils.is_beaker_job")
-    def test_description_does_not_accumulate(self, mock_is_beaker_job, mock_beaker_from_env):
+    def test_description_does_not_accumulate(self, mock_is_beaker_job, mock_beaker_from_env, mock_environ_get):
         """Test that the description doesn't accumulate git info and wandb URLs on repeated calls."""
+        # Configure os.environ.get mock
+        env_values = {"BEAKER_WORKLOAD_ID": "test-id-123", "GIT_COMMIT": "abc123", "GIT_BRANCH": "main"}
+        mock_environ_get.side_effect = lambda key, default=None: env_values.get(key, default)
+
         mock_client, mock_spec, description_history = _setup_beaker_mocks(
             mock_beaker_from_env, mock_is_beaker_job, "Beaker-Mason job."
         )
@@ -157,11 +160,15 @@ class TestBeakerDescription(unittest.TestCase):
             self.assertIn(wandb_url, desc)
             self.assertIn(f"% complete (step {(i + 1) * 10}/100)", desc)
 
-    @mock.patch.dict(os.environ, {"BEAKER_WORKLOAD_ID": "test-id-123", "GIT_COMMIT": "def456", "GIT_BRANCH": "dev"})
+    @mock.patch("os.environ.get")
     @mock.patch("beaker.Beaker.from_env")
     @mock.patch("open_instruct.utils.is_beaker_job")
-    def test_description_without_progress(self, mock_is_beaker_job, mock_beaker_from_env):
+    def test_description_without_progress(self, mock_is_beaker_job, mock_beaker_from_env, mock_environ_get):
         """Test description updates without progress information."""
+        # Configure os.environ.get mock
+        env_values = {"BEAKER_WORKLOAD_ID": "test-id-123", "GIT_COMMIT": "def456", "GIT_BRANCH": "dev"}
+        mock_environ_get.side_effect = lambda key, default=None: env_values.get(key, default)
+
         mock_client, mock_spec, description_history = _setup_beaker_mocks(
             mock_beaker_from_env, mock_is_beaker_job, "Initial job description"
         )

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -104,9 +104,9 @@ class TestBeakerDescription(unittest.TestCase):
     """Test the beaker description update function."""
 
     @mock.patch.dict(os.environ, {"BEAKER_WORKLOAD_ID": "test-id-123", "GIT_COMMIT": "abc123", "GIT_BRANCH": "main"})
-    @mock.patch("open_instruct.utils.is_beaker_job")
     @mock.patch("beaker.Beaker.from_env")
-    def test_description_does_not_accumulate(self, mock_beaker_from_env, mock_is_beaker_job):
+    @mock.patch("open_instruct.utils.is_beaker_job")
+    def test_description_does_not_accumulate(self, mock_is_beaker_job, mock_beaker_from_env):
         """Test that the description doesn't accumulate git info and wandb URLs on repeated calls."""
         mock_client, mock_spec, description_history = _setup_beaker_mocks(
             mock_beaker_from_env, mock_is_beaker_job, "Beaker-Mason job."
@@ -158,9 +158,9 @@ class TestBeakerDescription(unittest.TestCase):
             self.assertIn(f"% complete (step {(i + 1) * 10}/100)", desc)
 
     @mock.patch.dict(os.environ, {"BEAKER_WORKLOAD_ID": "test-id-123", "GIT_COMMIT": "def456", "GIT_BRANCH": "dev"})
-    @mock.patch("open_instruct.utils.is_beaker_job")
     @mock.patch("beaker.Beaker.from_env")
-    def test_description_without_progress(self, mock_beaker_from_env, mock_is_beaker_job):
+    @mock.patch("open_instruct.utils.is_beaker_job")
+    def test_description_without_progress(self, mock_is_beaker_job, mock_beaker_from_env):
         """Test description updates without progress information."""
         mock_client, mock_spec, description_history = _setup_beaker_mocks(
             mock_beaker_from_env, mock_is_beaker_job, "Initial job description"

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -13,13 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Copied from https://github.com/huggingface/alignment-handbook/blob/main/tests/test_data.py
+import os
+import time
 import unittest
+from unittest import mock
 
 import pytest
 from dateutil import parser
 from parameterized import parameterized
 
-from open_instruct.utils import get_datasets, repeat_each
+from open_instruct import utils
 
 
 class GetDatasetsTest(unittest.TestCase):
@@ -31,7 +34,7 @@ class GetDatasetsTest(unittest.TestCase):
             "HuggingFaceH4/testing_self_instruct_small": 0.3,
             "HuggingFaceH4/testing_codealpaca_small": 0.2,
         }
-        datasets = get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
+        datasets = utils.get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
         self.assertEqual(len(datasets["train"]), 100)
         self.assertEqual(len(datasets["test"]), 300)
 
@@ -41,24 +44,24 @@ class GetDatasetsTest(unittest.TestCase):
             "HuggingFaceH4/testing_self_instruct_small": 1.0,
             "HuggingFaceH4/testing_codealpaca_small": 1.0,
         }
-        datasets = get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
+        datasets = utils.get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
         self.assertEqual(len(datasets["train"]), 300)
         self.assertEqual(len(datasets["test"]), 300)
 
     def test_loading_with_fractions_greater_than_unity(self):
         dataset_mixer = {"HuggingFaceH4/testing_alpaca_small": 0.7, "HuggingFaceH4/testing_self_instruct_small": 0.4}
-        datasets = get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
+        datasets = utils.get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
         self.assertEqual(len(datasets["train"]), 70 + 40)
         self.assertEqual(len(datasets["test"]), 200)
 
     def test_loading_fails_with_negative_fractions(self):
         dataset_mixer = {"HuggingFaceH4/testing_alpaca_small": 0.7, "HuggingFaceH4/testing_self_instruct_small": -0.3}
         with pytest.raises(ValueError, match=r"Dataset fractions / lengths cannot be negative."):
-            get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
+            utils.get_datasets(dataset_mixer, columns_to_keep=["prompt", "completion"])
 
     def test_loading_single_split_with_unit_fractions(self):
         dataset_mixer = {"HuggingFaceH4/testing_alpaca_small": 1.0}
-        datasets = get_datasets(dataset_mixer, splits=["test"], columns_to_keep=["prompt", "completion"])
+        datasets = utils.get_datasets(dataset_mixer, splits=["test"], columns_to_keep=["prompt", "completion"])
         self.assertEqual(len(datasets["test"]), 100)
         self.assertRaises(KeyError, lambda: datasets["train"])
 
@@ -67,13 +70,135 @@ class GetDatasetsTest(unittest.TestCase):
             "ai2-adapt-dev/ultrafeedback-small": 1000,
             "ai2-adapt-dev/summarize_from_feedback_small": 1000,
         }
-        pref_datasets = get_datasets(dataset_mixer, splits=["train"], columns_to_keep=["chosen", "rejected"])
+        pref_datasets = utils.get_datasets(dataset_mixer, splits=["train"], columns_to_keep=["chosen", "rejected"])
         self.assertEqual(len(pref_datasets["train"]), 2000)
 
     def test_time_parser_used_in_get_beaker_dataset_ids(self):
         # two special cases which beaker uses
         self.assertTrue(parser.parse("2024-09-16T19:03:02.31502Z"))
         self.assertTrue(parser.parse("0001-01-01T00:00:00Z"))
+
+
+class TestBeakerDescription(unittest.TestCase):
+    """Test the beaker description update function."""
+
+    @mock.patch.dict(os.environ, {"BEAKER_WORKLOAD_ID": "test-id-123", "GIT_COMMIT": "abc123", "GIT_BRANCH": "main"})
+    @mock.patch("open_instruct.utils.is_beaker_job")
+    @mock.patch("beaker.Beaker.from_env")
+    def test_description_does_not_accumulate(self, mock_beaker_from_env, mock_is_beaker_job):
+        """Test that the description doesn't accumulate git info and wandb URLs on repeated calls."""
+        # Setup mocks
+        mock_is_beaker_job.return_value = True
+
+        # Mock the Beaker client and experiment
+        mock_client = mock.MagicMock()
+        mock_beaker_from_env.return_value = mock_client
+
+        # Mock experiment spec with initial description
+        mock_spec = mock.MagicMock()
+        mock_spec.description = "Beaker-Mason job."
+        mock_client.experiment.get.return_value = mock_spec
+
+        # Track all set_description calls
+        description_history = []
+
+        def track_description(exp_id, desc):
+            description_history.append(desc)
+
+        mock_client.experiment.set_description.side_effect = track_description
+
+        wandb_url = "https://wandb.ai/ai2-llm/open_instruct_internal/runs/1f3ow3oh"
+        start_time = time.time()
+
+        # Use a shared original_descriptions dictionary across calls
+        original_descriptions = {}
+
+        # Simulate a training loop with multiple updates
+        for step in [10, 20, 30]:
+            utils.maybe_update_beaker_description(
+                current_step=step,
+                total_steps=100,
+                start_time=start_time,
+                wandb_url=wandb_url,
+                original_descriptions=original_descriptions,
+            )
+            # Update the mock description to simulate what Beaker would return
+            if description_history:
+                mock_spec.description = description_history[-1]
+
+        # Check that descriptions were set
+        self.assertEqual(len(description_history), 3)
+
+        # Check that git info and wandb URL don't accumulate
+        for i, desc in enumerate(description_history):
+            # Count occurrences of key components
+            git_commit_count = desc.count("git_commit:")
+            git_branch_count = desc.count("git_branch:")
+            wandb_count = desc.count(wandb_url)
+
+            # Each should appear exactly once
+            self.assertEqual(
+                git_commit_count,
+                1,
+                f"Step {(i + 1) * 10}: git_commit should appear once, but appears {git_commit_count} times in: {desc}",
+            )
+            self.assertEqual(
+                git_branch_count,
+                1,
+                f"Step {(i + 1) * 10}: git_branch should appear once, but appears {git_branch_count} times in: {desc}",
+            )
+            self.assertEqual(
+                wandb_count,
+                1,
+                f"Step {(i + 1) * 10}: wandb URL should appear once, but appears {wandb_count} times in: {desc}",
+            )
+
+            # Verify the structure is correct
+            self.assertIn("Beaker-Mason job.", desc)
+            self.assertIn("git_commit: abc123", desc)
+            self.assertIn("git_branch: main", desc)
+            self.assertIn(wandb_url, desc)
+            self.assertIn(f"% complete (step {(i + 1) * 10}/100)", desc)
+
+    @mock.patch.dict(os.environ, {"BEAKER_WORKLOAD_ID": "test-id-123", "GIT_COMMIT": "def456", "GIT_BRANCH": "dev"})
+    @mock.patch("open_instruct.utils.is_beaker_job")
+    @mock.patch("beaker.Beaker.from_env")
+    def test_description_without_progress(self, mock_beaker_from_env, mock_is_beaker_job):
+        """Test description updates without progress information."""
+        mock_is_beaker_job.return_value = True
+
+        mock_client = mock.MagicMock()
+        mock_beaker_from_env.return_value = mock_client
+
+        mock_spec = mock.MagicMock()
+        mock_spec.description = "Initial job description"
+        mock_client.experiment.get.return_value = mock_spec
+
+        description_history = []
+
+        def track_description(exp_id, desc):
+            description_history.append(desc)
+
+        mock_client.experiment.set_description.side_effect = track_description
+
+        # Use a shared original_descriptions dictionary
+        original_descriptions = {}
+
+        # Call without progress info
+        utils.maybe_update_beaker_description(
+            wandb_url="https://wandb.ai/team/project/runs/xyz789", original_descriptions=original_descriptions
+        )
+
+        # Check the description
+        self.assertEqual(len(description_history), 1)
+        desc = description_history[0]
+
+        # Should have base description, git info, and wandb URL, but no progress
+        self.assertIn("Initial job description", desc)
+        self.assertIn("git_commit: def456", desc)
+        self.assertIn("git_branch: dev", desc)
+        self.assertIn("https://wandb.ai/team/project/runs/xyz789", desc)
+        self.assertNotIn("% complete", desc)
 
 
 class TestUtilityFunctions(unittest.TestCase):
@@ -92,14 +217,14 @@ class TestUtilityFunctions(unittest.TestCase):
     )
     def test_repeat_each(self, name, sequence, k, expected):
         """Test the repeat_each function with various inputs."""
-        result = repeat_each(sequence, k)
+        result = utils.repeat_each(sequence, k)
         self.assertEqual(result, expected)
 
     def test_repeat_each_mutation_isolation(self):
         """Test that mutating a sequence item after repeat_each doesn't change the repeated versions."""
         original_list = [1, 2]
         sequence = [original_list, ["a", "b"], [True, False]]
-        result = repeat_each(sequence, 2)
+        result = utils.repeat_each(sequence, 2)
 
         # Result should be: [[1, 2], [1, 2], ["a", "b"], ["a", "b"], [True, False], [True, False]]
         self.assertEqual(len(result), 6)

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -967,7 +967,6 @@ def maybe_update_beaker_description(
         )
         return
 
-    client = beaker.Beaker.from_env()
     try:
         client = beaker.Beaker.from_env()
     except beaker.exceptions.ConfigurationError as e:

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -957,12 +957,7 @@ def maybe_update_beaker_description(
         wandb_url: Optional wandb URL to include
         original_descriptions: Cache of original descriptions for progress updates
     """
-    logger.info(
-        f"maybe_update_beaker_description called with: current_step={current_step}, total_steps={total_steps}, wandb_url={wandb_url}"
-    )
-
     if not is_beaker_job():
-        logger.info("Not a Beaker job, returning early")
         return
 
     experiment_id = os.environ.get("BEAKER_WORKLOAD_ID")
@@ -981,22 +976,22 @@ def maybe_update_beaker_description(
 
     try:
         spec = client.experiment.get(experiment_id)
-        current_description = spec.description or ""
     except beaker.exceptions.ExperimentNotFound:
-        logger.warning(f"Failed to get Beaker experiment with ID: {experiment_id}")
-        logger.warning("This might be fine if you are e.g. running in an interactive job.")
+        logger.warning(
+            f"Failed to get Beaker experiment with ID: {experiment_id}"
+            "This might be fine if you are e.g. running in an interactive job."
+        )
         return
 
-    # Store the original description on first call
     if experiment_id not in original_descriptions:
-        original_descriptions[experiment_id] = current_description
+        original_descriptions[experiment_id] = spec.description or ""
 
     # Build description from scratch each time
-    description_components = [original_descriptions[experiment_id]]
-
-    # Add git info
-    description_components.append(f"git_commit: {os.environ.get('GIT_COMMIT', 'unknown')}")
-    description_components.append(f"git_branch: {os.environ.get('GIT_BRANCH', 'unknown')}")
+    description_components = [
+        original_descriptions[experiment_id],
+        f"git_commit: {os.environ.get('GIT_COMMIT', 'unknown')}",
+        f"git_branch: {os.environ.get('GIT_BRANCH', 'unknown')}",
+    ]
 
     if wandb_url:
         description_components.append(wandb_url)
@@ -1021,17 +1016,13 @@ def maybe_update_beaker_description(
         progress_bar = f"[{progress_pct:.1f}% complete (step {current_step}/{total_steps}), {time_label} {time_str}]"
         description_components.append(progress_bar)
     new_description = " ".join(description_components)
-    logger.info(
-        f"Setting new Beaker description: {new_description[:200]}..."
-        if len(new_description) > 200
-        else f"Setting new Beaker description: {new_description}"
-    )
     try:
         client.experiment.set_description(experiment_id, new_description)
-        logger.info("Successfully updated Beaker description")
     except requests.exceptions.HTTPError as e:
-        logger.warning(f"Failed to update Beaker description due to HTTP error: {e}")
-        logger.warning("Continuing without updating description - this is likely a temporary Beaker service issue")
+        logger.warning(
+            f"Failed to update Beaker description due to HTTP error: {e}"
+            "Continuing without updating description - this is likely a temporary Beaker service issue"
+        )
 
 
 def live_subprocess_output(cmd: List[str]) -> str:

--- a/scripts/train/debug/large_test_script.sh
+++ b/scripts/train/debug/large_test_script.sh
@@ -39,7 +39,7 @@ uv run python mason.py \
         --stop_strings "</answer>" \
         --non_stop_penalty False \
         --temperature 1.0 \
-	--verbose True \
+	--verbose False \
         --ground_truths_key ground_truth \
         --sft_messages_key messages \
         --total_episodes 10_000 \

--- a/scripts/train/debug/large_test_script.sh
+++ b/scripts/train/debug/large_test_script.sh
@@ -10,6 +10,7 @@ uv run python mason.py \
 	--pure_docker_mode \
         --workspace ai2/open-instruct-dev \
         --priority urgent \
+	--preemptible \
         --num_nodes 2 \
         --description "rlvr ace fn and og ocr stdio from base with perf penalty" \
         --max_retries 0 \

--- a/scripts/train/debug/large_test_script.sh
+++ b/scripts/train/debug/large_test_script.sh
@@ -55,6 +55,7 @@ uv run python mason.py \
         --gradient_checkpointing \
         --try_launch_beaker_eval_jobs_on_weka True \
         --with_tracking \
+	--update_progress_every 1 \
         --vllm_enable_prefix_caching \
         --oe_eval_max_length 32768 \
         --oe_eval_tasks "codex_humanevalplus:0-shot-chat-v1::tulu-thinker,mbppplus:0-shot-chat::tulu-thinker,livecodebench_codegeneration::tulu-thinker" \

--- a/scripts/train/debug/single_gpu_on_beaker.sh
+++ b/scripts/train/debug/single_gpu_on_beaker.sh
@@ -43,6 +43,7 @@ uv run python mason.py \
     --total_episodes 200 \
     --deepspeed_stage 2 \
     --with_tracking \
+    --update_progress_every 1 \
     --num_epochs 1 \
     --num_learners_per_node 1 \
     --vllm_tensor_parallel_size 1 \

--- a/scripts/train/debug/tool_grpo_fast.sh
+++ b/scripts/train/debug/tool_grpo_fast.sh
@@ -45,7 +45,7 @@ uv run python mason.py \
     --sft_messages_key messages \
     --exp_name 0605_general_tool_use_without_good_outputs \
     --learning_rate 5e-7 \
-    --total_episodes 500_000 \
+    --total_episodes 3_200 \
     --deepspeed_stage 2 \
     --with_tracking \
     --num_epochs 1 \


### PR DESCRIPTION
Other changes:

1. Tests that the progress update is correct. 
2. An argument to configure how often we make progress updates
3. Removes logging statements that weren't helpful. Now, in the success case, we shouldn't log anything.

Currently, long jobs end up with descriptions like this: 

> Beaker-Mason job. git_commit: 9bd34aa6 git_branch: stella-spurious-rewards https://wandb.ai/ai2-llm/open_instruct_internal/runs/qvwxbmsb git_commit: 9bd34aa6 git_branch: stella-spurious-rewards https://wandb.ai/ai2-llm/open_instruct_internal/runs/qvwxbmsb [22.0% complete (step 110/500), eta 2d 6h 34m]

This should be 

> Beaker-Mason job. git_commit: 9bd34aa6 git_branch: stella-spurious-rewards https://wandb.ai/ai2-llm/open_instruct_internal/runs/qvwxbmsb [22.0% complete (step 110/500), eta 2d 6h 34m]

This PR fixes it and adds tests to ensure it stays fixed. 

Multi-node test: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K45KDJQYFCVTZHMVS3M6VGPR?taskId=01K45KDJR5N3HMQZ5P45DHGDXS&jobId=01K45KDJW1B32Y93D3Q10DYC3W)