### PR TITLE
change default LCB to fixed prompt

### DIFF
--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -214,7 +214,7 @@ NEXT_MODEL_DEV=(
     # Coding
     "codex_humanevalplus:0-shot-chat::tulu-thinker_deepseek"
     "mbppplus:0-shot-chat::tulu-thinker_deepseek"
-    "livecodebench_codegeneration::tulu-thinker_deepseek"
+    "livecodebench_codegeneration::tulu-thinker_deepseek_no_think_tags"
     # [TODO not merged] codeeditorbench - requires separate server
     # [TODO, maybe] cruxeval
     
@@ -236,7 +236,7 @@ NEXT_MODEL_UNSEEN=(
     # [TODO, not implemented] Humanity's Last Exam
     # [TODO, not implemented] SuperGPQA
     # [TODO, not implemented] BigBenchExtraHard
-    "livecodebench_codegeneration::tulu-thinker-hidden"
+    "livecodebench_codegeneration::tulu-thinker-hidden_no_think_tags"
     "ifbench::tulu"
 )
 


### PR DESCRIPTION
we recently made a small prompting change to LCB, we should change the eval default here as well

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates LiveCodeBench codegen tasks in eval suites to use no_think_tags prompt variants.
> 
> - **Eval suites (`scripts/eval/oe-eval.sh`)**:
>   - **Coding**:
>     - In `NEXT_MODEL_DEV`, replace `livecodebench_codegeneration::tulu-thinker_deepseek` with `livecodebench_codegeneration::tulu-thinker_deepseek_no_think_tags`.
>     - In `NEXT_MODEL_UNSEEN`, replace `livecodebench_codegeneration::tulu-thinker-hidden` with `livecodebench_codegeneration::tulu-thinker-hidden_no_think_tags`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 455230c80b86047633d5d7ce3e2277c4826e8a34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->