### PR TITLE
make async_steps description clearer, and throw an error for invlaid …

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -230,7 +230,7 @@ class Args:
     The returned output will not contain the stop strings."""
     # Algorithm
     async_steps: int = 1
-    """Number of steps ahead to generate responses. Set to 0 to make the code synchronous. Values greater than 0 learn from a policy up to async_steps old like Cleanba (https://arxiv.org/abs/2310.00036)"""
+    """Number of steps ahead to generate responses. Fully synchronous training is not supported, so async_steps must be greater than 0. The trainer learns from a policy up to async_steps old like Cleanba (https://arxiv.org/abs/2310.00036)"""
     num_epochs: int = 1
     """the number of epochs to train"""
     num_mini_batches: int = 1
@@ -540,6 +540,8 @@ class Args:
                 "`filter_zero_std_samples` cannot be True when `num_samples_per_prompt_rollout` is 1, "
                 "as the reward standard deviation will always be 0, causing all samples to be filtered."
             )
+        if self.async_steps < 1:
+            raise ValueError("`async_steps` must be greater than 0. Fully synchronous training is not supported.")
 
 
 def masked_mean(


### PR DESCRIPTION
make async_steps description clearer, and throw an error for invlaid values

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies `async_steps` docs and adds validation to error on `async_steps < 1`, disallowing synchronous training.
> 
> - **Training config (`open_instruct/grpo_fast.py`)**:
>   - Update `Args.async_steps` docstring to state synchronous training is unsupported and `async_steps` must be > 0.
>   - Add `__post_init__` validation to raise `ValueError` when `async_steps < 1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c28eb33777c0c0c411190a0733876c7c8379e8d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->