### PR TITLE
Creates triton cache, silencing warning

### DIFF
--- a/configs/beaker_configs/ray_node_setup.sh
+++ b/configs/beaker_configs/ray_node_setup.sh
@@ -15,7 +15,7 @@ echo PATH=$PATH
 BEAKER_LEADER_REPLICA_IP=$(getent hosts ${BEAKER_LEADER_REPLICA_HOSTNAME} | awk '{print $1}')
 
 RAY_NODE_PORT=8888
-mkdir -p /root/.triton/autotune
+mkdir -p "$HOME/.triton/autotune"  # Create Triton autotune cache directory to silence warnings
 ray stop --force
 
 if [ "$BEAKER_REPLICA_RANK" == "0" ]; then


### PR DESCRIPTION
Previously, we would see this warning in our logs: 

```
2025-10-09T15:06:07.144Z df: /root/.triton/autotune: No such file or directory
```

Now, it's gone. Example run: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K759VNZKEJR1R2M9ZATMXX4V?taskId=01K759VNZQFT3Z1Y2NNHYX9B42&jobId=01K759VP39QG2NBKR4GYC9N4P3).