### PR TITLE
Fix disk usage check for Weka paths

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -147,11 +147,10 @@ def warn_if_low_disk_space(path: str, *, threshold: float, send_slack_alerts: bo
         threshold: Usage ratio (0.0-1.0) above which to warn.
         send_slack_alerts: Whether to also send a Slack alert when warning.
     """
-    if path.startswith("/weka") or path.startswith("/filestore/weka"):
-        mount_point = "/filestore"
+    if path.startswith(('/weka', '/filestore/weka')):
+        mount_point = '/filestore'
     else:
         mount_point = path
-        
     try:
         usage = shutil.disk_usage(mount_point)
     except FileNotFoundError:


### PR DESCRIPTION
This PR updates the disk-usage logic to correctly detect Weka filesystem paths.

Instead of checking cloud prefixes like gs://, we now check whether the path starts with /weka or /filestore/weka and map Weka paths to the /filestore mount point for usage calculation.

Original failed Beaker job:
https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01KC2TJ4WSMTSVRPNEDTMPNE0M

Test Beaker job:
https://beaker.allen.ai/orgs/ai2/workspaces/olmo-instruct/work/01KC354HSQFCJP5HJTBJC2GNBA?taskId=01KC354HSVGG31CZ3TAVNZMAQV&jobId=01KC354HXH3G7PE8QRYJK6BADR


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update disk usage check to map Weka paths (/weka, /filestore/weka) to /filestore and safely skip if the mount is missing.
> 
> - **open_instruct/grpo_fast.py**:
>   - `warn_if_low_disk_space`:
>     - Detect Weka paths (`/weka`, `/filestore/weka`) and use `/filestore` as the mount point for `shutil.disk_usage`.
>     - Handle missing mount with `FileNotFoundError` (debug log + early return).
>     - Use computed `mount_point` instead of the raw `path` for disk usage checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a946ed715eb9d33306d0e5ff189d6b3e8ca85ea8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->