### PR TITLE
Add jq to base image packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     sudo \
     nginx \
+    jq \
     && apt-get autoremove -y \
     && mkdir -p /etc/nginx/conf.d \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- add jq to the base Ubuntu packages installed in the Docker image

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d5d60e4518832dad982d6363d61846