### PR TITLE
Fix disk usage

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -135,37 +135,6 @@ logger = logger_utils.setup_logger(__name__)
 
 INVALID_LOGPROB = 1.0
 CHECKPOINT_COMPLETE_MARKER = ".checkpoint_complete"
-DISK_USAGE_WARNING_THRESHOLD = 0.85
-CLOUD_PATH_PREFIXES = ("gs://", "s3://", "az://", "hdfs://")
-
-
-def warn_if_low_disk_space(path: str, *, threshold: float, send_slack_alerts: bool) -> None:
-    """Warns when disk usage exceeds the provided threshold.
-
-    Args:
-        path: Filesystem path to check disk usage for.
-        threshold: Usage ratio (0.0-1.0) above which to warn.
-        send_slack_alerts: Whether to also send a Slack alert when warning.
-    """
-    if path.startswith(CLOUD_PATH_PREFIXES):
-        return
-
-    usage = shutil.disk_usage(path)
-    if usage.total == 0:
-        return
-
-    used_ratio = usage.used / usage.total
-    if used_ratio >= threshold:
-        used_percent = used_ratio * 100
-        free_gib = usage.free / (1024**3)
-        total_gib = usage.total / (1024**3)
-        warning_message = (
-            f"Disk usage near capacity for {path}: {used_percent:.1f}% used "
-            f"({free_gib:.1f} GiB free of {total_gib:.1f} GiB). Checkpointing may fail."
-        )
-        logger.warning(warning_message)
-        if send_slack_alerts:
-            utils.send_slack_message(f"{warning_message}")
 
 
 class ShutdownSentinel:
@@ -2843,11 +2812,7 @@ def run_training(
             and training_step % args.checkpoint_state_freq == 0
             and args.checkpoint_state_dir is not None
         ):
-            warn_if_low_disk_space(
-                args.checkpoint_state_dir,
-                threshold=DISK_USAGE_WARNING_THRESHOLD,
-                send_slack_alerts=args.send_slack_alerts,
-            )
+            utils.warn_if_low_disk_space(args.checkpoint_state_dir, send_slack_alerts=args.send_slack_alerts)
             with Timer("[Main Thread] 🗡️ Saving checkpoint state"):
                 # Save comprehensive client state including dataloader state
                 client_state = {

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -360,7 +360,7 @@ class TestWarnIfLowDiskSpace(unittest.TestCase):
             utils.warn_if_low_disk_space("/tmp/test")
             mock_warning.assert_not_called()
 
-    def test_disk_usage_warns_for_failing_path(self, mock_disk_usage):
+    def test_disk_usage_warns_for_failing_path(self):
         with mock.patch.object(utils.logger, "warning") as mock_warning:
             utils.warn_if_low_disk_space("/non/existant/path")
             mock_warning.assert_called()

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -317,21 +317,21 @@ class TestWarnIfLowDiskSpace(unittest.TestCase):
     )
     def test_cloud_paths_skipped(self, name, path):
         with mock.patch("shutil.disk_usage") as mock_disk_usage:
-            grpo_fast.warn_if_low_disk_space(path, threshold=0.5, send_slack_alerts=False)
+            utils.warn_if_low_disk_space(path, threshold=0.5, send_slack_alerts=False)
             mock_disk_usage.assert_not_called()
 
     @mock.patch("shutil.disk_usage")
     def test_no_warning_below_threshold(self, mock_disk_usage):
         mock_disk_usage.return_value = mock.Mock(total=100, used=50, free=50)
-        with mock.patch.object(grpo_fast.logger, "warning") as mock_warning:
-            grpo_fast.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=False)
+        with mock.patch.object(utils.logger, "warning") as mock_warning:
+            utils.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=False)
             mock_warning.assert_not_called()
 
     @mock.patch("shutil.disk_usage")
     def test_warning_above_threshold(self, mock_disk_usage):
         mock_disk_usage.return_value = mock.Mock(total=100 * 1024**3, used=90 * 1024**3, free=10 * 1024**3)
