### PR TITLE
Adds Wandb runs to olmo3 README.md

### DIFF
--- a/scripts/train/olmo3/README.md
+++ b/scripts/train/olmo3/README.md
@@ -4,7 +4,7 @@ For our recent [Olmo3 paper](insert link), we used the following scripts to trai
 
 | Model           | Script name           | Beaker Link | Wandb URL | Commit |
 |-----------------|----------------------|---|---|--------|
-| 7B Think DPO    | `7b_think_dpo.sh`     | https://beaker.org/ex/01K5SXG8YH7NZDT5JCWJSNFCKG | N/A | [`68da0a1`](https://github.com/allenai/open-instruct/commit/68da0a1) |
+| 7B Think DPO    | `7b_think_dpo.sh`     | https://beaker.org/ex/01K5SXG8YH7NZDT5JCWJSNFCKG | https://wandb.ai/ai2-llm/open_instruct_internal/runs/drm42by2 | [`68da0a1`](https://github.com/allenai/open-instruct/commit/68da0a1) |
 | 32B Think DPO   | `32b_think_dpo.sh`    | https://beaker.org/ex/01K9VYQV2RFPS9ECP63JFQFVDN | https://wandb.ai/ai2-llm/open_instruct_internal/runs/te37gyey | [`2fd104e`](https://github.com/allenai/open-instruct/commit/2fd104e) |
 | 7B Instruct DPO | `7b_instruct_dpo.sh`  | https://beaker.org/ex/01KA62AJW9P8AWA3YKWE4Y6XZD | https://wandb.ai/ai2-llm/open_instruct_internal/runs/kxc617kc | [`2fd104e`](https://github.com/allenai/open-instruct/commit/2fd104e) |
 | 7B Instruct RL  | `7b_instruct_rl.sh`   | https://beaker.org/ex/01KA8BY8MMAQWENWY4087MAPFE | https://wandb.ai/ai2-llm/open_instruct_internal/runs/p0l9m3ri | [`9ade62d`](https://github.com/allenai/open-instruct/commit/9ade62d) |


### PR DESCRIPTION
They are not public (yet). I will do so ASAP.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Wandb URL column with run links to the training scripts table in scripts/train/olmo3/README.md.
> 
> - **Docs**:
>   - Update `scripts/train/olmo3/README.md` table to include a new `Wandb URL` column with run links for all listed models, preserving existing Beaker links and commit hashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b849b4105a9a7f08829b31bfa82e95679ecf38d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->