### PR TITLE
Use less steps for tool_grpo_fast.sh

### DIFF
--- a/scripts/train/debug/tool_grpo_fast.sh
+++ b/scripts/train/debug/tool_grpo_fast.sh
@@ -48,7 +48,7 @@ uv run python mason.py \
     --sft_messages_key messages \
     --exp_name 0605_general_tool_use_without_good_outputs \
     --learning_rate 5e-7 \
-    --total_episodes 640 \
+    --total_episodes $((20 * 8 * 4)) \
     --deepspeed_stage 2 \
     --with_tracking \
     --num_epochs 1 \


### PR DESCRIPTION
100 was arbitrary, and slow. We now do 20.