### PR TITLE
fix batch indexing error

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1654,6 +1654,7 @@ class BatchStatistics:
     filtered_prompts_nonzero: int
     percent_solved_mean: float
     no_resampled_prompts: int
+    total_prompts: int
 
 
 def accumulate_inference_batches(
@@ -1901,6 +1902,7 @@ def accumulate_inference_batches(
         filtered_prompts_nonzero=filtered_prompt_nonzero,
         percent_solved_mean=percent_solved_mean,
         no_resampled_prompts=total_no_resampled,
+        total_prompts=len(results),
     )
     logging.info(
         f"[Data Preparation Thread] Calculating rewards took {combined_reward_metrics['time/reward']} seconds"

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -67,8 +67,10 @@ class Batch:
                 queries=self.queries[key],
                 ground_truths=self.ground_truths[key],
                 datasets=self.datasets[key],
-                raw_queries=self.raw_queries[key],
+                raw_queries=self.raw_queries[key] if self.raw_queries else None,
+                decoded_responses=self.decoded_responses[key] if self.decoded_responses else None,
                 indices=self.indices[key] if self.indices else None,
+                scores=self.scores[key] if self.scores else None,
             )
         elif isinstance(key, int):
             # Handle single index: batch[5]
@@ -76,8 +78,10 @@ class Batch:
                 queries=[self.queries[key]],
                 ground_truths=[self.ground_truths[key]],
                 datasets=[self.datasets[key]],
-                raw_queries=[self.raw_queries[key]],
+                raw_queries=[self.raw_queries[key]] if self.raw_queries else None,
+                decoded_responses=[self.decoded_responses[key]] if self.decoded_responses else None,
                 indices=[self.indices[key]] if self.indices else None,
+                scores=[self.scores[key]] if self.scores else None,
             )
         else:
             # Handle list of indices: batch[[1,3,5]]
@@ -85,8 +89,10 @@ class Batch:
                 queries=[self.queries[i] for i in key],
                 ground_truths=[self.ground_truths[i] for i in key],
                 datasets=[self.datasets[i] for i in key],
-                raw_queries=[self.raw_queries[i] for i in key],
+                raw_queries=[self.raw_queries[i] for i in key] if self.raw_queries else None,
+                decoded_responses=[self.decoded_responses[i] for i in key] if self.decoded_responses else None,
                 indices=[self.indices[i] for i in key] if self.indices else None,
+                scores=[self.scores[i] for i in key] if self.scores else None,
             )
 
 

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -67,10 +67,10 @@ class Batch:
                 queries=self.queries[key],
                 ground_truths=self.ground_truths[key],
                 datasets=self.datasets[key],
-                raw_queries=self.raw_queries[key] if self.raw_queries else None,
-                decoded_responses=self.decoded_responses[key] if self.decoded_responses else None,
-                indices=self.indices[key] if self.indices else None,
-                scores=self.scores[key] if self.scores else None,
+                raw_queries=self.raw_queries[key] if self.raw_queries is not None else None,
+                decoded_responses=self.decoded_responses[key] if self.decoded_responses is not None else None,
+                indices=self.indices[key] if self.indices is not None else None,
+                scores=self.scores[key] if self.scores is not None else None,
             )
         elif isinstance(key, int):
             # Handle single index: batch[5]
@@ -78,10 +78,10 @@ class Batch:
                 queries=[self.queries[key]],
                 ground_truths=[self.ground_truths[key]],
                 datasets=[self.datasets[key]],
-                raw_queries=[self.raw_queries[key]] if self.raw_queries else None,
-                decoded_responses=[self.decoded_responses[key]] if self.decoded_responses else None,
-                indices=[self.indices[key]] if self.indices else None,
-                scores=[self.scores[key]] if self.scores else None,
+                raw_queries=[self.raw_queries[key]] if self.raw_queries is not None else None,
+                decoded_responses=[self.decoded_responses[key]] if self.decoded_responses is not None else None,
+                indices=[self.indices[key]] if self.indices is not None else None,
+                scores=[self.scores[key]] if self.scores is not None else None,
             )
         else:
             # Handle list of indices: batch[[1,3,5]]
@@ -89,10 +89,12 @@ class Batch:
                 queries=[self.queries[i] for i in key],
                 ground_truths=[self.ground_truths[i] for i in key],
                 datasets=[self.datasets[i] for i in key],
-                raw_queries=[self.raw_queries[i] for i in key] if self.raw_queries else None,
-                decoded_responses=[self.decoded_responses[i] for i in key] if self.decoded_responses else None,
-                indices=[self.indices[i] for i in key] if self.indices else None,
-                scores=[self.scores[i] for i in key] if self.scores else None,
+                raw_queries=[self.raw_queries[i] for i in key] if self.raw_queries is not None else None,
+                decoded_responses=[self.decoded_responses[i] for i in key]
+                if self.decoded_responses is not None
+                else None,
+                indices=[self.indices[i] for i in key] if self.indices is not None else None,
+                scores=[self.scores[i] for i in key] if self.scores is not None else None,
             )
 
 

--- a/open_instruct/test_model_utils.py
+++ b/open_instruct/test_model_utils.py
@@ -3,6 +3,43 @@ import unittest
 import torch
 
 import open_instruct.model_utils
+from open_instruct.model_utils import Batch
+
+
+class TestBatchSlicing(unittest.TestCase):
+    def test_batch_slicing_with_all_fields(self):
+        batch = Batch(
+            queries=[[1, 2], [3, 4], [5, 6]],
+            ground_truths=[[7, 8], [9, 10], [11, 12]],
+            datasets=["ds1", "ds2", "ds3"],
+            raw_queries=["q1", "q2", "q3"],
+            decoded_responses=["r1", "r2", "r3"],
+            indices=[0, 1, 2],
+            scores=[0.1, 0.2, 0.3],
+        )
+
+        sliced = batch[[0, 2]]
+        self.assertEqual(len(sliced.queries), 2)
+        self.assertEqual(sliced.queries, [[1, 2], [5, 6]])
+        self.assertEqual(sliced.decoded_responses, ["r1", "r3"])
+        self.assertEqual(sliced.scores, [0.1, 0.3])
+
+    def test_batch_slicing_with_none_fields(self):
+        batch = Batch(
+            queries=[[1, 2], [3, 4], [5, 6]],
+            ground_truths=[[7, 8], [9, 10], [11, 12]],
+            datasets=["ds1", "ds2", "ds3"],
+            raw_queries=None,
+            decoded_responses=None,
+            indices=None,
+            scores=None,
+        )
+
+        sliced = batch[[0, 2]]
+        self.assertEqual(len(sliced.queries), 2)
+        self.assertEqual(sliced.queries, [[1, 2], [5, 6]])
+        self.assertIsNone(sliced.decoded_responses)
+        self.assertIsNone(sliced.scores)
 
 
 class TestLogSoftmaxAndGather(unittest.TestCase):


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make Batch slicing None-safe and include decoded_responses/scores, add unit tests, and track total_prompts in batch stats.
> 
> - **Model utils (`open_instruct/model_utils.py`)**:
>   - Update `Batch.__getitem__` to be None-safe and include `decoded_responses` and `scores` in all indexing modes (slice/int/list).
> - **Training pipeline (`open_instruct/grpo_fast.py`)**:
>   - Extend `BatchStatistics` with `total_prompts` and populate it during accumulation.
> - **Tests (`open_instruct/test_model_utils.py`)**:
>   - Add unit tests for `Batch` slicing with all fields and with `None` fields; retain log-softmax gather test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8700ec2b4848527f7a282a3390cc81685f55242. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->