-        with mock.patch.object(grpo_fast.logger, "warning") as mock_warning:
-            grpo_fast.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=False)
+        with mock.patch.object(utils.logger, "warning") as mock_warning:
+            utils.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=False)
             mock_warning.assert_called_once()
             self.assertIn("90.0%", mock_warning.call_args[0][0])
 
@@ -346,7 +346,7 @@ class TestWarnIfLowDiskSpace(unittest.TestCase):
         mock_disk_usage.return_value = mock.Mock(total=100 * 1024**3, used=90 * 1024**3, free=10 * 1024**3)
         responses.add(responses.POST, webhook_url, json={"ok": True}, status=200)
 
-        grpo_fast.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=True)
+        utils.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=True)
 
         self.assertEqual(len(responses.calls), 1)
         request_body = json.loads(responses.calls[0].request.body)
@@ -355,8 +355,8 @@ class TestWarnIfLowDiskSpace(unittest.TestCase):
     @mock.patch("shutil.disk_usage")
     def test_zero_total_disk_space_returns_early(self, mock_disk_usage):
         mock_disk_usage.return_value = mock.Mock(total=0, used=0, free=0)
-        with mock.patch.object(grpo_fast.logger, "warning") as mock_warning:
-            grpo_fast.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=False)
+        with mock.patch.object(utils.logger, "warning") as mock_warning:
+            utils.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=False)
             mock_warning.assert_not_called()
 
 

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -313,25 +313,26 @@ class TestWarnIfLowDiskSpace(unittest.TestCase):
             ("s3", "s3://bucket/path"),
             ("azure", "az://container/path"),
             ("hdfs", "hdfs://cluster/path"),
+            ("gcs localpath", "/filestore/path"),
         ]
     )
     def test_cloud_paths_skipped(self, name, path):
         with mock.patch("shutil.disk_usage") as mock_disk_usage:
-            utils.warn_if_low_disk_space(path, threshold=0.5, send_slack_alerts=False)
+            utils.warn_if_low_disk_space(path)
             mock_disk_usage.assert_not_called()
 
     @mock.patch("shutil.disk_usage")
     def test_no_warning_below_threshold(self, mock_disk_usage):
         mock_disk_usage.return_value = mock.Mock(total=100, used=50, free=50)
         with mock.patch.object(utils.logger, "warning") as mock_warning:
-            utils.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=False)
+            utils.warn_if_low_disk_space("/tmp/test", threshold=0.85)
             mock_warning.assert_not_called()
 
     @mock.patch("shutil.disk_usage")
     def test_warning_above_threshold(self, mock_disk_usage):
         mock_disk_usage.return_value = mock.Mock(total=100 * 1024**3, used=90 * 1024**3, free=10 * 1024**3)
         with mock.patch.object(utils.logger, "warning") as mock_warning:
-            utils.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=False)
+            utils.warn_if_low_disk_space("/tmp/test", threshold=0.85)
             mock_warning.assert_called_once()
             self.assertIn("90.0%", mock_warning.call_args[0][0])
 
@@ -346,7 +347,7 @@ class TestWarnIfLowDiskSpace(unittest.TestCase):
         mock_disk_usage.return_value = mock.Mock(total=100 * 1024**3, used=90 * 1024**3, free=10 * 1024**3)
         responses.add(responses.POST, webhook_url, json={"ok": True}, status=200)
 
-        utils.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=True)
+        utils.warn_if_low_disk_space("/tmp/test", send_slack_alerts=True)
 
         self.assertEqual(len(responses.calls), 1)
         request_body = json.loads(responses.calls[0].request.body)
@@ -356,8 +357,13 @@ class TestWarnIfLowDiskSpace(unittest.TestCase):
     def test_zero_total_disk_space_returns_early(self, mock_disk_usage):
         mock_disk_usage.return_value = mock.Mock(total=0, used=0, free=0)
         with mock.patch.object(utils.logger, "warning") as mock_warning:
-            utils.warn_if_low_disk_space("/tmp/test", threshold=0.85, send_slack_alerts=False)
+            utils.warn_if_low_disk_space("/tmp/test")
             mock_warning.assert_not_called()
