### PR TITLE
Make zero std filtering explicitly configurable

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -530,6 +530,11 @@ class Args:
                 "filter_zero_std_samples must be True when active_sampling is True. "
                 "Active sampling requires filtering to work correctly."
             )
+        if self.num_samples_per_prompt_rollout == 1 and self.filter_zero_std_samples:
+            raise ValueError(
+                "`filter_zero_std_samples` cannot be True when `num_samples_per_prompt_rollout` is 1, "
+                "as the reward standard deviation will always be 0, causing all samples to be filtered."
+            )
 
 
 def next_batch(dataset_indices: list[int], dataset: datasets.Dataset) -> Batch:


### PR DESCRIPTION
The active sample PR made it so if active sampling is not on, we don't do zero std filtering. This changes default behaviour and makes tracking whether the sampling is useful a bit harder (when comparing the real_batch_size between a run with and without it). This PR makes zero_std_filtering explicitly configurable, in case a user wants to use it without active sampling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `Args.filter_zero_std_samples` to control zero-std reward filtering, requires it with `active_sampling`, forbids it for single-sample rollouts, and plumbs it into batch accumulation.
> 
> - **Config/Args**:
>   - Add `Args.filter_zero_std_samples: bool = True` to control zero-std reward filtering.
>   - Enforce: when `active_sampling=True`, `filter_zero_std_samples` must be `True`.
>   - Validate: raise if `num_samples_per_prompt_rollout==1` and `filter_zero_std_samples=True`.
> - **Data prep**:
>   - Pass `args.filter_zero_std_samples` to `accumulate_inference_batches` (replacing prior coupling to `active_sampling`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62abd8f1c2e2449d8c3ba9333a119067903493a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->