### PR TITLE
allow gs models as model_name_or_path

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -589,24 +589,29 @@ def make_internal_command(command: list[str], args: argparse.Namespace, whoami: 
                     model_revision = command[idx + 1]
                     break
 
-            commit_hash = get_commit_hash(model_name_or_path, model_revision, "config.json", "model")
-            if os.path.exists(model_name_or_path):
-                path = model_name_or_path
-                assert args.gs_model_name is not None, "for local models to upload to gs, you must set --gs_model_name"
-                model_name_or_path = args.gs_model_name
-                commit_hash = hashlib.md5(model_name_or_path.encode("utf-8")).hexdigest()[:8]
-                console.log(
-                    f"Local model is already downloaded, using gs_model_name {model_name_or_path}, with hash of model path {commit_hash}"
-                )
+            if model_name_or_path.startswith("gs://"):
+                gs_saved_path = model_name_or_path
             else:
-                download_from_hf(model_name_or_path, model_revision)  # first download the model
-                path = download_from_hf(model_name_or_path, model_revision)  # then get the path
-            gs_saved_path = f"gs://ai2-llm/post-training/deletable_cache_models/{model_name_or_path}/{commit_hash}"
-            gs_folder = gs_folder_exists(
-                gs_saved_path
-            )  # race condition exists, but it's fine since we are launching mason sequentially
-            if not gs_folder:
-                upload_to_gs_bucket(path, gs_saved_path)
+                commit_hash = get_commit_hash(model_name_or_path, model_revision, "config.json", "model")
+                if os.path.exists(model_name_or_path):
+                    path = model_name_or_path
+                    assert args.gs_model_name is not None, (
+                        "for local models to upload to gs, you must set --gs_model_name"
+                    )
+                    model_name_or_path = args.gs_model_name
+                    commit_hash = hashlib.md5(model_name_or_path.encode("utf-8")).hexdigest()[:8]
+                    console.log(
+                        f"Local model is already downloaded, using gs_model_name {model_name_or_path}, with hash of model path {commit_hash}"
+                    )
+                else:
+                    download_from_hf(model_name_or_path, model_revision)  # first download the model
+                    path = download_from_hf(model_name_or_path, model_revision)  # then get the path
+                gs_saved_path = f"gs://ai2-llm/post-training/deletable_cache_models/{model_name_or_path}/{commit_hash}"
+                gs_folder = gs_folder_exists(
+                    gs_saved_path
+                )  # race condition exists, but it's fine since we are launching mason sequentially
+                if not gs_folder:
+                    upload_to_gs_bucket(path, gs_saved_path)
 
             download_path = gs_saved_path.replace("gs://", "/gs/")
             download_path_without_last_folder = download_path.rsplit("/", 1)[0]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Allows passing a GCS path (gs://...) as --model_name_or_path, skipping HF download/upload and using the provided bucket path directly.
> 
> - **mason.py (GCP model handling)**:
>   - Accepts `gs://` URIs for `--model_name_or_path`; uses the given GCS path directly.
>   - When not a `gs://` path, retains existing behavior: compute commit hash, download from HF or local path, upload to GCS if missing, then download to node and rewrite `--model_name_or_path` to the local path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fe20bda12baca1fd1984380c5060507c1d67416. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->