### PR TITLE
Adds MFU/MBU reporting to the actors

### DIFF
--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -403,9 +403,9 @@ def run_benchmark(
     generation_future = executor.submit(generate_thread, vllm_engines, stop_event)
 
     results = []
-    # Get the vLLM config from one of the engines and create ModelDims
-    vllm_config = ray.get(vllm_engines[0].get_vllm_config.remote())
-    model_dims = utils.ModelDims.from_vllm_config(vllm_config)
+    # Get the model dimensions from one of the engines without loading weights
+    model_dims_dict = ray.get(vllm_engines[0].get_model_dims_dict.remote())
+    model_dims = utils.ModelDims(**model_dims_dict)
 
     # Submit warmup batch first
     logger.info("Submitting warmup batch...")

--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -403,8 +403,9 @@ def run_benchmark(
     generation_future = executor.submit(generate_thread, vllm_engines, stop_event)
 
     results = []
-    # Load model dimensions first to get device info
-    model_dims = utils.load_model_dims(model_config.model_name_or_path)
+    # Get the vLLM model config from one of the engines and create ModelDims
+    vllm_model_config = ray.get(vllm_engines[0].get_model_config.remote())
+    model_dims = utils.ModelDims.from_vllm_config(vllm_model_config)
 
     # Submit warmup batch first
     logger.info("Submitting warmup batch...")

--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -16,23 +16,19 @@ import pathlib
 import threading
 import time
 from concurrent import futures
-from typing import Any, ClassVar, Optional, Sequence
+from typing import Any, Optional
 
 import datasets
 import numpy as np
 import ray
 import torch
 import torch.utils.flop_counter
-import transformers
 import vllm
 from ray.util import queue as ray_queue
 
 from open_instruct import dataset_transformation, grpo_fast, logger_utils, model_utils, utils, vllm_utils3
 from open_instruct.actor_manager import ActorManager
 from open_instruct.queue_types import PromptRequest
-
-# GPU_SPECS moved to utils.py - use utils.GPU_SPECS instead
-
 
 logger = logger_utils.setup_logger(__name__)
 
@@ -200,357 +196,6 @@ def free_all_gpu_memory(device: int | str = 0) -> None:
     free, total = torch.cuda.mem_get_info(dev)
     gib = 1024**3
     logger.info(f"[GPU {dev.index}] {free / gib:.2f} GiB free of {total / gib:.2f} GiB after cleanup")
-
-
-# ModelDims class moved to utils.py - use utils.ModelDims
-class ModelDimsPlaceholder:
-    num_layers: int
-    hidden_size: int
-    intermediate_size: int
-    vocab_size: int
-    num_attn_heads: int
-    num_kv_heads: Optional[int] = None
-
-    # Conventions (fixed; not switches)
-    FLOP_PER_MAC: ClassVar[int] = 2
-    # Approximate softmax cost per attention score:
-    # ~4 scalar ops/score: exp + subtract max (stabilization) + sum + divide.
-    SOFTMAX_FLOPS_PER_SCORE: ClassVar[int] = 4
-
-    def __post_init__(self):
-        if self.num_kv_heads is None:
-            self.num_kv_heads = self.num_attn_heads
-
-        assert self.hidden_size % self.num_attn_heads == 0, "hidden_size must be divisible by num_attn_heads"
-        assert self.num_attn_heads % self.num_kv_heads == 0, (
-            "num_attn_heads must be divisible by num_kv_heads (GQA/MQA)"
-        )
-
-    @property
-    def head_dim(self) -> int:
-        return self.hidden_size // self.num_attn_heads
-
-    def attn_flops(self, query_len: int, kv_len: int) -> int:
-        """FLOPs for one layer of self-attention given query_len and kv_len.
-
-        Assumptions:
-          - 1 MAC = 2 FLOPs (FLOP_PER_MAC).
-          - Efficient GQA/MQA K/V projections with width = num_kv_heads * head_dim.
-          - Softmax ≈ 4 FLOPs per score (see SOFTMAX_FLOPS_PER_SCORE).
-          - LayerNorms and minor ops ignored (dominated by matmuls).
-        """
-        d = self.head_dim
-        mul = self.FLOP_PER_MAC
-
-        # Projections for the query_len new tokens
-        q_proj = mul * query_len * self.hidden_size * self.hidden_size
-        kv_proj = mul * 2 * query_len * self.hidden_size * (self.num_kv_heads * d)  # GQA/MQA
-
-        # Scores and attention-weighted values
-        qk = mul * self.num_attn_heads * query_len * kv_len * d
-        softmax = self.SOFTMAX_FLOPS_PER_SCORE * self.num_attn_heads * query_len * kv_len
-        av = mul * self.num_attn_heads * query_len * kv_len * d
-
-        # Output projection
-        out_proj = mul * query_len * self.hidden_size * self.hidden_size
-
-        return q_proj + kv_proj + qk + softmax + av + out_proj
-
-    def mlp_flops(self, seq_len: int) -> int:
-        """Two matmuls dominate; activation cost under-counted on purpose."""
-        mul = self.FLOP_PER_MAC
-        first = mul * seq_len * self.hidden_size * self.intermediate_size
-        act = seq_len * self.intermediate_size  # under-counted on purpose
-        second = mul * seq_len * self.intermediate_size * self.hidden_size
-        return first + act + second
-
-    def prefill_flops(self, prompt_lengths: Sequence[int]) -> int:
-        """Prefill builds the KV cache; logits are computed once after each prompt."""
-        total = 0
-        for L in prompt_lengths:
-            total += self.num_layers * (self.attn_flops(L, L) + self.mlp_flops(L))
-            # Always include a single LM head after prefill (next-token logits)
-            total += self.FLOP_PER_MAC * self.hidden_size * self.vocab_size
-        return total
-
-    def decode_flops(
-        self, prompt_lengths: Sequence[int], response_lengths: Sequence[int], samples_per_prompt: int = 1
-    ) -> int:
-        """Decode/generation FLOPs.
-
-        Args:
-            prompt_lengths: List of prompt lengths (one per unique prompt)
-            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
-            samples_per_prompt: Number of samples generated per prompt
-
-        Embedding lookups are ignored by design.
-        """
-        assert len(response_lengths) == len(prompt_lengths) * samples_per_prompt, (
-            f"Expected {len(prompt_lengths) * samples_per_prompt} response lengths, got {len(response_lengths)}"
-        )
-
-        total = 0
-        response_idx = 0
-        for P in prompt_lengths:
-            # Process all samples for this prompt
-            for _ in range(samples_per_prompt):
-                R = response_lengths[response_idx]
-                total += R * self.num_layers * self.mlp_flops(seq_len=1)
-                for t in range(R):
-                    kv_len = P + t + 1  # prompt + generated so far + current
-                    total += self.num_layers * self.attn_flops(query_len=1, kv_len=kv_len)
-                total += R * self.FLOP_PER_MAC * self.hidden_size * self.vocab_size
-                response_idx += 1
-        return total
-
-    def flops(
-        self,
-        prompt_lengths: Sequence[int],
-        response_lengths: Optional[Sequence[int]] = None,
-        samples_per_prompt: int = 1,
-    ) -> int:
-        """Total FLOPs for prefill and (optionally) decode.
-
-        Args:
-            prompt_lengths: List of prompt lengths (one per unique prompt)
-            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
-            samples_per_prompt: Number of samples generated per prompt
-        """
-        total = self.prefill_flops(prompt_lengths)
-        if response_lengths is not None:
-            total += self.decode_flops(prompt_lengths, response_lengths, samples_per_prompt)
-        return total
-
-    def weight_memory_bytes(self, num_tokens: int, dtype_bytes: int = 2) -> int:
-        """Memory bytes for reading model weights for a given number of tokens.
-
-        Args:
-            num_tokens: Number of tokens to process
-            dtype_bytes: Bytes per element (2 for FP16/BF16)
-
-        Returns:
-            Total bytes for weight reads across all layers
-        """
-        num_kv = self.num_kv_heads if self.num_kv_heads is not None else self.num_attn_heads
-        head_dim = self.hidden_size // self.num_attn_heads
-        hidden_kv = num_kv * head_dim
-
-        # Per-layer weight params (Q, K, V, O, MLP up, MLP down)
-        w_q = self.hidden_size * self.hidden_size
-        w_k = self.hidden_size * hidden_kv
-        w_v = self.hidden_size * hidden_kv
-        w_o = self.hidden_size * self.hidden_size
-        w_up = self.hidden_size * self.intermediate_size
-        w_dn = self.intermediate_size * self.hidden_size
-
-        per_layer_weight_bytes = (w_q + w_k + w_v + w_o + w_up + w_dn) * dtype_bytes
-        return self.num_layers * num_tokens * per_layer_weight_bytes
-
-    def kv_cache_write_bytes(self, num_tokens: int, dtype_bytes: int = 2) -> int:
-        """Memory bytes for writing KV cache for a given number of tokens.
-
-        Args:
-            num_tokens: Number of tokens being cached
-            dtype_bytes: Bytes per element (2 for FP16/BF16)
-
-        Returns:
-            Total bytes for KV cache writes across all layers
-        """
-        num_kv = self.num_kv_heads if self.num_kv_heads is not None else self.num_attn_heads
-        head_dim = self.hidden_size // self.num_attn_heads
-
-        # 2x for K and V
-        kv_write_bytes_per_token = 2 * num_kv * head_dim * dtype_bytes
-        return self.num_layers * num_tokens * kv_write_bytes_per_token
-
-    def kv_cache_read_bytes(
-        self,
-        prompt_lengths: Sequence[int],
-        response_lengths: Sequence[int],
-        samples_per_prompt: int = 1,
-        dtype_bytes: int = 2,
-    ) -> int:
-        """Memory bytes for reading KV cache during decode.
-
-        For each new token generated, we read all previous tokens' KV cache.
-        When generating multiple samples per prompt, the prompt KV cache is shared.
-
-        Args:
-            prompt_lengths: List of prompt lengths (one per unique prompt)
-            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
-            samples_per_prompt: Number of samples generated per prompt
-            dtype_bytes: Bytes per element (2 for FP16/BF16)
-
-        Returns:
-            Total bytes for KV cache reads during decode
-        """
-        assert len(response_lengths) == len(prompt_lengths) * samples_per_prompt, (
-            f"Expected {len(prompt_lengths) * samples_per_prompt} response lengths, got {len(response_lengths)}"
-        )
-
-        num_kv = self.num_kv_heads if self.num_kv_heads is not None else self.num_attn_heads
-        head_dim = self.hidden_size // self.num_attn_heads
-
-        # For batched sampling with shared prompt KV cache:
-        # - Prompt KV is read once per new token position across ALL samples (not per sample)
-        # - Each sample has its own KV for generated tokens
-        kv_read_terms = 0
-        response_idx = 0
-
-        for P in prompt_lengths:
-            # For this prompt, collect all response lengths
-            prompt_responses = []
-            for _ in range(samples_per_prompt):
-                prompt_responses.append(response_lengths[response_idx])
-                response_idx += 1
-
-            # Prompt KV reads: In synchronized batch generation with vLLM n>1,
-            # the prompt KV cache is stored once but each sample reads it independently.
-            # At each decoding position, each sample reads the prompt KV cache.
-            # Number of positions = max response length (all generate synchronously)
-            max_response_length = max(prompt_responses) if prompt_responses else 0
-            # Each of the samples_per_prompt samples reads prompt KV at each position
-            kv_read_terms += max_response_length * samples_per_prompt * P
-
-            # Per-sample generated KV reads: Each sample reads its own previously generated tokens
-            for R in prompt_responses:
-                # Each token in this sample reads its previously generated tokens
-                # sum_{i=0}^{R-1} i = R*(R-1)/2
-                kv_read_terms += R * (R - 1) // 2
-
-        # 2x for K and V
-        kv_bytes_per_token = 2 * num_kv * head_dim * dtype_bytes
-        return self.num_layers * kv_bytes_per_token * kv_read_terms
-
-    def prefill_memory_bytes(self, prompt_lengths: Sequence[int], dtype_bytes: int = 2) -> int:
-        """Memory bytes for prefill phase.
-
-        During prefill:
-        - Read weights once for the entire batch (batched matmul)
-        - Write KV cache for each token
-
-        Args:
-            prompt_lengths: List of prompt lengths
-            dtype_bytes: Bytes per element (2 for FP16/BF16)
-
-        Returns:
-            Total memory bytes for prefill
-        """
-        # In batched prefill, weights are read once for the entire operation,
-        # not once per token. We process all prompts in a single batch.
-        num_prefill_batches = len(prompt_lengths)  # Each prompt is a "batch"
-        weight_bytes = self.weight_memory_bytes(num_prefill_batches, dtype_bytes)
-
-        # KV cache is written for every token
-        total_prefill_tokens = sum(prompt_lengths)
-        kv_write_bytes = self.kv_cache_write_bytes(total_prefill_tokens, dtype_bytes)
-        return weight_bytes + kv_write_bytes
-
-    def decode_memory_bytes(
-        self,
-        prompt_lengths: Sequence[int],
-        response_lengths: Sequence[int],
-        samples_per_prompt: int = 1,
-        dtype_bytes: int = 2,
-    ) -> int:
-        """Memory bytes for decode/generation phase.
-
-        During decode:
-        - Read weights for each new token position (shared across samples in batch)
-        - Write KV cache for each new token
-        - Read all previous KV cache for attention
-
-        Args:
-            prompt_lengths: List of prompt lengths (one per unique prompt)
-            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
-            samples_per_prompt: Number of samples generated per prompt
-            dtype_bytes: Bytes per element (2 for FP16/BF16)
-
-        Returns:
-            Total memory bytes for decode
-        """
-        # In synchronized batch generation, weights are read once per position,
-        # not once per token. With multiple samples per prompt generating in parallel,
-        # we only need to read weights for the number of unique positions.
-        unique_positions = 0
-        response_idx = 0
-        for _ in prompt_lengths:
-            # Get response lengths for this prompt's samples
-            prompt_responses = response_lengths[response_idx : response_idx + samples_per_prompt]
-            response_idx += samples_per_prompt
-            # In synchronized generation, all samples generate the same number of positions
-            # (up to the max length among them)
-            unique_positions += max(prompt_responses) if prompt_responses else 0
-
-        weight_bytes = self.weight_memory_bytes(unique_positions, dtype_bytes)
-
-        # KV writes happen for all tokens (each sample writes its own KV)
-        total_decode_tokens = sum(response_lengths)
-        kv_write_bytes = self.kv_cache_write_bytes(total_decode_tokens, dtype_bytes)
-
-        kv_read_bytes = self.kv_cache_read_bytes(prompt_lengths, response_lengths, samples_per_prompt, dtype_bytes)
-        return weight_bytes + kv_write_bytes + kv_read_bytes
-
-    def memory_bytes(
-        self,
-        prompt_lengths: Sequence[int],
-        response_lengths: Optional[Sequence[int]] = None,
-        samples_per_prompt: int = 1,
-        dtype_bytes: int = 2,
-    ) -> int:
-        """Approximate total HBM bytes moved for prefill + decode.
-
-        Returns an integer number of bytes. Divide by elapsed seconds to get B/s;
-        compare against peak bandwidth to get utilization.
-
-        Args:
-            prompt_lengths: List of prompt lengths (one per unique prompt)
-            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
-            samples_per_prompt: Number of samples generated per prompt
-            dtype_bytes: Bytes per element (2 for FP16/BF16)
-
-        Returns:
-            Total memory bytes moved
-
-        Assumptions:
-          - Weights are read once per token per layer (Q,K,V,O + MLP up/down)
-          - KV cache: write K/V for every token; during decode, read all past K/V per new token
-          - When batching samples, prompt KV cache is shared across samples
-          - Embedding and LM head reads are ignored (usually dominated by matmul weight traffic)
-        """
-        total = self.prefill_memory_bytes(prompt_lengths, dtype_bytes)
-
-        if response_lengths is not None:
-            assert len(response_lengths) == len(prompt_lengths) * samples_per_prompt, (
-                f"Expected {len(prompt_lengths) * samples_per_prompt} response lengths, got {len(response_lengths)}"
-            )
-
-            # Pass original prompt_lengths with samples_per_prompt to correctly handle shared KV cache
-            total += self.decode_memory_bytes(prompt_lengths, response_lengths, samples_per_prompt, dtype_bytes)
-
-        return total
-
-
-def load_model_dims(model_name: str) -> utils.ModelDims:
-    # Delegating to utils.load_model_dims
-    return utils.load_model_dims(model_name)
-
-
-def _old_load_model_dims(model_name: str) -> utils.ModelDims:
-    cfg = transformers.AutoConfig.from_pretrained(model_name, trust_remote_code=True)
-    return utils.ModelDims(
-        num_layers=cfg.num_hidden_layers,
-        hidden_size=cfg.hidden_size,
-        intermediate_size=cfg.intermediate_size,
-        vocab_size=cfg.vocab_size,
-        num_attn_heads=cfg.num_attention_heads,
-        num_kv_heads=getattr(cfg, "num_key_value_heads", None),
-    )
-
-
-def get_device_name(device_name: str) -> str:
-    # Delegating to utils.get_device_name
-    return utils.get_device_name(device_name)
 
 
 def setup_dataset(args: grpo_fast.Args, tokenizer_config: dataset_transformation.TokenizerConfig) -> datasets.Dataset:
@@ -758,9 +403,8 @@ def run_benchmark(
     generation_future = executor.submit(generate_thread, vllm_engines, stop_event)
 
     results = []
-    device_name = utils.get_device_name(torch.cuda.get_device_name(0))
-    device_flops = utils.GPU_SPECS[device_name]["flops"]
-    device_memory_bandwidth = utils.GPU_SPECS[device_name]["memory_bandwidth"]
+    # Load model dimensions first to get device info
+    model_dims = utils.load_model_dims(model_config.model_name_or_path)
 
     # Submit warmup batch first
     logger.info("Submitting warmup batch...")
@@ -779,7 +423,6 @@ def run_benchmark(
                 start_time=time.perf_counter(),
             )
         )
-    model_dims = utils.load_model_dims(model_config.model_name_or_path)
 
     try:
         logger.info("Running warmup batch...")
@@ -860,7 +503,7 @@ def run_benchmark(
 
             # MFU = (FLOPs / time) / peak_FLOPS * 100
             model_flops_per_second = model_flops / batch_generation_time if batch_generation_time > 0 else 0
-            result_dict["mfu"] = 100 * model_flops_per_second / device_flops
+            result_dict["mfu"] = 100 * model_flops_per_second / model_dims.device_flops
 
             # Calculate total memory bytes for all prompts and responses in the batch
             model_memory_bytes = model_dims.memory_bytes(
@@ -869,7 +512,7 @@ def run_benchmark(
 
             # MBU = (Memory bytes / time) / peak_bandwidth * 100
             model_bytes_per_second = model_memory_bytes / batch_generation_time if batch_generation_time > 0 else 0
-            result_dict["mbu"] = 100 * model_bytes_per_second / device_memory_bandwidth
+            result_dict["mbu"] = 100 * model_bytes_per_second / model_dims.device_memory_bandwidth
 
             save_completion_lengths([result_dict], timestamp, batch_idx)
             results.append(result_dict)
@@ -886,7 +529,7 @@ def run_benchmark(
         # Calculate total time for main benchmark only
         main_benchmark_time = sum(r["generation_time"] for r in results)
 
-        print_summary(results, main_benchmark_time, args, model_config)
+        print_summary(results, main_benchmark_time, args, model_config, model_dims)
         save_benchmark_results_to_csv(results, main_benchmark_time, args, model_config)
 
     finally:
@@ -942,7 +585,11 @@ def aggregate_results(results: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def print_summary(
-    results: list[dict[str, Any]], total_time: float, args: grpo_fast.Args, model_config: model_utils.ModelConfig
+    results: list[dict[str, Any]],
+    total_time: float,
+    args: grpo_fast.Args,
+    model_config: model_utils.ModelConfig,
+    model_dims: utils.ModelDims,
 ) -> None:
     """Print benchmark summary statistics."""
 
@@ -979,11 +626,11 @@ def print_summary(
 
     print("-" * 60)
     print("HARDWARE SPECIFICATIONS:")
-    gpu_specs = utils.GPU_SPECS[utils.get_device_name(torch.cuda.get_device_name(0))]
     print(f"GPU device: {torch.cuda.get_device_name(0)}")
-    print(f"GPU peak FLOPs: {gpu_specs['flops'] / 1e12:.0f} TFLOPs")
+    print(f"GPU peak FLOPs: {model_dims.device_flops / 1e12:.0f} TFLOPs")
+    gpu_specs = utils.GPU_SPECS[model_dims.device_name]
     print(f"GPU memory size: {gpu_specs['memory_size'] / 1e9:.0f} GB")
-    print(f"GPU memory bandwidth: {gpu_specs['memory_bandwidth'] / 1e12:.2f} TB/s")
+    print(f"GPU memory bandwidth: {model_dims.device_memory_bandwidth / 1e12:.2f} TB/s")
 
     print("-" * 60)
     print("COMPLETION LENGTH STATISTICS:")

--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -403,9 +403,9 @@ def run_benchmark(
     generation_future = executor.submit(generate_thread, vllm_engines, stop_event)
 
     results = []
-    # Get the vLLM model config from one of the engines and create ModelDims
-    vllm_model_config = ray.get(vllm_engines[0].get_model_config.remote())
-    model_dims = utils.ModelDims.from_vllm_config(vllm_model_config)
+    # Get the vLLM config from one of the engines and create ModelDims
+    vllm_config = ray.get(vllm_engines[0].get_vllm_config.remote())
+    model_dims = utils.ModelDims.from_vllm_config(vllm_config)
 
     # Submit warmup batch first
     logger.info("Submitting warmup batch...")

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1521,13 +1521,11 @@ def accumulate_inference_batches(
 
         total_prompt_tokens += result.token_statistics.num_prompt_tokens
         total_response_tokens += result.token_statistics.num_response_tokens
-        logger.info(f"Engine {i} generation_time: {result.token_statistics.generation_time:.6f}s")
         max_generation_time = max(max_generation_time, result.token_statistics.generation_time)
 
     # Use the maximum generation time across engines since they work in parallel
     # This avoids including queue overhead and accumulation time in MFU/MBU calculations
     total_generation_time = max_generation_time
-    logger.info(f"Max generation time across {len(results)} engines: {max_generation_time:.6f}s")
 
     # Calculate total number of GPUs used in vLLM
     num_gpus = args.vllm_num_engines * args.vllm_tensor_parallel_size

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1409,6 +1409,16 @@ def calculate_utilization_metrics(
     mfu = 100 * flops_per_second / total_device_flops
     mbu = 100 * bytes_per_second / total_device_bandwidth
 
+    # Debug logging
+    logger.info(f"MFU/MBU Debug - total_generation_time: {total_generation_time:.6f}s")
+    logger.info(f"MFU/MBU Debug - total_flops: {total_flops:,}")
+    logger.info(f"MFU/MBU Debug - total_memory_bytes: {total_memory_bytes:,}")
+    logger.info(f"MFU/MBU Debug - flops_per_second: {flops_per_second:,.2f}")
+    logger.info(f"MFU/MBU Debug - bytes_per_second: {bytes_per_second:,.2f}")
+    logger.info(f"MFU/MBU Debug - total_device_flops: {total_device_flops:,}")
+    logger.info(f"MFU/MBU Debug - total_device_bandwidth: {total_device_bandwidth:,}")
+    logger.info(f"MFU/MBU Debug - MFU: {mfu:.2e}%, MBU: {mbu:.2e}%")
+
     return mfu, mbu, total_flops, total_memory_bytes
 
 
@@ -1511,11 +1521,13 @@ def accumulate_inference_batches(
 
         total_prompt_tokens += result.token_statistics.num_prompt_tokens
         total_response_tokens += result.token_statistics.num_response_tokens
+        logger.info(f"Engine {i} generation_time: {result.token_statistics.generation_time:.6f}s")
         max_generation_time = max(max_generation_time, result.token_statistics.generation_time)
 
     # Use the maximum generation time across engines since they work in parallel
     # This avoids including queue overhead and accumulation time in MFU/MBU calculations
     total_generation_time = max_generation_time
+    logger.info(f"Max generation time across {len(results)} engines: {max_generation_time:.6f}s")
 
     # Calculate total number of GPUs used in vLLM
     num_gpus = args.vllm_num_engines * args.vllm_tensor_parallel_size

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1514,11 +1514,11 @@ def accumulate_inference_batches(
         num_prompt_tokens=total_prompt_tokens,
         num_response_tokens=total_response_tokens,
         generation_time=total_generation_time,
-        mfu=mfu,
-        mbu=mbu,
-        earliest_start_time=earliest_start_time if earliest_start_time != float("inf") else 0.0,
-        total_flops=total_flops,
-        total_memory_bytes=total_memory_bytes,
+        mfu=mfu if model_dims else None,
+        mbu=mbu if model_dims else None,
+        earliest_start_time=earliest_start_time if earliest_start_time != float("inf") else None,
+        total_flops=total_flops if model_dims else None,
+        total_memory_bytes=total_memory_bytes if model_dims else None,
     )
 
     # Create combined RequestInfo

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2910,7 +2910,7 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig):
         )
     )
 
-    # Get the vLLM config from one of the engines and create ModelDims
+    # Get the model dimensions from one of the engines without loading weights
     def log_gpu_memory(stage: str):
         """Log GPU memory usage using torch."""
         if torch.cuda.is_available():
@@ -2921,10 +2921,10 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig):
                 free = total - reserved
                 logger.info(f"GPU {i} memory {stage}: Allocated={allocated:.2f}GB, Reserved={reserved:.2f}GB, Free={free:.2f}GB, Total={total:.2f}GB")
 
-    log_gpu_memory("BEFORE getting vLLM config")
-    vllm_config = ray.get(vllm_engines[0].get_vllm_config.remote())
-    log_gpu_memory("AFTER getting vLLM config")
-    model_dims = utils.ModelDims.from_vllm_config(vllm_config)
+    log_gpu_memory("BEFORE getting model dims")
+    model_dims_dict = ray.get(vllm_engines[0].get_model_dims_dict.remote())
+    log_gpu_memory("AFTER getting model dims dict")
+    model_dims = utils.ModelDims(**model_dims_dict)
     log_gpu_memory("AFTER creating ModelDims")
 
     generation_configs = create_generation_configs(args)

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1513,10 +1513,9 @@ def accumulate_inference_batches(
         total_response_tokens += result.token_statistics.num_response_tokens
         max_generation_time = max(max_generation_time, result.token_statistics.generation_time)
 
-    current_time = time.perf_counter()
-    total_generation_time = (
-        current_time - earliest_start_time if earliest_start_time != float("inf") else max_generation_time
-    )
+    # Use the maximum generation time across engines since they work in parallel
+    # This avoids including queue overhead and accumulation time in MFU/MBU calculations
+    total_generation_time = max_generation_time
 
     # Calculate total number of GPUs used in vLLM
     num_gpus = args.vllm_num_engines * args.vllm_tensor_parallel_size

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2397,6 +2397,7 @@ def maybe_evaluate(
     eval_generation_config,
     generate_metrics_Q: Queue,
     num_eval_prompts: int,
+    model_dims: utils.ModelDims,
     actor_manager=None,
 ):
     """Optionally evaluate the model."""
@@ -2413,7 +2414,7 @@ def maybe_evaluate(
             training_step,
             eval_generation_config,
             num_prompts=num_eval_prompts,
-            model_dims=None,
+            model_dims=model_dims,
             actor_manager=actor_manager,
             timeout=timeout,
         )
@@ -2858,6 +2859,7 @@ def run_training(
             generation_configs["eval"],
             generate_metrics_Q,
             len(eval_batch.queries) if eval_batch else 0,
+            model_dims,
             actor_manager,
         )
 

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1890,6 +1890,8 @@ def data_preparation_thread(
                 "val/good_outputs_rate": np.array(good_outputs).mean(),
                 "val/tool_runtimes_rate": np.array(result.request_info.tool_runtimes).mean(),
                 "val/tool_calleds_rate": np.array(result.request_info.tool_calleds).mean(),
+                "actor_mfu": result.token_statistics.mfu,
+                "actor_mbu": result.token_statistics.mbu,
                 "time/getting_response": getting_response_time,
                 **reward_metrics,
             }

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2884,8 +2884,6 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig):
 
     pprint([args, model_config])
 
-    model_dims = utils.load_model_dims(model_config.model_name_or_path)
-
     # Initialize Ray before creating Ray objects
     ray.init(dashboard_host="0.0.0.0")
 
@@ -2911,6 +2909,10 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig):
             evaluation_inference_results_Q,
         )
     )
+
+    # Get the vLLM model config from one of the engines and create ModelDims
+    vllm_model_config = ray.get(vllm_engines[0].get_model_config.remote())
+    model_dims = utils.ModelDims.from_vllm_config(vllm_model_config)
 
     generation_configs = create_generation_configs(args)
 

--- a/open_instruct/queue_types.py
+++ b/open_instruct/queue_types.py
@@ -9,11 +9,11 @@ class TokenStatistics:
     num_prompt_tokens: int
     num_response_tokens: int
     generation_time: float
-    mfu: float
-    mbu: float
-    earliest_start_time: float
-    total_flops: int
-    total_memory_bytes: int
+    mfu: Optional[float] = None
+    mbu: Optional[float] = None
+    earliest_start_time: Optional[float] = None
+    total_flops: Optional[int] = None
+    total_memory_bytes: Optional[int] = None
 
 
 @dataclass

--- a/open_instruct/queue_types.py
+++ b/open_instruct/queue_types.py
@@ -9,6 +9,11 @@ class TokenStatistics:
     num_prompt_tokens: int
     num_response_tokens: int
     generation_time: float
+    mfu: float
+    mbu: float
+    earliest_start_time: float
+    total_flops: int
+    total_memory_bytes: int
 
 
 @dataclass

--- a/open_instruct/test_benchmark_generators.py
+++ b/open_instruct/test_benchmark_generators.py
@@ -2,7 +2,7 @@ import unittest
 
 import parameterized
 
-from open_instruct import benchmark_generators
+from open_instruct import utils
 
 
 class TestBenchmark(unittest.TestCase):
@@ -10,7 +10,7 @@ class TestBenchmark(unittest.TestCase):
         [("NVIDIA H100 80GB HBM3", "h100"), ("NVIDIA L40S", "l40s"), ("NVIDIA RTX A6000", "a6000")]
     )
     def test_get_device_name(self, device_name, expected):
-        result = benchmark_generators.get_device_name(device_name)
+        result = utils.get_device_name(device_name)
         self.assertEqual(result, expected)
 
 

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -1693,10 +1693,15 @@ class ModelDims:
     def from_vllm_config(cls, vllm_config: vllm.config.VllmConfig) -> "ModelDims":
         """Create ModelDims from a vLLM config object."""
         model_config = vllm_config.model_config
+        hidden_size = model_config.get_hidden_size()
+
+        # Try to get intermediate_size, default to 4x hidden_size if not present
+        intermediate_size = getattr(model_config.hf_text_config, "intermediate_size", 4 * hidden_size)
+
         return cls(
             num_layers=model_config.get_num_layers(vllm_config.parallel_config),
-            hidden_size=model_config.get_hidden_size(),
-            intermediate_size=model_config.get_intermediate_size(),
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
             vocab_size=model_config.get_vocab_size(),
             num_attn_heads=model_config.get_num_attention_heads(),
             num_kv_heads=model_config.get_num_kv_heads(),

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -1703,8 +1703,8 @@ class ModelDims:
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             vocab_size=model_config.get_vocab_size(),
-            num_attn_heads=model_config.get_num_attention_heads(),
-            num_kv_heads=model_config.get_num_kv_heads(),
+            num_attn_heads=model_config.get_num_attention_heads(vllm_config.parallel_config),
+            num_kv_heads=model_config.get_num_kv_heads(vllm_config.parallel_config),
         )
 
     @property

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -1690,15 +1690,16 @@ class ModelDims:
         )
 
     @classmethod
-    def from_vllm_config(cls, vllm_model_config: vllm.config.ModelConfig) -> "ModelDims":
-        """Create ModelDims from a vLLM model config object."""
+    def from_vllm_config(cls, vllm_config: vllm.config.VllmConfig) -> "ModelDims":
+        """Create ModelDims from a vLLM config object."""
+        model_config = vllm_config.model_config
         return cls(
-            num_layers=vllm_model_config.get_num_layers(),
-            hidden_size=vllm_model_config.get_hidden_size(),
-            intermediate_size=vllm_model_config.get_intermediate_size(),
-            vocab_size=vllm_model_config.get_vocab_size(),
-            num_attn_heads=vllm_model_config.get_num_attention_heads(),
-            num_kv_heads=vllm_model_config.get_num_kv_heads(),
+            num_layers=model_config.get_num_layers(vllm_config.parallel_config),
+            hidden_size=model_config.get_hidden_size(),
+            intermediate_size=model_config.get_intermediate_size(),
+            vocab_size=model_config.get_vocab_size(),
+            num_attn_heads=model_config.get_num_attention_heads(),
+            num_kv_heads=model_config.get_num_kv_heads(),
         )
 
     @property

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -53,6 +53,7 @@ import numpy as np
 import ray
 import requests
 import torch
+import transformers
 from datasets import DatasetDict, concatenate_datasets, load_dataset, load_from_disk
 from datasets.builder import DatasetGenerationError
 from dateutil import parser
@@ -1644,3 +1645,354 @@ def check_oe_eval_internal():
             "when running in Beaker. Please ensure the Docker image was built "
             "with access to the oe-eval-internal repository."
         )
+
+
+# For FLOPS, we assume bf16 and ignore sparsity.
+# Memory bandwidth values are peak theoretical bandwidth.
+GPU_SPECS = {
+    "a100": {"flops": 312e12, "memory_size": 80e9, "memory_bandwidth": 1.6e12},  # 1.6 TB/s HBM2e
+    "b200": {"flops": 2250e12, "memory_size": 192e9, "memory_bandwidth": 8e12},  # 8 TB/s HBM3e
+    "h100": {"flops": 990e12, "memory_size": 80e9, "memory_bandwidth": 3.35e12},  # 3.35 TB/s HBM3
+    "a6000": {"flops": 155e12, "memory_size": 48e9, "memory_bandwidth": 768e9},  # 768 GB/s GDDR6
+    "l40s": {"flops": 362e12, "memory_size": 48e9, "memory_bandwidth": 864e9},  # 864 GB/s GDDR6
+}
+
+# Conventions for FLOPs calculations (fixed; not switches)
+FLOP_PER_MAC = 2
+# Approximate softmax cost per attention score:
+# ~4 scalar ops/score: exp + subtract max (stabilization) + sum + divide.
+SOFTMAX_FLOPS_PER_SCORE = 4
+
+
+@dataclasses.dataclass
+class ModelDims:
+    num_layers: int
+    hidden_size: int
+    intermediate_size: int
+    vocab_size: int
+    num_attn_heads: int
+    num_kv_heads: Optional[int] = None
+
+    def __post_init__(self):
+        if self.num_kv_heads is None:
+            self.num_kv_heads = self.num_attn_heads
+
+        assert self.hidden_size % self.num_attn_heads == 0, "hidden_size must be divisible by num_attn_heads"
+        assert self.num_attn_heads % self.num_kv_heads == 0, (
+            "num_attn_heads must be divisible by num_kv_heads (GQA/MQA)"
+        )
+
+    @property
+    def head_dim(self) -> int:
+        return self.hidden_size // self.num_attn_heads
+
+    def attn_flops(self, query_len: int, kv_len: int) -> int:
+        """FLOPs for one layer of self-attention given query_len and kv_len.
+
+        Assumptions:
+          - 1 MAC = 2 FLOPs (FLOP_PER_MAC).
+          - Efficient GQA/MQA K/V projections with width = num_kv_heads * head_dim.
+          - Softmax ≈ 4 FLOPs per score (see SOFTMAX_FLOPS_PER_SCORE).
+          - LayerNorms and minor ops ignored (dominated by matmuls).
+        """
+        d = self.head_dim
+        mul = FLOP_PER_MAC
+
+        # Projections for the query_len new tokens
+        q_proj = mul * query_len * self.hidden_size * self.hidden_size
+        kv_proj = mul * 2 * query_len * self.hidden_size * (self.num_kv_heads * d)  # GQA/MQA
+
+        # Scores and attention-weighted values
+        qk = mul * self.num_attn_heads * query_len * kv_len * d
+        softmax = SOFTMAX_FLOPS_PER_SCORE * self.num_attn_heads * query_len * kv_len
+        av = mul * self.num_attn_heads * query_len * kv_len * d
+
+        # Output projection
+        out_proj = mul * query_len * self.hidden_size * self.hidden_size
+
+        return q_proj + kv_proj + qk + softmax + av + out_proj
+
+    def mlp_flops(self, seq_len: int) -> int:
+        """Two matmuls dominate; activation cost under-counted on purpose."""
+        mul = FLOP_PER_MAC
+        first = mul * seq_len * self.hidden_size * self.intermediate_size
+        act = seq_len * self.intermediate_size  # under-counted on purpose
+        second = mul * seq_len * self.intermediate_size * self.hidden_size
+        return first + act + second
+
+    def prefill_flops(self, prompt_lengths: list[int]) -> int:
+        """Prefill builds the KV cache; logits are computed once after each prompt."""
+        total = 0
+        for L in prompt_lengths:
+            total += self.num_layers * (self.attn_flops(L, L) + self.mlp_flops(L))
+            # Always include a single LM head after prefill (next-token logits)
+            total += FLOP_PER_MAC * self.hidden_size * self.vocab_size
+        return total
+
+    def decode_flops(self, prompt_lengths: list[int], response_lengths: list[int], samples_per_prompt: int = 1) -> int:
+        """Decode/generation FLOPs.
+
+        Args:
+            prompt_lengths: List of prompt lengths (one per unique prompt)
+            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
+            samples_per_prompt: Number of samples generated per prompt
+
+        Embedding lookups are ignored by design.
+        """
+        assert len(response_lengths) == len(prompt_lengths) * samples_per_prompt, (
+            f"Expected {len(prompt_lengths) * samples_per_prompt} response lengths, got {len(response_lengths)}"
+        )
+
+        total = 0
+        response_idx = 0
+        for P in prompt_lengths:
+            # Process all samples for this prompt
+            for _ in range(samples_per_prompt):
+                R = response_lengths[response_idx]
+                total += R * self.num_layers * self.mlp_flops(seq_len=1)
+                for t in range(R):
+                    kv_len = P + t + 1  # prompt + generated so far + current
+                    total += self.num_layers * self.attn_flops(query_len=1, kv_len=kv_len)
+                total += R * FLOP_PER_MAC * self.hidden_size * self.vocab_size
+                response_idx += 1
+        return total
+
+    def flops(
+        self, prompt_lengths: list[int], response_lengths: Optional[list[int]] = None, samples_per_prompt: int = 1
+    ) -> int:
+        """Total FLOPs for prefill and (optionally) decode.
+
+        Args:
+            prompt_lengths: List of prompt lengths (one per unique prompt)
+            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
+            samples_per_prompt: Number of samples generated per prompt
+        """
+        total = self.prefill_flops(prompt_lengths)
+        if response_lengths is not None:
+            total += self.decode_flops(prompt_lengths, response_lengths, samples_per_prompt)
+        return total
+
+    def weight_memory_bytes(self, num_tokens: int, dtype_bytes: int = 2) -> int:
+        """Memory bytes for reading model weights for a given number of tokens.
+
+        Args:
+            num_tokens: Number of tokens to process
+            dtype_bytes: Bytes per element (2 for FP16/BF16)
+
+        Returns:
+            Total bytes for weight reads across all layers
+        """
+        num_kv = self.num_kv_heads if self.num_kv_heads is not None else self.num_attn_heads
+        head_dim = self.hidden_size // self.num_attn_heads
+        hidden_kv = num_kv * head_dim
+
+        # Per-layer weight params (Q, K, V, O, MLP up, MLP down)
+        w_q = self.hidden_size * self.hidden_size
+        w_k = self.hidden_size * hidden_kv
+        w_v = self.hidden_size * hidden_kv
+        w_o = self.hidden_size * self.hidden_size
+        w_up = self.hidden_size * self.intermediate_size
+        w_dn = self.intermediate_size * self.hidden_size
+
+        per_layer_weight_bytes = (w_q + w_k + w_v + w_o + w_up + w_dn) * dtype_bytes
+        return self.num_layers * num_tokens * per_layer_weight_bytes
+
+    def kv_cache_write_bytes(self, num_tokens: int, dtype_bytes: int = 2) -> int:
+        """Memory bytes for writing KV cache for a given number of tokens.
+
+        Args:
+            num_tokens: Number of tokens being cached
+            dtype_bytes: Bytes per element (2 for FP16/BF16)
+
+        Returns:
+            Total bytes for KV cache writes across all layers
+        """
+        num_kv = self.num_kv_heads if self.num_kv_heads is not None else self.num_attn_heads
+        head_dim = self.hidden_size // self.num_attn_heads
+
+        # 2x for K and V
+        kv_write_bytes_per_token = 2 * num_kv * head_dim * dtype_bytes
+        return self.num_layers * num_tokens * kv_write_bytes_per_token
+
+    def kv_cache_read_bytes(
+        self, prompt_lengths: list[int], response_lengths: list[int], samples_per_prompt: int = 1, dtype_bytes: int = 2
+    ) -> int:
+        """Memory bytes for reading KV cache during decode.
+
+        For each new token generated, we read all previous tokens' KV cache.
+        When generating multiple samples per prompt, the prompt KV cache is shared.
+
+        Args:
+            prompt_lengths: List of prompt lengths (one per unique prompt)
+            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
+            samples_per_prompt: Number of samples generated per prompt
+            dtype_bytes: Bytes per element (2 for FP16/BF16)
+
+        Returns:
+            Total bytes for KV cache reads during decode
+        """
+        assert len(response_lengths) == len(prompt_lengths) * samples_per_prompt, (
+            f"Expected {len(prompt_lengths) * samples_per_prompt} response lengths, got {len(response_lengths)}"
+        )
+
+        num_kv = self.num_kv_heads if self.num_kv_heads is not None else self.num_attn_heads
+        head_dim = self.hidden_size // self.num_attn_heads
+
+        # For batched sampling with shared prompt KV cache:
+        # - Prompt KV is read once per new token position across ALL samples (not per sample)
+        # - Each sample has its own KV for generated tokens
+        kv_read_terms = 0
+        response_idx = 0
+
+        for P in prompt_lengths:
+            # For this prompt, collect all response lengths
+            prompt_responses = []
+            for _ in range(samples_per_prompt):
+                prompt_responses.append(response_lengths[response_idx])
+                response_idx += 1
+
+            # Prompt KV reads: In synchronized batch generation with vLLM n>1,
+            # the prompt KV cache is stored once but each sample reads it independently.
+            # At each decoding position, each sample reads the prompt KV cache.
+            # Number of positions = max response length (all generate synchronously)
+            max_response_length = max(prompt_responses) if prompt_responses else 0
+            # Each of the samples_per_prompt samples reads prompt KV at each position
+            kv_read_terms += max_response_length * samples_per_prompt * P
+
+            # Per-sample generated KV reads: Each sample reads its own previously generated tokens
+            for R in prompt_responses:
+                # Each token in this sample reads its previously generated tokens
+                # sum_{i=0}^{R-1} i = R*(R-1)/2
+                kv_read_terms += R * (R - 1) // 2
+
+        # 2x for K and V
+        kv_bytes_per_token = 2 * num_kv * head_dim * dtype_bytes
+        return self.num_layers * kv_bytes_per_token * kv_read_terms
+
+    def prefill_memory_bytes(self, prompt_lengths: list[int], dtype_bytes: int = 2) -> int:
+        """Memory bytes for prefill phase.
+
+        During prefill:
+        - Read weights once for the entire batch (batched matmul)
+        - Write KV cache for each token
+
+        Args:
+            prompt_lengths: List of prompt lengths
+            dtype_bytes: Bytes per element (2 for FP16/BF16)
+
+        Returns:
+            Total memory bytes for prefill
+        """
+        # In batched prefill, weights are read once for the entire operation,
+        # not once per token. We process all prompts in a single batch.
+        num_prefill_batches = len(prompt_lengths)  # Each prompt is a "batch"
+        weight_bytes = self.weight_memory_bytes(num_prefill_batches, dtype_bytes)
+
+        # KV cache is written for every token
+        total_prefill_tokens = sum(prompt_lengths)
+        kv_write_bytes = self.kv_cache_write_bytes(total_prefill_tokens, dtype_bytes)
+        return weight_bytes + kv_write_bytes
+
+    def decode_memory_bytes(
+        self, prompt_lengths: list[int], response_lengths: list[int], samples_per_prompt: int = 1, dtype_bytes: int = 2
+    ) -> int:
+        """Memory bytes for decode/generation phase.
+
+        During decode:
+        - Read weights for each new token position (shared across samples in batch)
+        - Write KV cache for each new token
+        - Read all previous KV cache for attention
+
+        Args:
+            prompt_lengths: List of prompt lengths (one per unique prompt)
+            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
+            samples_per_prompt: Number of samples generated per prompt
+            dtype_bytes: Bytes per element (2 for FP16/BF16)
+
+        Returns:
+            Total memory bytes for decode
+        """
+        # In synchronized batch generation, weights are read once per position,
+        # not once per token. With multiple samples per prompt generating in parallel,
+        # we only need to read weights for the number of unique positions.
+        unique_positions = 0
+        response_idx = 0
+        for _ in prompt_lengths:
+            # Get response lengths for this prompt's samples
+            prompt_responses = response_lengths[response_idx : response_idx + samples_per_prompt]
+            response_idx += samples_per_prompt
+            # In synchronized generation, all samples generate the same number of positions
+            # (up to the max length among them)
+            unique_positions += max(prompt_responses) if prompt_responses else 0
+
+        weight_bytes = self.weight_memory_bytes(unique_positions, dtype_bytes)
+
+        # KV writes happen for all tokens (each sample writes its own KV)
+        total_decode_tokens = sum(response_lengths)
+        kv_write_bytes = self.kv_cache_write_bytes(total_decode_tokens, dtype_bytes)
+
+        kv_read_bytes = self.kv_cache_read_bytes(prompt_lengths, response_lengths, samples_per_prompt, dtype_bytes)
+        return weight_bytes + kv_write_bytes + kv_read_bytes
+
+    def memory_bytes(
+        self,
+        prompt_lengths: list[int],
+        response_lengths: Optional[list[int]] = None,
+        samples_per_prompt: int = 1,
+        dtype_bytes: int = 2,
+    ) -> int:
+        """Approximate total HBM bytes moved for prefill + decode.
+
+        Returns an integer number of bytes. Divide by elapsed seconds to get B/s;
+        compare against peak bandwidth to get utilization.
+
+        Args:
+            prompt_lengths: List of prompt lengths (one per unique prompt)
+            response_lengths: List of response lengths (samples_per_prompt * len(prompt_lengths) total)
+            samples_per_prompt: Number of samples generated per prompt
+            dtype_bytes: Bytes per element (2 for FP16/BF16)
+
+        Returns:
+            Total memory bytes moved
+
+        Assumptions:
+          - Weights are read once per token per layer (Q,K,V,O + MLP up/down)
+          - KV cache: write K/V for every token; during decode, read all past K/V per new token
+          - When batching samples, prompt KV cache is shared across samples
+          - Embedding and LM head reads are ignored (usually dominated by matmul weight traffic)
+        """
+        total = self.prefill_memory_bytes(prompt_lengths, dtype_bytes)
+
+        if response_lengths is not None:
+            assert len(response_lengths) == len(prompt_lengths) * samples_per_prompt, (
+                f"Expected {len(prompt_lengths) * samples_per_prompt} response lengths, got {len(response_lengths)}"
+            )
+
+            # Pass original prompt_lengths with samples_per_prompt to correctly handle shared KV cache
+            total += self.decode_memory_bytes(prompt_lengths, response_lengths, samples_per_prompt, dtype_bytes)
+
+        return total
+
+
+def load_model_dims(model_name: str) -> ModelDims:
+    cfg = transformers.AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+    return ModelDims(
+        num_layers=cfg.num_hidden_layers,
+        hidden_size=cfg.hidden_size,
+        intermediate_size=cfg.intermediate_size,
+        vocab_size=cfg.vocab_size,
+        num_attn_heads=cfg.num_attention_heads,
+        num_kv_heads=getattr(cfg, "num_key_value_heads", None),
+    )
+
+
+def get_device_name(device_name: str) -> str:
+    tokens = device_name.lower().replace("-", " ").split()
+
+    filtered = [val for val in tokens if val not in ["nvidia", "80gb", "40gb", "48gb", "hbm3", "rtx", "sxm4", "pcie"]]
+
+    for token in filtered:
+        if token in GPU_SPECS:
+            return token
+
+    raise ValueError(f"Unsupported device name: {device_name}. Expected one of: {list(GPU_SPECS.keys())}")

--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -404,6 +404,10 @@ class LLMRayActor:
         """Get the vLLM model config from the engine."""
         return self.llm_engine.model_config
 
+    def get_vllm_config(self):
+        """Get the full vLLM config including parallel_config."""
+        return self.llm_engine.vllm_config
+
     def _should_stop(self) -> bool:
         if (time.perf_counter() - self._last_should_stop_update) > self._should_stop_timeout_s:
             should_stop_ref = self.actor_manager.should_stop.remote()

--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -408,6 +408,24 @@ class LLMRayActor:
         """Get the full vLLM config including parallel_config."""
         return self.llm_engine.vllm_config
 
+    def get_model_dims_dict(self):
+        """Get only the model dimensions as a simple dict without loading weights."""
+        model_config = self.llm_engine.model_config
+        parallel_config = self.llm_engine.vllm_config.parallel_config
+
+        # Extract only the necessary dimensions as simple Python types
+        hidden_size = model_config.get_hidden_size()
+        intermediate_size = getattr(model_config.hf_text_config, "intermediate_size", 4 * hidden_size)
+
+        return {
+            "num_layers": model_config.get_num_layers(parallel_config),
+            "hidden_size": hidden_size,
+            "intermediate_size": intermediate_size,
+            "vocab_size": model_config.get_vocab_size(),
+            "num_attn_heads": model_config.get_num_attention_heads(parallel_config),
+            "num_kv_heads": model_config.get_num_kv_heads(parallel_config),
+        }
+
     def _should_stop(self) -> bool:
         if (time.perf_counter() - self._last_should_stop_update) > self._should_stop_timeout_s:
             should_stop_ref = self.actor_manager.should_stop.remote()

--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -400,6 +400,10 @@ class LLMRayActor:
         self.tracking = _init_tool_tracking()
         self.request_outputs = {}
 
+    def get_model_config(self):
+        """Get the vLLM model config from the engine."""
+        return self.llm_engine.model_config
+
     def _should_stop(self) -> bool:
         if (time.perf_counter() - self._last_should_stop_update) > self._should_stop_timeout_s:
             should_stop_ref = self.actor_manager.should_stop.remote()

--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -515,7 +515,7 @@ class LLMRayActor:
                 self._prefetch_future.result()
 
             self._poll_tool_futures(self.tracking, self.llm_engine.tokenizer)
-            current_time = time.time()
+            current_time = time.perf_counter()
             if self.llm_engine.has_unfinished_requests():
                 for output in [o for o in self.llm_engine.step() if o.finished]:
                     # Fix the index field for all sub-requests
@@ -842,7 +842,7 @@ class LLMRayActor:
                 tracking["pending_tool_futures"].pop(req_id, None)
 
                 complete_output = tracking["concat_outputs"][req_id].outputs[0]
-                current_time = time.time()
+                current_time = time.perf_counter()
                 self._finalize_sub_request(req_id, last_output, complete_output, current_time)
                 # Don't add to dict_keys_to_delete since we already removed it
                 continue

--- a/open_instruct/vllm_utils3.py
+++ b/open_instruct/vllm_utils3.py
@@ -400,14 +400,6 @@ class LLMRayActor:
         self.tracking = _init_tool_tracking()
         self.request_outputs = {}
 
-    def get_model_config(self):
-        """Get the vLLM model config from the engine."""
-        return self.llm_engine.model_config
-
-    def get_vllm_config(self):
-        """Get the full vLLM config including parallel_config."""
-        return self.llm_engine.vllm_config
-
     def get_model_dims_dict(self):
         """Get only the model dimensions as a simple dict without loading weights."""
         model_config = self.llm_engine.model_config


### PR DESCRIPTION
Now, we report MFU/MBU from the actors into Wandb, aggregated over all of the actors. 

To enable this, we move the `ModelDims` class into `open_instruct/utils.py` to avoid a circular import.

Successful runs: 

1. Single GPU job: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K5VTHB9W7HV363ANKHMW9B00?taskId=01K5VTHBA0J1JX78DS2EW43Y3D&jobId=01K5VTHBFBQZJ13WCDFKMWVXXZ)
2. Multi-node: [Beaker](https://wandb.ai/ai2-llm/open_instruct_internal/runs/nmn0o60h?nw=nwuserfinbarrt)

Results:
 
<img width="1103" height="317" alt="Screenshot 2025-09-23 at 1 11 30 PM" src="https://github.com/user-attachments/assets/a51fdf59-243f-45f4-8023-8d0fce90c889" />


