### PR TITLE
Fixes bug where failing experiments would return exit code 0

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2869,8 +2869,6 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig):
             actor_manager,
             checkpoint_state,
         )
-    except Exception as e:
-        logger.error(f"Error in run_training: {e}", exc_info=True)
     finally:
         cleanup_training_resources(
             stop_event, executor, [inference_results_Q, param_prompt_Q, evaluation_inference_results_Q], actor_manager


### PR DESCRIPTION
I don't know why I introduced the error! The `except` clause seems completely useless. Worse than useless!

Anyway, tested with two fake errors: 

- During `LLMRayActor.__init__`: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K56V8V74GZYP5Y58PDTRXRJA?taskId=01K56V8V78QV33QYJDDTXRZK6B&jobId=01K56V8VAVST5QMA2RQWFC499A)
- During `LLMRayActor.process_from_queue`: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K56VSE2S4H0B2TD4HV09W7G4?taskId=01K56VSE2XWDWYSH5GXB1NE6DA&jobId=01K56VSE6GNVMXKCPF4RPYAHZP)

And verified by running without the fake errors that everything is fine: 

- Tool use script: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K56W251Z87CPA4EXDAW4JNQ1?taskId=01K56W2522NW4B15HTEWTJSCJN&jobId=01K56W25BJA7SE9MFAXGE4HEF6)
- Single GPU script: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K56W25ZZNSMT30WHJ7GPYDVF?taskId=01K56W2609PZ57ATTCZN1Y9ZV5&jobId=01K56W264TWANMRETSRHXVCW17)