### PR TITLE
Sets default env vars, copying mason.py

### DIFF
--- a/scripts/train/debug/grpo_fast.sh
+++ b/scripts/train/debug/grpo_fast.sh
@@ -1,3 +1,6 @@
+export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+export VLLM_DISABLE_COMPILE_CACHE=1
+export VLLM_USE_V1=1    
 uv run python open_instruct/grpo_fast.py \
     --dataset_mixer_list ai2-adapt-dev/rlvr_gsm8k_zs 64 \
     --dataset_mixer_list_splits train \


### PR DESCRIPTION
There has to be a better way to keep these in sync...

See also #1102, which ran into this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds VLLM environment defaults in `scripts/train/debug/grpo_fast.sh` (enable V1, disable compile cache, allow insecure serialization).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d84783d5689702375451726931337bf3a85541b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->