+
+    def test_disk_usage_warns_for_failing_path(self, mock_disk_usage):
+        with mock.patch.object(utils.logger, "warning") as mock_warning:
+            utils.warn_if_low_disk_space("/non/existant/path")
+            mock_warning.assert_called()
 
 
 class TestUtilityFunctions(unittest.TestCase):

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -77,7 +77,7 @@ MODEL_CONFIG_CLASSES = list(MODEL_FOR_CAUSAL_LM_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
 
 DISK_USAGE_WARNING_THRESHOLD = 0.85
-CLOUD_PATH_PREFIXES = ("gs://", "s3://", "az://", "hdfs://")
+CLOUD_PATH_PREFIXES = ("gs://", "s3://", "az://", "hdfs://", "/filestore")
 
 logger = logger_utils.setup_logger(__name__)
 
@@ -97,7 +97,12 @@ def warn_if_low_disk_space(
     if path.startswith(CLOUD_PATH_PREFIXES):
         return
 
-    usage = shutil.disk_usage(path)
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError as e:
+        logger.debug(f"Skipping disk usage check for {path}, encountered OS error: {e}")
+        return
+
     if usage.total == 0:
         return
 

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -100,7 +100,7 @@ def warn_if_low_disk_space(
     try:
         usage = shutil.disk_usage(path)
     except OSError as e:
-        logger.debug(f"Skipping disk usage check for {path}, encountered OS error: {e}")
+        logger.warning(f"Skipping disk usage check for {path}, encountered OS error: {e}")
         return
 
     if usage.total == 0:

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -76,10 +76,43 @@ INTERCONNECT_CLUSTERS = ["ai2/jupiter", "ai2/ceres", "ai2/titan", "ai2/augusta"]
 MODEL_CONFIG_CLASSES = list(MODEL_FOR_CAUSAL_LM_MAPPING.keys())
 MODEL_TYPES = tuple(conf.model_type for conf in MODEL_CONFIG_CLASSES)
 
+DISK_USAGE_WARNING_THRESHOLD = 0.85
+CLOUD_PATH_PREFIXES = ("gs://", "s3://", "az://", "hdfs://")
 
 logger = logger_utils.setup_logger(__name__)
 
 DataClassType = NewType("DataClassType", Any)
+
+
+def warn_if_low_disk_space(
+    path: str, *, threshold: float = DISK_USAGE_WARNING_THRESHOLD, send_slack_alerts: bool = False
+) -> None:
+    """Warns when disk usage exceeds the provided threshold.
+
+    Args:
+        path: Filesystem path to check disk usage for.
+        threshold: Usage ratio (0.0-1.0) above which to warn.
+        send_slack_alerts: Whether to also send a Slack alert when warning.
+    """
+    if path.startswith(CLOUD_PATH_PREFIXES):
+        return
+
+    usage = shutil.disk_usage(path)
+    if usage.total == 0:
+        return
+
+    used_ratio = usage.used / usage.total
+    if used_ratio >= threshold:
+        used_percent = used_ratio * 100
+        free_gib = usage.free / (1024**3)
+        total_gib = usage.total / (1024**3)
+        warning_message = (
+            f"Disk usage near capacity for {path}: {used_percent:.1f}% used "
+            f"({free_gib:.1f} GiB free of {total_gib:.1f} GiB). Checkpointing may fail."
+        )
+        logger.warning(warning_message)
+        if send_slack_alerts:
+            send_slack_message(f"{warning_message}")
 
 
 class MetricsTracker:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves disk-space warning logic into utils with better handling and updates trainer checkpointing and tests to use it.
> 
> - **Utils**:
>   - Add `utils.warn_if_low_disk_space(path, threshold=..., send_slack_alerts=...)` with OSError handling and optional Slack alerts.
>   - Introduce `DISK_USAGE_WARNING_THRESHOLD` and expand `CLOUD_PATH_PREFIXES` to include `/filestore`.
> - **Trainer (`open_instruct/grpo_fast.py`)**:
>   - Replace local disk-space check with `utils.warn_if_low_disk_space` before checkpointing.
> - **Tests**:
>   - Update tests to target `utils.warn_if_low_disk_space` and logger.
>   - Add cases for `/filestore` paths being skipped and nonexistent paths triggering a warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b1d292db9c6414946fdf6379b732126e9acbbbcf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->