### PR TITLE
FP8 KV Cache

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -232,6 +232,8 @@ class Args:
     stop_strings: Optional[List[str]] = None
     """List of strings that stop the generation when they are generated.
     The returned output will not contain the stop strings."""
+    use_fp8_kv_cache: bool = False
+    """Whether to use fp8 kv cache. This is useful for larger models or olmo."""
 
     # Algorithm
     async_steps: int = 1
@@ -2041,6 +2043,7 @@ def create_model_and_optimizer(
         results_queue=inference_results_Q,
         eval_results_queue=evaluation_inference_results_Q,
         actor_manager=actor_manager,
+        use_fp8_kv_cache=args.use_fp8_kv_cache,
     )
 
     resume_training_step = ray_get_with_progress(inits, desc="Initializing models")[0] + 1

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2051,9 +2051,13 @@ def create_model_and_optimizer(
     logger.info("======== ✅ all models and vLLM engines initialized =========")
 
     # Get and set KV cache max concurrency from the first engine (all engines have the same config)
-    if vllm_engines:
+    # fp8 kv cache for now forces v0 engine and breaks this.
+    if vllm_engines and not args.use_fp8_kv_cache:
         kv_cache_max_concurrency = ray.get(vllm_engines[0].get_kv_cache_info.remote())
         ray.get(actor_manager.set_kv_cache_max_concurrency.remote(kv_cache_max_concurrency))
+    else:
+        # dummy value
+        ray.get(actor_manager.set_kv_cache_max_concurrency.remote(-1))
 
     ray_get_with_progress(
         [m.setup_model_update_group.remote(vllm_engines=vllm_engines) for m in policy_group.models],

--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -710,6 +710,7 @@ def create_vllm_engines(
     results_queue=None,
     eval_results_queue=None,
     actor_manager=None,
+    use_fp8_kv_cache=False,
 ) -> list[LLMRayActor]:
     # Convert max_tool_calls to a dict mapping tool end strings to their limits
     if tools:
@@ -790,6 +791,8 @@ def create_vllm_engines(
                 actor_manager=actor_manager,
                 tools=tools,
                 max_tool_calls=max_tool_calls_dict,
+                kv_cache_dtype="auto" if not use_fp8_kv_cache else "fp8",
+                calculate_kv_scales=use_fp8_kv_cache,
             )
         )
 


### PR DESCRIPTION
Adds FP8 KV cache arg.
Note that this swaps you over to the V0 engine and so breaks the kv cache concurrency check. Other things might break too, but it does help to improve training speeds for OLMo 2!

Example of a succesful job: https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K48TY5C0F4D26R265DFR6RCS?taskId=01K48TY5C52QWKE7XBNK1FMSSG&jobId=01K48TY5FSF4H44EJFHV2465FC (generation speeds slow because I put 32 requests on 8 vllm engines, whoops).