### PR TITLE
Downgrade deepspeed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "bitsandbytes>=0.44.1; platform_system != 'Darwin'",
     "datasets>=4.0.0",
     "debugpy>=1.8.13",
-    "deepspeed<0.17.6",  # version 17.6 and up break our training code right now
+    "deepspeed<0.17.3",  # version 17.3 and up break our training code right now
     "hf-transfer>=0.1.8",
     "litellm>=1.72.0,<1.75.2",  # avoid needing backoff https://github.com/BerriAI/litellm/issues/13827
     "matplotlib>=3.9.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1804,7 +1804,7 @@ requires-dist = [
     { name = "bitsandbytes", marker = "sys_platform != 'darwin'", specifier = ">=0.44.1" },
     { name = "datasets", specifier = ">=4.0.0" },
     { name = "debugpy", specifier = ">=1.8.13" },
-    { name = "deepspeed", specifier = "<0.17.6" },
+    { name = "deepspeed", specifier = "<0.17.3" },
     { name = "fastapi", marker = "extra == 'code'", specifier = ">=0.100.0" },
     { name = "flash-attn", marker = "sys_platform != 'darwin'", specifier = ">=2.8.3" },
     { name = "hf-transfer", specifier = ">=0.1.8" },


### PR DESCRIPTION
I thought I tested it but maybe I mucked something up. This version should work instead. We should eventually investigate why newer versions break (I think something around gradient accumulation).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers the allowed `deepspeed` version from <0.17.6 to <0.17.3 across project config and lock metadata.
> 
> - **Dependencies**:
>   - Tighten `deepspeed` upper bound to `<0.17.3` in `pyproject.toml` and reflected in `uv.lock` metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f29756b9cae489f6e4b10addd54fcf1eb7a712af. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->