### PR TITLE
Fixes a few small issues with `mason.py`

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -31,6 +31,13 @@ OPEN_INSTRUCT_COMMANDS = [
 
 OPEN_INSTRUCT_RESUMABLES = ["open_instruct/grpo_fast.py"]
 
+CACHE_EXCLUDED_ARGS = {
+    "--with_tracking": False,
+    "--checkpoint_state_freq": True,
+    "--checkpoint_state_dir": True,
+    "--gs_checkpoint_state_dir": True,
+}
+
 
 # ----------------------------------------------------------------------
 # Mason logic
@@ -458,12 +465,6 @@ def make_internal_command(command: List[str], args: argparse.Namespace, whoami: 
                 except ValueError:
                     continue
 
-                CACHE_EXCLUDED_ARGS = {
-                    "--with_tracking": False,
-                    "--checkpoint_state_freq": True,
-                    "--checkpoint_state_dir": True,
-                    "--gs_checkpoint_state_dir": True,
-                }
                 filtered_command = build_command_without_args(command[idx:], CACHE_EXCLUDED_ARGS)
                 caching_command = "python " + " ".join(filtered_command) + " --cache_dataset_only"
                 console.log("📦📦📦 Running the caching command with `--cache_dataset_only`")

--- a/test_mason.py
+++ b/test_mason.py
@@ -1,0 +1,83 @@
+import unittest
+
+import parameterized
+
+import mason
+
+
+class TestBuildCommandWithoutArgs(unittest.TestCase):
+    @parameterized.parameterized.expand([
+        (
+            "remove_arg_without_value",
+            ["python", "script.py", "--with_tracking", "--output", "out.txt"],
+            {"--with_tracking": False},
+            ["python", "script.py", "--output", "out.txt"],
+        ),
+        (
+            "remove_arg_with_value",
+            ["python", "script.py", "--checkpoint_state_dir", "/path/to/dir", "--output", "out.txt"],
+            {"--checkpoint_state_dir": True},
+            ["python", "script.py", "--output", "out.txt"],
+        ),
+        (
+            "remove_multiple_args",
+            ["python", "script.py", "--with_tracking", "--checkpoint_state_dir", "/path", "--output", "out.txt"],
+            {"--with_tracking": False, "--checkpoint_state_dir": True},
+            ["python", "script.py", "--output", "out.txt"],
+        ),
+        (
+            "arg_not_present",
+            ["python", "script.py", "--output", "out.txt"],
+            {"--nonexistent": True},
+            ["python", "script.py", "--output", "out.txt"],
+        ),
+        (
+            "empty_command",
+            [],
+            {"--with_tracking": False},
+            [],
+        ),
+        (
+            "empty_args_to_remove",
+            ["python", "script.py", "--output", "out.txt"],
+            {},
+            ["python", "script.py", "--output", "out.txt"],
+        ),
+        (
+            "remove_all_cache_excluded_args",
+            [
+                "python",
+                "open_instruct/grpo_fast.py",
+                "--with_tracking",
+                "--checkpoint_state_freq",
+                "200",
+                "--checkpoint_state_dir",
+                "/weka/path",
+                "--gs_checkpoint_state_dir",
+                "gs://bucket",
+                "--output",
+                "out.txt",
+            ],
+            mason.CACHE_EXCLUDED_ARGS,
+            ["python", "open_instruct/grpo_fast.py", "--output", "out.txt"],
+        ),
+        (
+            "arg_at_end_without_value",
+            ["python", "script.py", "--output", "out.txt", "--with_tracking"],
+            {"--with_tracking": False},
+            ["python", "script.py", "--output", "out.txt"],
+        ),
+        (
+            "arg_at_end_with_value",
+            ["python", "script.py", "--output", "out.txt", "--checkpoint_dir", "/path"],
+            {"--checkpoint_dir": True},
+            ["python", "script.py", "--output", "out.txt"],
+        ),
+    ])
+    def test_build_command_without_args(self, name, command, args_to_remove, expected):
+        result = mason.build_command_without_args(command, args_to_remove)
+        self.assertEqual(result, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. The `find_list_idx` function was redundant as there's a `List.index` method in Python
2. By pulling the logic out into a function, we can test it and verify it's correct. 
3. With the previous `remove_arg_from_list` function, we were doing repeated (redundant) traversals of the command list. Now, with `build_command_without_args`, we do so in a single pass. 

Tested by running the DPO script and verifying it runs: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/tulu-thinker/work/01K97Y10HRRMEZJ4QH4N8BZKS8?taskId=01K97Y10HWCZ36E8677MM2FG34&jobId=01K97Y10PA50C1DV1VHRYHFMMK).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `mason.py` to build cache commands by filtering excluded args in one pass and adds unit tests for the new helper.
> 
> - **mason.py**:
>   - Introduces `CACHE_EXCLUDED_ARGS` and `build_command_without_args` to filter specified flags (with/without values) in one pass.
>   - Replaces ad-hoc arg-removal logic with the new helper when constructing the dataset caching command; simplifies command indexing and subprocess handling.
> - **Tests**:
>   - Adds `test_mason.py` with parameterized tests covering multiple scenarios for `build_command_without_args`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3db6e22f5af26267309a90070decb92eee224da8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->