### PR TITLE
Constant denom for loss

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -449,7 +449,9 @@ class Args:
                 "use_vllm_logprobs sets old_logprobs to vLLM logprobs, making importance sampling pointless."
             )
         if self.masked_mean_denominator is not None:
-            assert self.masked_mean_denominator > 0, "`masked_mean_denominator` must be greater than 0!"
+            assert self.masked_mean_denominator > 0, (
+                f"masked_mean_denominator (={self.masked_mean_denominator}) must be greater than 0!"
+            )
         assert self.num_samples_per_prompt_rollout > 0, "Number of samples per prompt must be greater than 0!"
         if self.num_samples_per_prompt_rollout == 1:
             logger.warning("num_samples_per_prompt_rollout is 1. This reduces GRPO to REINFORCE.")
@@ -517,13 +519,9 @@ def masked_mean(
     values: torch.Tensor, mask: torch.Tensor, axis: Optional[int] = None, denominator: Optional[float] = None
 ) -> torch.Tensor:
     """Compute mean of tensor with a masked values."""
-    if axis is not None:
-        numerator = (values * mask).sum(axis=axis)
-        denom = denominator if denominator is not None else mask.sum(axis=axis)
-        return (numerator / denom).mean()
-    else:
-        denom = denominator if denominator is not None else mask.sum()
-        return (values * mask).sum() / denom
+    numerator = (values * mask).sum(axis=axis)
+    denom = mask.sum(axis=axis) if denominator is None else denominator
+    return (numerator / denom).mean()
 
 
 class MetricsTracker:


### PR DESCRIPTION
Allows using a constant divisor for loss/masked mean stats following Dr GRPO (https://arxiv.org/abs/2503.20783)
Using this + masked_mean_axis of 1 recovers the dr grpo loss.