### PR TITLE
Increase packed sequence timeout

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2469,8 +2469,8 @@ def load_data_from_packing_thread(
                 return None, {}, num_total_tokens, 0, None, None, 0
             try:
                 # When running at 32k generation length, it typically takes 900s to generate data,
-                # so we set the timeout to be slightly more than that.
-                packed_data = packed_sequences_Q.get(timeout=1000.0)
+                # so you might see this fire a bunch of times. That's normal!
+                packed_data = packed_sequences_Q.get(timeout=300)
                 break
             except Empty:
                 health_check_fn()


### PR DESCRIPTION
Increases the timeout for packed sequences so that we see the error less often. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raises `packed_sequences_Q.get` timeout from 30s to 300s in `load_data_from_packing_thread`, adding a note for long generation runs.
> 
> - **Training runtime**:
>   - Increase timeout in `open_instruct/grpo_fast.py::load_data_from_packing_thread` for `packed_sequences_Q.get` from `30` to `300`, with an explanatory comment for long (32k) generations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c4b1dde81856f6cf9ef1218fb7deb8f7c54fb55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->