### PR TITLE
default tulu-3-results

### DIFF
--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -76,7 +76,7 @@ today = date.today().strftime("%m%d%Y")
 
 parser = argparse.ArgumentParser()
 # Require fully-qualified workspace or use a fully-qualified default.
-parser.add_argument("--workspace", type=str, default="ai2/oe-adapt-general")
+parser.add_argument("--workspace", type=str, default="ai2/tulu-3-results")
 parser.add_argument("--model_name", type=str, default="hf-opt-7B")
 parser.add_argument("--hf_revision", type=str, default=None)
 parser.add_argument("--location", type=str, default=None)


### PR DESCRIPTION
Default workspace for evals should be tulu-3-results now that the `--workspace` argument is actually passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the default `--workspace` in `scripts/submit_eval_jobs.py` to `ai2/tulu-3-results`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d18b3a1d00eba5cfde7f8f3e414ea71e5d9176b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->