### PR TITLE
Silences flash attention warning by loading models directly on device

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -646,11 +646,7 @@ class PolicyTrainerRayProcess(RayProcess):
             torch_dtype=torch.bfloat16,
             attn_implementation="flash_attention_2",
             use_cache=False,
-            **(
-                {"device_map": {"": self.local_rank}}
-                if ds_config.get("zero_optimization", {}).get("stage") != 3
-                else {}
-            ),
+            **({"device_map": {"": self.local_rank}} if args.deepspeed_stage != 3 else {}),
         )
         disable_dropout_in_model(self.policy)
         self.policy.gradient_checkpointing_enable()
@@ -749,11 +745,7 @@ class PolicyTrainerRayProcess(RayProcess):
             torch_dtype=torch.bfloat16,
             attn_implementation="flash_attention_2",
             use_cache=False,
-            **(
-                {"device_map": {"": self.local_rank}}
-                if ds_config.get("zero_optimization", {}).get("stage") != 3
-                else {}
-            ),
+            **({"device_map": {"": self.local_rank}} if args.deepspeed_stage != 3 else {}),
         )
         disable_dropout_in_model(self.ref_policy)
         self.ref_policy, *_ = deepspeed.initialize(model=self.ref_policy, config=ds_config)


### PR DESCRIPTION
Currently, we get this warning: 

```
2025-10-03T15:49:36.135Z (PolicyTrainerRayProcess pid=1864) You are attempting to use Flash Attention 2.0 with a model not initialized on GPU. Make sure to move the model to GPU after initializing it on CPU with `model.to('cuda')`.
```

This PR silences the warning by directly initializing the model on device. 