### PR TITLE
use keywords args for evals

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -420,6 +420,8 @@ class Args:
     """multiply the gpus used for each oe-eval task"""
     eval_priority: Literal["low", "normal", "high", "urgent"] = "normal"
     """the priority of auto-launched evaluation jobs"""
+    eval_workspace: str = "ai2/tulu-3-results"
+    """the workspace to launch evaluation jobs on"""
     send_slack_alerts: bool = False
     """Whether to send Slack alerts on training failures"""
 
@@ -1447,17 +1449,18 @@ class PolicyTrainerRayProcess(RayProcess):
         args = self.args
         if self.rank == 0:
             ray.remote(launch_ai2_evals_on_weka).options(num_cpus=1).remote(
-                step_dir,
-                leaderboard_name,
-                args.oe_eval_max_length,
-                wandb_url,
-                training_step,
-                args.oe_eval_tasks,
-                args.stop_strings,
-                args.gs_bucket_path,
-                args.eval_priority,
-                args.oe_eval_beaker_image,
-                args.oe_eval_gpu_multiplier,
+                path=step_dir,
+                leaderboard_name=leaderboard_name,
+                oe_eval_max_length=args.oe_eval_max_length,
+                wandb_url=wandb_url,
+                training_step=training_step,
+                oe_eval_tasks=args.oe_eval_tasks,
+                stop_strings=args.stop_strings,
+                gs_bucket_path=args.gs_bucket_path,
+                eval_priority=args.eval_priority,
+                eval_workspace=args.eval_workspace,
+                beaker_image=args.oe_eval_beaker_image,
+                oe_eval_gpu_multiplier=args.oe_eval_gpu_multiplier,
             )
 
 


### PR DESCRIPTION
this should fix a bug where the image was being passed as the workspace, causing auto-evals to not launch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches auto-eval launch to keyword args and adds `Args.eval_workspace` to correctly target the Beaker workspace.
> 
> - **Evaluation launch**:
>   - Change `launch_ai2_evals_on_weka` call to use keyword arguments (e.g., `path`, `leaderboard_name`, `beaker_image`, etc.) to avoid misordered params.
>   - Pass new `Args.eval_workspace` (default `"ai2/tulu-3-results"`) to evaluation jobs.
> - **Config**:
>   - Add `eval_workspace` field and docstring to `Args` for selecting the Beaker workspace.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb5981b4f8a257df11693afa7b82549d3fb82dc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->