### PR TITLE
separate active sampling from filtering

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -271,7 +271,7 @@ class Args:
     active_sampling: bool = False
     """Whether to continue sampling responses until you get a full batch."""
     filter_zero_std_samples: bool = True
-    """Whether to filter out prompts with zero reward std (all samples have the same score). Must be True when active_sampling is True."""
+    """Whether to filter out prompts with zero reward std (all samples have the same score)."""
     no_resampling_pass_rate: float | None = None
     """If the response to a prompt is solved at a rate higher than this, do not resample this prompt again"""
 
@@ -1667,6 +1667,7 @@ def accumulate_inference_batches(
     reward_fn: Callable,
     actor_manager=None,
     timeout: float | None = None,
+    active_sampling: bool = False,
     filter_zero_std_samples: bool = False,
     no_resampling_pass_rate: float | None = None,
     iter_dataloader: ShufflingIterator | None = None,
@@ -1680,7 +1681,8 @@ def accumulate_inference_batches(
         generation_config: Generation config containing n (number of samples per prompt)
         num_prompts: Number of prompts to accumulate
         timeout: Optional timeout in seconds for queue get operations. If None, blocks indefinitely.
-        filter_zero_std_samples: Whether to filter samples with zero reward std and continue sampling
+        active_sampling: Whether to continue sampling until we have sampled num_prompts prompts with non-zero std
+        filter_zero_std_samples: Whether to filter samples with zero reward std
         no_resampling_pass_rate: Optional rate at which to note samples solved at greater than this rate
             and exclude them from further sampling
         iter_dataloader: Optional, used for no_resampling_pass_rate
@@ -1712,7 +1714,8 @@ def accumulate_inference_batches(
         bar_format="{l_bar}{bar}{r_bar}\n",
         disable=not args.verbose,
     )
-    while len(results) < num_prompts:
+    num_prompts_sampled = 0
+    while num_prompts_sampled < num_prompts:
         result = inference_results_Q.get(timeout=timeout)
 
         if isinstance(result, ShutdownSentinel):
@@ -1765,6 +1768,11 @@ def accumulate_inference_batches(
 
         # Filter out zero std prompts
         if filter_zero_std_samples and np.std(scores) == 0:
+            # If we're not active sampling, still count this as a sample
+            if not active_sampling:
+                num_prompts_sampled += 1
+                progress_bar.update(1)
+
             total_filtered_prompts += 1
             if scores[0] == 0:
                 filtered_prompt_zero += 1
@@ -1776,6 +1784,9 @@ def accumulate_inference_batches(
                 f"[Data Preparation Thread] Filtered prompt with reward std 0, total filtered {total_filtered_prompts}"
             )
             continue
+        else:
+            num_prompts_sampled += 1
+            progress_bar.update(1)
 
         results.append(result)
         all_queries.extend(k_queries)
@@ -1786,7 +1797,6 @@ def accumulate_inference_batches(
         all_scores.extend(scores)
         all_reward_metrics.append(reward_metrics)
         all_percent_solved.append(percent_solved)
-        progress_bar.update(1)
 
     # Combine all results into a single GenerationResult
     combined_responses = []
@@ -1926,6 +1936,7 @@ def data_preparation_thread(
                 tokenizer=tokenizer,
                 reward_fn=reward_fn,
                 actor_manager=actor_manager,
+                active_sampling=args.active_sampling,
                 filter_zero_std_samples=args.filter_zero_std_samples,
                 no_resampling_pass_rate=args.no_resampling_pass_rate,
                 iter_dataloader=iter_dataloader,
@@ -2624,6 +2635,7 @@ def maybe_evaluate(
             reward_fn=reward_fn,
             actor_manager=actor_manager,
             timeout=timeout,
+            active_sampling=False,
             filter_zero_std_samples=False,
             no_resampling_pass_rate=None,
             iter_dataloader=None,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Decouples active sampling from zero-std filtering and updates batch accumulation/control flow to count filtered prompts only when not actively sampling.
> 
> - **Batch accumulation (`accumulate_inference_batches`)**:
>   - Add `active_sampling` flag and adjust loop to track `num_prompts_sampled` instead of `len(results)`.
>   - When `filter_zero_std_samples` is enabled, only count filtered prompts toward quota if `active_sampling` is False; otherwise continue sampling until non-zero-std prompts fill the batch.
>   - Update progress bar and sampling counters accordingly.
> - **Wiring and call sites**:
>   - Pass `args.active_sampling` from `data_preparation_thread` and set `active_sampling=False` in evaluation calls.
> - **Config/Docs (`Args`)**:
>   - Clarify `filter_zero_std_samples` docstring (remove coupling note); keep `active_sampling` option documented.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfabd762e86dc54bbc3cb9b9c51bf1130f6ee9e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->