### PR TITLE
Make sure `large_test_script.sh` exercises caching and checkpointing code paths

### DIFF
--- a/scripts/train/debug/large_test_script.sh
+++ b/scripts/train/debug/large_test_script.sh
@@ -60,7 +60,8 @@ uv run python mason.py \
         --vllm_enable_prefix_caching \
         --oe_eval_max_length 32768 \
         --oe_eval_tasks "codex_humanevalplus:0-shot-chat-v1::tulu-thinker,mbppplus:0-shot-chat::tulu-thinker,livecodebench_codegeneration::tulu-thinker" \
-        --dataset_skip_cache True \
+		--checkpoint_state_freq 2 \
+        --checkpoint_state_dir /tmp/checkpoint_test \
         --active_sampling \
         --async_steps 4 \
 	--push_to_hub False


### PR DESCRIPTION
Ran it: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01KCHP0EJD3KNT6R8Z7QRHWQR4?taskId=01KCHP0EJH1R4KR13ZZ4E43Z0M&jobId=01KCHP0EPP3NGA8JGA1A1X7C5R). 