### PR TITLE
Fixes quality.yml Action to use updated uv version

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,8 +18,6 @@ jobs:
         uses: astral-sh/setup-uv@v4
         with:
           version: "0.8.8"
-      - name: Install dependencies
-        run: uv sync --frozen --only-group dev
       - name: Code quality
         run: |
           uv run ruff format --check --diff open_instruct mason.py


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates the quality workflow to use uv 0.8.8 and run ruff via uv, adding `mason.py` checks and removing separate Python setup/dependency steps.
> 
> - **CI (GitHub Actions)**:
>   - Update `astral-sh/setup-uv` to `version: "0.8.8"` in `.github/workflows/quality.yml`.
>   - Simplify steps by removing separate Python setup and dependency install.
>   - Run code quality with `uv run`:
>     - `uv run ruff format --check --diff open_instruct mason.py`
>     - `uv run ruff check --exit-non-zero-on-fix open_instruct mason.py`
>   - Expand ruff targets to include `mason.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1953f9eea627ba7ba7c1514d1d8bd55b4ff81aed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->