### PR TITLE
Remove unused get_cached_dataset helper

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1825,6 +1825,8 @@ class LocalDatasetTransformationCache:
 
         loaded_dataset = Dataset.load_from_disk(cache_path, keep_in_memory=True)
         return loaded_dataset, all_statistics
+
+
 def load_dataset_configs(
     dataset_mixer_list: List[str],
     dataset_mixer_list_splits: List[str],


### PR DESCRIPTION
Removes the unused `get_cached_dataset` function.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove the unused `get_cached_dataset` function from `open_instruct/dataset_transformation.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd949b0b40ef307776bde6d8f979f62a524fccd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->