### PR TITLE
Makes checkpointing and evaluation bookkeeping run asynchronously

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,7 @@
 - To run the `./scripts/train/build_image_and_launch.sh` script, you must commit the current changes.
 - Launch tool use experiments by running `./scripts/train/build_image_and_launch.sh scripts/train/debug/tool_grpo_fast.sh`.
 - Launch multi-node non-tool experiments by running `./scripts/train/build_image_and_launch.sh scripts/train/debug/large_test_script.sh`.
+
+# Code Style
+- Always add type annotations to function signatures.
+- Always add docstrings to functions, using Google-style docstring format.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extracts checkpoint saving into `maybe_save_checkpoint` and runs checkpointing and evaluation asynchronously after each step; updates docs with code style rules.
> 
> - **Training pipeline**:
>   - Extracts checkpoint logic into `maybe_save_checkpoint` (with `Timer`) and replaces inline checkpointing.
>   - Runs `maybe_save_checkpoint` and `maybe_evaluate` via thread pool, waits for both, then triggers weight sync.
>   - Minor reordering: weight sync trigger moved to occur after async tasks complete.
> - **Docs**:
>   - Add code style guidelines in `CLAUDE.md` (require type annotations and Google-style docstrings).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74ff4e5f9e9dd8019661bd834fa52b0dd1d98e1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->