### PR TITLE
Fix prompt_logprobs bug

### DIFF
--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -231,6 +231,7 @@ async def process_request_async(
                 prompt_token_ids=final_prompt_token_ids,
                 outputs=[complete_output],
                 finished=True,
+                prompt_logprobs=None,  # not used but required for init.
             ),
             "tools": actor.tools,
         }


### PR DESCRIPTION
We removed prompt_logprobs field since it was unused. But turns out we need to explicitly set it to something when making the request output object, otherwise code crashes.

Fixing this makes our debug script run for me again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set `prompt_logprobs=None` when constructing `vllm.RequestOutput` in `process_request_async` to satisfy required field and prevent crashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 046844e5270f1ea8e7e3113401e83652ed321da0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->