### PR TITLE
Removes timeout from OpenAI API client, which is unneeded.

### DIFF
--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -650,7 +650,7 @@ class LLMRayActor:
 
     def _init_openai_client(self) -> None:
         base_url = f"http://127.0.0.1:{self.server_port}/v1"
-        self.client = openai.AsyncOpenAI(base_url=base_url, api_key="EMPTY", timeout=600.0)
+        self.client = openai.AsyncOpenAI(base_url=base_url, api_key="EMPTY", timeout=3600)
         self.model_name = self.llm_engine.vllm_config.model_config.model
 
         logger.info(f"Waiting for vLLM OpenAI API server to be ready at {base_url}")


### PR DESCRIPTION
Now that we go through the OpenAI client for all our inference calls, we get timeouts for long sequence generations. Whoops! This PR removes the timeout. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extends the vLLM OpenAI client timeout from 60s to 3600s during initialization to support long-running completions.
> 
> - **Backend**:
>   - Increase OpenAI client timeout in `open_instruct/vllm_utils.py` (`_init_openai_client`): set `openai.AsyncOpenAI(..., timeout=3600)` (was `60.0`) to accommodate long generations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e5e4d1915df936f18b5dabcc70d92ad3d4256fb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->