### PR TITLE
Silences proc warning when we have a small dataset. 

### DIFF
--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -226,7 +226,7 @@ class DatasetConfig:
 
 def get_num_proc(dataset_len: int, num_available_cpus: int, example_per_second_per_cpu) -> int:
     num_required_cpus = max(1, dataset_len // example_per_second_per_cpu)
-    return min(num_required_cpus, num_available_cpus)
+    return min(num_required_cpus, num_available_cpus, dataset_len)
 
 
 def select_nested(dataset: DatasetDict, max_examples_per_split: int):

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -127,7 +127,7 @@ FILTER_EXAMPLE_PER_SECOND_PER_CPU = 1130
 
 def get_num_proc(dataset_len: int, num_available_cpus: int, example_per_second_per_cpu) -> int:
     num_required_cpus = max(1, dataset_len // example_per_second_per_cpu)
-    return min(num_required_cpus, num_available_cpus)
+    return min(num_required_cpus, num_available_cpus, dataset_len)
 
 
 COLORS = ["on red", "on green", "on blue", "on yellow", "on magenta"]


### PR DESCRIPTION
Previously, we got this warning when running `large_test_script.sh` (example: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K75BDBGPPBT2SPQPSNB9KK3C)):

```
2025-10-09 20:46:20 - WARNING - arrow_dataset.py:3100 - num_proc must be <= 8. Reducing num_proc to 8 for dataset of size 8.
```

By capping the number of procs based on the length of the dataset, we guarantee we don't set that value too high (and thus remove the warning). Example run: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01K75CR3R3B0H2WZFK00CAK3VM?).