### PR TITLE
Add CISPO loss.

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1156,6 +1156,8 @@ class PolicyTrainerRayProcess(RayProcess):
                             ratio_BT, max=1.0 + self.args.clip_higher
                         )
                         pg_losses2_BT = pg_losses_BT
+                    else:
+                        raise ValueError(f"Invalid loss function: {self.args.loss_fn}")
 
                     # Apply truncated importance sampling if enabled
                     if self.args.truncated_importance_sampling_ratio_cap > 0 and vllm_logprobs_BT is not None:


### PR DESCRIPTION
Adds CISPO loss from https://arxiv.org/abs/2506.13585
Based on ScaleRL (https://arxiv.org/abs/2510.13786), CISPO dramatically outperforms DAPO and is easier to tune than DAPO/GSPO, and so I think its worth using! Implementation here is based on ScaleRL implementation, in that we just remove the clip-lower term entirely.

Some notes in slack #scaling-rl channel about results using it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds selectable CISPO loss (upper-only ratio clipping) via `Args.loss_fn`, alongside existing DAPO.
> 
> - **GRPO Trainer (`open_instruct/grpo_fast.py`)**:
>   - **Config**: Add `Args.loss_fn: Literal["dapo", "cispo"] = "dapo"` to choose loss function.
>   - **Policy loss**:
>     - Keep existing DAPO path (symmetric clipping with `clip_lower`/`clip_higher`).
>     - Add CISPO path: clip importance ratio with only an upper bound (`max=1.0 + clip_higher`), no lower bound; reuse same value for `pg_losses2`.
>   - **Validation**: Raise `ValueError` for invalid `loss_fn`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a925c0903025ee166bbea63f9ddd7649148258b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->