### PR TITLE
Makes sure GCP checkpointing uses Filestore.

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -502,7 +502,7 @@ class Args:
             # TODO(finbarrtimbers): Chanage this so we can checkpoint to GCS.
             # TODO(finbarrtimbers): Move this logic to mason.py once we refactor config.
             if not checkpoint_dir_name.startswith("/filestore"):
-                self.checkpoint_state_dir = f"/filestore{self.checkpoint_state_dir}"ss
+                self.checkpoint_state_dir = f"/filestore{self.checkpoint_state_dir}"
 
         if self.checkpoint_state_dir is not None:
             if self.gs_checkpoint_state_dir is not None:


### PR DESCRIPTION
Takes from #1161. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Automatically prefixes `/filestore` to `checkpoint_state_dir` on GCP when `gs_bucket_path` is set, ensuring checkpoints are written to Filestore.
> 
> - **Training/Checkpointing**
>   - In `open_instruct/grpo_fast.py` (`Args.__post_init__`), when `gs_bucket_path` is used, auto-prefix `/filestore` to `checkpoint_state_dir` if it doesn't already start with it to ensure GCP checkpointing uses Filestore (plus inline TODO notes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a77a7f018717aec17c8b05dc489faaedbe119b7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->