### PR TITLE
Refactored GPU test script to 1) use a pattern instead of hardcoding filenames and 2) be cleaner.

### DIFF
--- a/scripts/train/debug/run_gpu_pytest.sh
+++ b/scripts/train/debug/run_gpu_pytest.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 BEAKER_USER=$(beaker account whoami --format json | jq -r '.[0].name')
 BEAKER_IMAGE="${1:-${BEAKER_USER}/open-instruct-integration-test}"

--- a/scripts/train/debug/run_gpu_tests.sh
+++ b/scripts/train/debug/run_gpu_tests.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 source configs/beaker_configs/ray_node_setup.sh
 


### PR DESCRIPTION
Example run: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01KCAADGV6182DJPWTEB1QZW1B?)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors GPU test runner to default Beaker image from user, run all `test_*_gpu.py` via a new wrapper script, and set job priority to urgent.
> 
> - **GPU test orchestration**:
>   - `scripts/train/debug/run_gpu_pytest.sh`:
>     - Defaults `BEAKER_IMAGE` to `${USER}/open-instruct-integration-test` via `beaker account whoami` when not provided.
>     - Switches test target from a single file to pattern `test_*_gpu.py` and updates description accordingly.
>     - Changes job priority to `urgent` and enables `set -eo pipefail`.
>     - Replaces inline setup/pytest/copy sequence with call to `scripts/train/debug/run_gpu_tests.sh`.
>   - `scripts/train/debug/run_gpu_tests.sh` (new):
>     - Sources `configs/beaker_configs/ray_node_setup.sh`.
>     - Runs `uv run pytest open_instruct/test_*_gpu.py -xvs`, preserves exit code, and copies `open_instruct/test_data` to `/output/test_data`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c70783cab3c9ae6b819f370f764404f2a5c57dd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->