### PR TITLE
New gpqa

### DIFF
--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -207,7 +207,7 @@ NEXT_MODEL_DEV=(
     
     # Reasoning
     "bbh:cot::hamish_zs_reasoning_deepseek_v2" # OLD: "bbh:cot::hamish_zs_reasoning_deepseek"
-    "gpqa:0shot_cot::hamish_zs_reasoning_deepseek"
+    "gpqa:0shot_cot::qwen3-instruct"
     "zebralogic::hamish_zs_reasoning_deepseek"
     "agi_eval_english:0shot_cot::hamish_zs_reasoning_deepseek"
 


### PR DESCRIPTION
update evals to use new gpqa setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `NEXT_MODEL_DEV` suite’s `gpqa:0shot_cot` task to use `qwen3-instruct` instead of `hamish_zs_reasoning_deepseek`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28b14bdbc834e6ad36c630c397d20c542b414ec0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->