### PR TITLE
Fix zero std filtering

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1717,6 +1717,7 @@ def accumulate_inference_batches(
 
     def process_result(result):
         """Process a single result and optionally add it to results."""
+        # TODO: refactor this to use a class instance instead of nonlocal variables
         nonlocal \
             total_filtered_prompts, \
             filtered_prompt_zero, \
@@ -1815,7 +1816,7 @@ def accumulate_inference_batches(
         while len(results) < num_prompts:
             result = inference_results_Q.get(timeout=timeout)
             shutdown_result = process_result(result)
-            if shutdown_result is not None and shutdown_result[0] is not None:
+            if shutdown_result is not None:
                 return shutdown_result
     else:
         # Without active_sampling, use for loop for exactly num_prompts iterations
@@ -1824,7 +1825,7 @@ def accumulate_inference_batches(
         for _ in range(num_prompts):
             result = inference_results_Q.get(timeout=timeout)
             shutdown_result = process_result(result)
-            if shutdown_result is not None and shutdown_result[0] is not None:
+            if shutdown_result is not None:
                 return shutdown_result
 
     # Combine all results into a single GenerationResult


### PR DESCRIPTION
my bad - I thought #1184 allowed zero std without active filtering, but the logic wasn't right.

This correctly splits the two: now, if we set zero std filtering, we filter without retrying. We only accumulate a full batch when active sampling is set. This is useful for when you want to do the filtering, and see statistics on how much of a batch gets dropped, but you don't want active sampling (since it can slow down training).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Separates zero-std reward filtering from active sampling and updates accumulation to optionally refill until a full batch, wiring the flag through callers.
> 
> - **Training data accumulation**:
>   - Add `active_sampling` parameter to `accumulate_inference_batches` and pass `args.active_sampling` from caller.
>   - Refactor accumulation flow with `process_result`; filtered items are dropped without incrementing progress.
>   - Control flow:
>     - When `active_sampling=True`, keep pulling until `num_prompts` accepted results.
>     - When `False`, pull exactly `num_prompts` items and allow ending with fewer after filtering.
>   - Update docstrings for `filter_zero_std_samples` and function args to reflect new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f103e9e5b4b57db4d79e6a0281ac95b114c7d07. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->