### PR TITLE
Remove dead vllm command references

### DIFF
--- a/mason.py
+++ b/mason.py
@@ -25,8 +25,6 @@ OPEN_INSTRUCT_COMMANDS = [
     "open_instruct/dpo_tune_cache.py",
     "open_instruct/grpo_fast.py",
     "open_instruct/ppo.py",
-    "open_instruct/grpo_vllm_thread_ray_gtrl.py",
-    "open_instruct/ppo_vllm_thread_ray_gtrl.py",
     "open_instruct/reward_modeling.py",
 ]
 


### PR DESCRIPTION
Deletes dead code from `mason.py.`