### PR TITLE
Combines the process_from_queue and _process_request methods. 

### DIFF
--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -432,101 +432,99 @@ class LLMRayActor:
             except queue.Empty:
                 return 0
 
-            result = self._process_request(request)
+            self.logger.info(
+                f"[LLMRayActor] Processing request with {len(request.prompts)} prompts, tools={bool(self.tools)}"
+            )
+
+            tracking = _init_tool_tracking() if self.tools else None
+            tokenizer = self.llm_engine.tokenizer
+
+            add_request(request, self.llm_engine, self.tools, request_metadata=self.request_metadata)
+
+            outputs = []
+            iteration = 0
+
+            while True:
+                iteration += 1
+
+                # Poll tool futures first (matching ToolUseLLM order)
+                if tracking and tracking.get("pending_tool_futures"):
+                    outputs.extend(self._poll_tool_futures(tracking, tokenizer))
+
+                # Process engine steps - ONLY if there are unfinished requests (matching ToolUseLLM)
+                if self.llm_engine.has_unfinished_requests():
+                    step_outputs = [o for o in self.llm_engine.step() if o.finished]
+                    for output in step_outputs:
+                        self.logger.info(f"{len(output.outputs)=}")
+                        result = _handle_output(
+                            output, self.tools, tracking, request.generation_config, self.max_tool_calls, self.executor
+                        )
+                        # Result is None when we do more tool processing.
+                        if result is not None:
+                            outputs.append(result)
+
+                # Check termination condition (matching ToolUseLLM exactly)
+                pending_count = len(tracking["pending_tool_futures"]) if tracking else 0
+                if not self.llm_engine.has_unfinished_requests() and pending_count == 0:
+                    self.logger.info(
+                        f"[LLMRayActor] Terminating after {iteration} iterations with {len(outputs)} outputs"
+                    )
+                    break
+
+            end_time = time.time()
+            total_prompt_tokens = 0
+            total_generation_tokens = 0
+            earliest_start_time = float("inf")
+
+            # Now, we combine outputs:
+            combined_outputs = defaultdict(list)
+            for output in outputs:
+                # Remove the sub_idx.
+                request_id = "_".join(output.request_id.split("_")[:-1])
+                combined_outputs[request_id].append(output)
+            # Preserve original order from request.dataset_index
+            prefix = "eval" if request.is_eval else "train"
+            # request_id is batch_num _ training_step _ within_batch_idx _ repetition_idx.
+            # we order by within_batch_idx.
+            ordered_ids = [
+                f"{prefix}_{request.training_step}_{batch_idx}" for batch_idx in range(len(request.prompts))
+            ]
+            final_outputs = []
+            for request_id in ordered_ids:
+                outs = combined_outputs[request_id]
+                assert len(outs) == request.generation_config.n, f"{len(outs)=} != {request.generation_config.n=}"
+                final_outputs.append(
+                    vllm.RequestOutput(
+                        request_id=request_id,
+                        prompt=outs[0].prompt,
+                        prompt_token_ids=outs[0].prompt_token_ids,
+                        prompt_logprobs=outs[0].prompt_logprobs,
+                        outputs=[completion for out in outs for completion in out.outputs],
+                        finished=outs[0].finished,
+                    )
+                )
+                metadata = self.request_metadata.pop(request_id)
+                total_prompt_tokens += metadata["prompt_tokens"]
+                earliest_start_time = min(earliest_start_time, metadata["start_time"])
+                for output in outs:
+                    for completion in output.outputs:
+                        total_generation_tokens += len(completion.token_ids)
+            generation_time = end_time - earliest_start_time
+            result = _finalize_outputs(
+                final_outputs,
+                tracking,
+                request.dataset_index,
+                self.tools,
+                token_statistics=TokenStatistics(
+                    num_prompt_tokens=total_prompt_tokens,
+                    num_response_tokens=total_generation_tokens,
+                    generation_time=generation_time,
+                ),
+                start_time=request.start_time,
+            )
 
             self._insert_result_to_queue(result, is_eval=request.is_eval)
             return 1
