### PR TITLE
Adds a Slack integration, and fixes import error in main.

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -3252,13 +3252,8 @@ def main(args: Args, tc: TokenizerConfig, model_config: ModelConfig):
             checkpoint_state,
         )
     except Exception as e:
-        beaker_url = utils.get_beaker_experiment_url()
-        if beaker_url:
-            error_message = f"<!here> A RL job has died. Check it out: {beaker_url}. Error message: {str(e)}"
-        else:
-            error_message = f"<!here> A RL job has died. Error message: {str(e)}"
         if args.send_slack_alerts:
-            utils.send_slack_alert(error_message)
+            utils.send_slack_alert(e)
         raise
     finally:
         cleanup_training_resources(

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -19,6 +19,7 @@ import unittest
 from unittest import mock
 
 import pytest
+import responses
 import torch
 import vllm
 from dateutil import parser
@@ -238,6 +239,27 @@ class TestBeakerDescription(unittest.TestCase):
         self.assertIn("git_branch: dev", desc)
         self.assertIn("https://wandb.ai/team/project/runs/xyz789", desc)
         self.assertNotIn("% complete", desc)
+
+
+class TestSlackAlert(unittest.TestCase):
+    @responses.activate
+    @mock.patch("open_instruct.utils.get_beaker_experiment_url")
+    @mock.patch("os.environ.get")
+    def test_send_slack_alert_with_beaker_url(self, mock_environ_get, mock_get_beaker_url):
+        webhook_url = "https://hooks.slack.com/services/test"
+        mock_environ_get.return_value = webhook_url
+        mock_get_beaker_url.return_value = "https://beaker.org/ex/test-123"
+
+        responses.add(responses.POST, webhook_url, json={"ok": True}, status=200)
+
+        test_error = ValueError("Test error message")
+        utils.send_slack_alert(test_error)
+
+        self.assertEqual(len(responses.calls), 1)
+        request_body = json.loads(responses.calls[0].request.body)
+        self.assertIn("<!here> A RL job has died.", request_body["text"])
+        self.assertIn("https://beaker.org/ex/test-123", request_body["text"])
+        self.assertIn("Test error message", request_body["text"])
 
 
 class TestUtilityFunctions(unittest.TestCase):

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -2435,12 +2435,15 @@ def combine_reward_metrics(reward_metrics: list[dict[str, Any]]) -> dict[str, An
     return combined
 
 
-def send_slack_alert(message: str) -> None:
-    """Sends the provided message to a Slack webhook (if the env var SLACK_WEBHOOK is set)."""
+def send_slack_alert(error: Exception) -> None:
+    """Sends an alert about a training failure to a Slack webhook (if the env var SLACK_WEBHOOK is set)."""
     slack_webhook_url = os.environ.get("SLACK_WEBHOOK")
     if not slack_webhook_url:
         logger.warning("SLACK_WEBHOOK environment variable not set. Skipping Slack alert.")
         return
+    beaker_url = get_beaker_experiment_url()
+    beaker_message = f"Check it out: {beaker_url}. " if beaker_url else ""
+    message = f"<!here> A RL job has died. {beaker_message}Error message: {str(error)}."
     payload = {"text": message}
     response = requests.post(slack_webhook_url, json=payload)
     if not response.ok:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dev = [
     "ruff>=0.11.13",
     "parameterized>=0.9.0",
     "rich>=13.7.0",
+    "responses>=0.25.8",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -1793,6 +1793,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "parameterized" },
     { name = "pytest" },
+    { name = "responses" },
     { name = "rich" },
     { name = "ruff" },
 ]
@@ -1839,6 +1840,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.6.8" },
     { name = "parameterized", specifier = ">=0.9.0" },
     { name = "pytest", specifier = ">=8.3.4" },
+    { name = "responses", specifier = ">=0.25.8" },
     { name = "rich", specifier = ">=13.7.0" },
     { name = "ruff", specifier = ">=0.11.13" },
 ]
@@ -2630,6 +2632,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.25.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/95/89c054ad70bfef6da605338b009b2e283485835351a9935c7bfbfaca7ffc/responses-0.25.8.tar.gz", hash = "sha256:9374d047a575c8f781b94454db5cab590b6029505f488d12899ddb10a4af1cf4", size = 79320, upload-time = "2025-08-08T19:01:46.709Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl", hash = "sha256:0c710af92def29c8352ceadff0c3fe340ace27cf5af1bbe46fb71275bcd2831c", size = 34769, upload-time = "2025-08-08T19:01:45.018Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds opt-in Slack webhook alerts on training failures with tests and dev dependency support.
> 
> - **Training/Runtime**:
>   - Add `Args.send_slack_alerts` flag in `open_instruct/grpo_fast.py` and send Slack alert on exceptions during training (wrapped in `try/except`).
> - **Utils**:
>   - Implement `utils.send_slack_alert(error)` and `utils.get_beaker_experiment_url()` to post to `SLACK_WEBHOOK` and include Beaker URL when available.
> - **Tests**:
>   - Add `TestSlackAlert` in `open_instruct/test_utils.py` using `responses` to validate webhook payload.
> - **Dependencies**:
>   - Add `responses` to dev dependencies in `pyproject.toml` and lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d690ad90493ea7c4b336e576effe9ff9df7b2cac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->