### PR TITLE
Fix final save when job crashes early.

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -478,7 +478,6 @@ class Args:
                 if tool not in ["search", "code"]:
                     raise ValueError(f"Tool {tool} is not supported. Supported tools are: search, code")
             assert len(self.tools) == len(set(self.tools)), "Duplicate tools are not allowed"
-        self.checkpoint_dir = f"{self.output_dir}_checkpoints"
 
 
 def next_batch(dataset_indices: List[int], dataset: datasets.Dataset) -> Batch:
@@ -2292,7 +2291,8 @@ def one_training_step(
     save_time = 0
     if args.save_freq > 0 and training_step % args.save_freq == 0 and (args.eval_on_step_0 or training_step > 1):
         with Timer("[Main Thread] 🗡️ Saving model") as timer:
-            step_dir = os.path.join(args.checkpoint_dir, f"step_{training_step}")
+            checkpoint_dir = f"{args.output_dir}_checkpoints"
+            step_dir = os.path.join(checkpoint_dir, f"step_{training_step}")
             logger.info(f"Saving model at step {training_step} to {step_dir}")
             ray_get_with_progress(
                 [

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2933,10 +2933,9 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_sa
         and is_beaker_job()
         and len(beaker_config.beaker_dataset_id_urls) > 0
         and args.output_dir.rstrip("/") != "/output"
+        and os.path.isdir(args.output_dir)
     ):
-        # sometimes the job finishes before we have an output directory.
-        if os.path.isdir(args.output_dir):
-            shutil.copytree(args.output_dir, "/output", dirs_exist_ok=True)
+        shutil.copytree(args.output_dir, "/output", dirs_exist_ok=True)
     logger.info("finished training")
 
     accelerator = Namespace()

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2937,6 +2937,9 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_sa
         # sometimes the job finishes before we have an output directory.
         if os.path.isdir(args.output_dir):
             shutil.copytree(args.output_dir, "/output", dirs_exist_ok=True)
+        # also copy the checkpoints
+        if os.path.isdir(args.checkpoint_dir):
+            shutil.copytree(args.checkpoint_dir, "/output/checkpoints", dirs_exist_ok=True)
     logger.info("finished training")
 
     accelerator = Namespace()

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2937,9 +2937,6 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig, num_eval_sa
         # sometimes the job finishes before we have an output directory.
         if os.path.isdir(args.output_dir):
             shutil.copytree(args.output_dir, "/output", dirs_exist_ok=True)
-        # also copy the checkpoints
-        if os.path.isdir(args.checkpoint_dir):
-            shutil.copytree(args.checkpoint_dir, "/output/checkpoints", dirs_exist_ok=True)
     logger.info("finished training")
 
     accelerator = Namespace()


### PR DESCRIPTION
Reported here: https://allenai.slack.com/archives/C0836QPULRK/p1757012951849209?thread_ts=1757006364.247539&cid=C0836QPULRK

Basically, if we crash, we don't do the final save into `/output`, and the copy fails and the job crashes. Fixes by just checking if the output dir exists before trying to copy from it!