### PR TITLE
Remove duplicated `allenai/tulu-2-7b` config

### DIFF
--- a/scripts/synth_pref/utils/model_configs.py
+++ b/scripts/synth_pref/utils/model_configs.py
@@ -60,14 +60,6 @@ MODELS: dict[str, dict[str, Any]] = {
         "generate": default_generation_params,
         "task": {"gpu_count": 2},
     },
-    "allenai/tulu-2-7b": {
-        "model": {
-            "name_or_path": "allenai/tulu-2-7b",
-            "num_scheduler_steps": 1,
-        },
-        "generate": default_generation_params,
-        "task": {"gpu_count": 1},
-    },
     "allenai/tulu-2-13b": {
         "model": {
             "name_or_path": "allenai/tulu-2-13b",


### PR DESCRIPTION
## PR Summary
This minor maintenance PR removes the duplicated `allenai/tulu-2-7b` configuration, which could potentially cause issues in the future if one copy were updated independently.