### PR TITLE
Added reasonable timeouts to our debug scripts to ensure they don't hang forever and take up resources.

### DIFF
--- a/scripts/train/debug/large_test_script.sh
+++ b/scripts/train/debug/large_test_script.sh
@@ -13,6 +13,7 @@ uv run python mason.py \
 	--preemptible \
         --num_nodes 2 \
 	--description "Large (multi-node) test script." \
+	--timeout "1h" \
         --max_retries 0 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
         --budget ai2/oe-adapt \

--- a/scripts/train/debug/single_gpu_on_beaker.sh
+++ b/scripts/train/debug/single_gpu_on_beaker.sh
@@ -17,6 +17,7 @@ uv run python mason.py \
        --priority urgent \
        --num_nodes 1 \
        --max_retries 0 \
+       --timeout "15m" \
        --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
        --budget ai2/oe-adapt \
        --gpus 1 \

--- a/scripts/train/debug/tool_grpo_fast.sh
+++ b/scripts/train/debug/tool_grpo_fast.sh
@@ -21,6 +21,7 @@ uv run python mason.py \
        --preemptible \
        --num_nodes 1 \
        --max_retries 0 \
+       --timeout "45m" \
        --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
        --env GIT_COMMIT="$(git rev-parse --short HEAD)" \
        --budget ai2/oe-adapt \


### PR DESCRIPTION
Sometimes, during development, these will have bugs and hang forever. This prevents them from taking up resources indefinitely. 