### PR TITLE
Fix from_pretrained return annotation

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -712,7 +712,7 @@ class PolicyTrainerRayProcess(RayProcess):
         beaker_config: BeakerRuntimeConfig,
         wandb_url: str,
         tokenizer: PreTrainedTokenizer,
-    ):
+    ) -> int:
         # ------------------------------------------------------------
         # Monkey patch to load checkpoints with `weights_only=False`
         # otherwise it errors out with:


### PR DESCRIPTION
## Summary
- change `PolicyTrainerRayProcess.from_pretrained` to return `int` to reflect that the method returns `optimization_steps_done`

## Testing
- make style *(fails: uv cannot download torch==2.8.0+cu128 from download.pytorch.org because the connection repeatedly times out through the proxy tunnel)*
- make quality *(fails: same torch==2.8.0+cu128 download issue)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691cf78e48b4832d8c9bbcf467efe2c0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Annotates `PolicyTrainerRayProcess.from_pretrained` to return `int`, matching the `optimization_steps_done` return value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4b9828c4e802b62eb23360b3986d2614937a28f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->