### PR TITLE
Handle Slack alert failures without raising exceptions

### DIFF
--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -1268,7 +1268,12 @@ def send_slack_alert(message: str) -> None:
         return
     payload = {"text": message}
     response = requests.post(slack_webhook_url, json=payload)
-    response.raise_for_status()
+    if not response.ok:
+        logger.warning(
+            "Failed to send Slack alert with status %s: %s",
+            response.status_code,
+            response.text,
+        )
 
 
 def get_beaker_experiment_url() -> str | None:


### PR DESCRIPTION
## Summary
- log a warning when Slack alert delivery fails instead of raising an exception

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69160aa8d6e8832da03983c3a611c23d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `send_slack_alert` to log a warning when the Slack webhook POST fails (using `response.ok`) instead of raising an exception.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a0fc586f07747c6e3985b1376a7f867b745483d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->