### PR TITLE
Add GPU specs for PRO 6000

### DIFF
--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -1696,7 +1696,7 @@ GPU_SPECS = {
     "h100": {"flops": 990e12, "memory_size": 80e9, "memory_bandwidth": 3.35e12},  # 3.35 TB/s HBM3
     "a6000": {"flops": 155e12, "memory_size": 48e9, "memory_bandwidth": 768e9},  # 768 GB/s GDDR6
     "l40s": {"flops": 362e12, "memory_size": 48e9, "memory_bandwidth": 864e9},  # 864 GB/s GDDR6
-    "6000": {"flops": 503.8e12, "memory_size": 96e9, "memory_bandwidth": 1792e9},  # 1792 GB/s GDDR7
+    "pro 6000": {"flops": 503.8e12, "memory_size": 96e9, "memory_bandwidth": 1792e9},  # 1792 GB/s GDDR7
 }
 
 # Conventions for FLOPs calculations (fixed; not switches)
@@ -2059,12 +2059,10 @@ class ModelDims:
 
 
 def get_device_name(device_name: str) -> str:
-    tokens = device_name.lower().replace("-", " ").split()
+    normalized_device_name = device_name.lower().replace("-", " ")
 
-    filtered = [val for val in tokens if val not in ["nvidia", "80gb", "40gb", "48gb", "hbm3", "rtx", "sxm4", "pcie"]]
-
-    for token in filtered:
-        if token in GPU_SPECS:
-            return token
+    for key in GPU_SPECS.keys():
+        if key in normalized_device_name:
+            return key
 
     raise ValueError(f"Unsupported device name: {device_name}. Expected one of: {list(GPU_SPECS.keys())}")


### PR DESCRIPTION
Without the supported GPU specs, running `grpo_fast.py` will fail at this line

https://github.com/allenai/open-instruct/blob/3abad8d3bc9527b7e529b4d62f062f5b8ba47baf/open_instruct/utils.py#L2069

The full GPU name reported by `torch.cuda.get_device_name()` for my GPU is `NVIDIA RTX PRO 6000 Blackwell Server Edition`, hence I added the key `"pro 6000"` to `GPU_SPECS` dict.

6000 alone is too generic, as it can be confused with `NVIDIA RTX 6000 Ada Generation`. Hence, I also need to modify the logic in `get_device_name()` to match based on the keys in `GPU_SPECS`, instead of tokenizing the original device name string.

The FLOPS and memory bandwidth numbers can be found here (Table 4, last column) https://www.nvidia.com/content/dam/en-zz/Solutions/design-visualization/quadro-product-literature/NVIDIA-RTX-Blackwell-PRO-GPU-Architecture-v1.0.pdf

<img width="947" height="449" alt="image" src="https://github.com/user-attachments/assets/e4d9e7b0-8ff2-4207-9cb6-dd533342d497" />

I suppose the "more correct" solution is to also gracefully handle GPUs without known specs (i.e. skip MFU computation?). But for now, I'm adding the specs for my GPU here so that I can run the script.