### PR TITLE
fixes for manual eval jobs with new cluster names

### DIFF
--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -353,7 +353,7 @@ for TASK in "${TASKS[@]}"; do
         --gpus "$GPU_COUNT" \
         --gantry-args "$GANTRY_ARGS" \
         ${REVISION_ARG} \
-        --cluster ai2/augusta-google-1 \
+        --cluster ai2/augusta \
         --beaker-retries 2 \
         --beaker-image "$BEAKER_IMAGE" \
         --beaker-priority  "$PRIORITY" \

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -65,13 +65,13 @@ def adjust_gpus(task_spec, experiment_group, model_name, gpu_multiplier):
 # Launcher
 
 WEKA_CLUSTERS = [
-    "ai2/jupiter-cirrascale-2",
-    "ai2/saturn-cirrascale",
-    "ai2/neptune-cirrascale",
-    "ai2/ceres-cirrascale"
+    "ai2/jupiter",
+    "ai2/saturn",
+    "ai2/neptune",
+    "ai2/ceres"
 ]
 GCP_CLUSTERS = [
-    "ai2/augusta-google-1"
+    "ai2/augusta"
 ]
 
 


### PR DESCRIPTION
Given the new cluster name, this PR contains some minor fixes to `submit_eval_jobs.py` and their related script which is mostly used for running evaluation manually. 