### PR TITLE
active sampling or whatever we call it

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -279,9 +279,9 @@ class Args:
     use_vllm_logprobs: bool = False
     """whether to use vLLM's logprobs for training instead of calculating them via forward pass"""
 
-    active_fill_completions: bool = False
+    active_sampling: bool = False
     """Whether to refill the batch with *new prompts/completions* after filtering."""
-    active_fill_max_attempts: int = 3
+    active_sampling_max_attempts: int = 3
     """How many times to attempt to fill"""
 
     # Reward
@@ -1889,7 +1889,7 @@ def data_preparation_thread(
 
             prompts_kept_this_iter = len(scores) // per_prompt_rollout if per_prompt_rollout > 0 else 0
 
-            if not args.active_fill_completions:
+            if not args.active_sampling:
                 break
 
             collected_samples = sum(len(chunk.scores) for chunk in aggregation.chunks)
@@ -1898,11 +1898,11 @@ def data_preparation_thread(
             if prompts_remaining <= 0:
                 break
 
-            if prompts_kept_this_iter == 0 and fill_iteration > args.active_fill_max_attempts:
+            if prompts_kept_this_iter == 0 and fill_iteration > args.active_sampling_max_attempts:
                 total_responses = sum(len(chunk.kept_indices) for chunk in aggregation.chunks)
                 logger.warning(
                     "[Active fill completions] Unable to collect non-zero advantage prompts in iteration %d; "
-                    "set as max by args.active_fill_max_attempts, proceeding with existing batch of size %d.",
+                    "set as max by args.active_sampling_max_attempts, proceeding with existing batch of size %d.",
                     fill_iteration,
                     total_responses,
                 )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduce active sampling to refill batches after filtering, refactor data preparation into aggregated chunks with safer iterators and enriched metrics, and adjust save/eval flow.
> 
> - **GRPO pipeline**:
>   - Add `args.active_sampling` and `args.active_sampling_max_attempts`; remove `args.fill_completions`.
>   - Refactor `data_preparation_thread` to iteratively accumulate, score, filter (zero-std), optionally refill with new prompts, aggregate chunks, and pack sequences.
>   - Mask truncated completions by zeroing scores/advantages and response masks when enabled.
>   - Compute and log new metrics: per-batch filtered group counts, zero/solved reward group ratios, packed ratio, and guarded tokens/sec; propagate `prompt_lengths`/`response_lengths`.
> - **Batch/inference handling**:
>   - `accumulate_inference_batches` now returns `(GenerationResult, Batch, prompt_lengths, response_lengths)` and preserves `indices` field.
>   - Add `combine_reward_metrics`, `FilteredChunk`, and `AggregationState` to merge multi-iteration results and stats.
> - **Iterator robustness**:
>   - `ShufflingIterator` now guards empty data, centralizes effective-size computation, and updates it on state restore.
> - **Training loop**:
>   - Track `val/total_filtered_groups` to submit extra prompt batches when filtering shrinks data; avoid step collisions via fractional `training_step` offsets.
>   - Save condition updated to allow save at step 1 when `eval_on_step_0` is true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8181e51ac1c6f83396e7171066de216fb7ccee3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->