-
-    def _process_request(self, request):
-        """Unified processing for both tool and non-tool generation."""
-
-        self.logger.info(
-            f"[LLMRayActor] Processing request with {len(request.prompts)} prompts, tools={bool(self.tools)}"
-        )
-
-        tracking = _init_tool_tracking() if self.tools else None
-        tokenizer = self.llm_engine.tokenizer
-
-        add_request(request, self.llm_engine, self.tools, request_metadata=self.request_metadata)
-
-        outputs = []
-        iteration = 0
-
-        while True:
-            iteration += 1
-
-            # Poll tool futures first (matching ToolUseLLM order)
-            if tracking and tracking.get("pending_tool_futures"):
-                outputs.extend(self._poll_tool_futures(tracking, tokenizer))
-
-            # Process engine steps - ONLY if there are unfinished requests (matching ToolUseLLM)
-            if self.llm_engine.has_unfinished_requests():
-                step_outputs = [o for o in self.llm_engine.step() if o.finished]
-                for output in step_outputs:
-                    self.logger.info(f"{len(output.outputs)=}")
-                    result = _handle_output(
-                        output, self.tools, tracking, request.generation_config, self.max_tool_calls, self.executor
-                    )
-                    # Result is None when we do more tool processing.
-                    if result is not None:
-                        outputs.append(result)
-
-            # Check termination condition (matching ToolUseLLM exactly)
-            pending_count = len(tracking["pending_tool_futures"]) if tracking else 0
-            if not self.llm_engine.has_unfinished_requests() and pending_count == 0:
-                self.logger.info(f"[LLMRayActor] Terminating after {iteration} iterations with {len(outputs)} outputs")
-                break
-
-        end_time = time.time()
-        total_prompt_tokens = 0
-        total_generation_tokens = 0
-        earliest_start_time = float("inf")
-
-        # Now, we combine outputs:
-        combined_outputs = defaultdict(list)
-        for output in outputs:
-            # Remove the sub_idx.
-            request_id = "_".join(output.request_id.split("_")[:-1])
-            combined_outputs[request_id].append(output)
-        # Preserve original order from request.dataset_index
-        prefix = "eval" if request.is_eval else "train"
-        # request_id is batch_num _ training_step _ within_batch_idx _ repetition_idx.
-        # we order by within_batch_idx.
-        ordered_ids = [f"{prefix}_{request.training_step}_{batch_idx}" for batch_idx in range(len(request.prompts))]
-        final_outputs = []
-        for request_id in ordered_ids:
-            outs = combined_outputs[request_id]
-            assert len(outs) == request.generation_config.n, f"{len(outs)=} != {request.generation_config.n=}"
-            final_outputs.append(
-                vllm.RequestOutput(
-                    request_id=request_id,
-                    prompt=outs[0].prompt,
-                    prompt_token_ids=outs[0].prompt_token_ids,
-                    prompt_logprobs=outs[0].prompt_logprobs,
-                    outputs=[completion for out in outs for completion in out.outputs],
-                    finished=outs[0].finished,
-                )
-            )
-            metadata = self.request_metadata.pop(request_id)
-            total_prompt_tokens += metadata["prompt_tokens"]
-            earliest_start_time = min(earliest_start_time, metadata["start_time"])
-            for output in outs:
-                for completion in output.outputs:
-                    total_generation_tokens += len(completion.token_ids)
-        generation_time = end_time - earliest_start_time
-        result = _finalize_outputs(
-            final_outputs,
-            tracking,
-            request.dataset_index,
-            self.tools,
-            token_statistics=TokenStatistics(
-                num_prompt_tokens=total_prompt_tokens,
-                num_response_tokens=total_generation_tokens,
-                generation_time=generation_time,
-            ),
-            start_time=request.start_time,
-        )
-        return result
 
     def _poll_tool_futures(self, tracking, tokenizer):
         """Poll and handle completed tool executions."""


### PR DESCRIPTION
As part of https://github.com/allenai/open-instruct/pull/859, I made a number of major changes. To be a better software engineer, I'm breaking them out into separate PRs (and also because there's a bug in https://github.com/allenai/open-instruct/pull/859 that I can't identify).

This is a minor refactor combining two methods into one. 

Runs:

Single GPU: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K48KVS1WYWPB2KXCS82SF1AH?taskId=01K48KVS20SCFTK81WKT9X5JY4&jobId=01K48KVS68DVW385QRB7RNS6NA)
Multi-node: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K48M1Q2N1HHSWQN8FSM8RWDE?)
Single GPU with tool use: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K48M0X27E1X7EZRH8EA8H7A0?taskId=01K48M0X2D48W6Y81GF3HRCESQ&jobId=01K48M0X75EXTW5PY6QZW2J1HT)