### PR TITLE
Propagate errors during request finalization

### DIFF
--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -432,7 +432,7 @@ def _create_server_args(model_path: str) -> argparse.Namespace:
     args = parser.parse_args(["--model", model_path])
     args.disable_fastapi_docs = True
     return args
-  
+
 
 def accumulate_completions(actor: "LLMRayActor", sub_request: dict) -> futures.Future | None:
     base_request_id = sub_request["base_request_id"]


### PR DESCRIPTION
## Summary
- ensure accumulate_completions waits for finalize_completed_request to surface exceptions
- prevent silent failures when reward computation or finalization raises

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f195de988832db494308e2c02fe7e)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure finalization futures are returned and awaited so errors during request finalization/rewarding propagate instead of failing silently.
> 
> - **Runtime/error handling**:
>   - Update `accumulate_completions` to return a `futures.Future` for `finalize_completed_request` when a request is complete.
>   - Modify `LLMRayActor.process_from_queue` to collect and `wait` on these futures and call `result()` on completed ones, surfacing exceptions from finalization/reward computation instead of silently dropping them.
>   - Add precise type hints and minimal control-flow to track `finalize_futures` and drain completed tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 199123a3c06507b64f44a775c8099305bc92a584. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->