### PR TITLE
Disables cascade attention.

### DIFF
--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -399,7 +399,7 @@ class LLMRayActor:
         # Cascade attention has known performance issues: https://github.com/vllm-project/vllm/issues/17652
         engine_args.disable_cascade_attn = True
 
-        self.llm_engine = vllm.LLMEngine.from_engine_args()
+        self.llm_engine = vllm.LLMEngine.from_engine_args(engine_args)
 
         self.prompt_queue = prompt_queue
         self.results_queue = results_queue


### PR DESCRIPTION
Cascade attention is [causing issues](https://github.com/vllm-project/vllm/issues/17652) in Qwen. 

Ran a [single GPU run](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K4ZGQPWZ88G2MCWFH03FA58K?) to verify this doesn't break anything.