### PR TITLE
Revert "Silences NCCL warning"

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -625,15 +625,6 @@ class PolicyTrainerRayProcess(RayProcess):
         np.random.seed(worker_seed)
         random.seed(worker_seed)
 
-        torch.distributed.init_process_group(
-            backend="nccl",
-            init_method="env://",
-            world_size=self.world_size,
-            rank=self.rank,
-            timeout=timedelta(minutes=args.backend_timeout),
-            device_id=torch.device("cuda", self.local_rank),
-        )
-
         deepspeed.init_distributed(timeout=timedelta(minutes=args.backend_timeout))
 
         ds_config = get_train_ds_config(offload=False, adam_offload=False, stage=args.deepspeed_stage, bf16=True)


### PR DESCRIPTION
Reverts allenai/open-instruct#1055, which broke the multi-node job.