### PR TITLE
Move ShutdownSentinel class to data_types module

### DIFF
--- a/open_instruct/data_types.py
+++ b/open_instruct/data_types.py
@@ -5,6 +5,10 @@ from typing import Any
 import torch
 
 
+class ShutdownSentinel:
+    """Sentinel value to signal thread shutdown via queue."""
+
+
 @dataclass
 class TokenStatistics:
     """Container for token statistics from inference."""

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -81,7 +81,14 @@ from transformers.integrations import HfDeepSpeedConfig
 from open_instruct import data_loader as data_loader_lib
 from open_instruct import logger_utils, vllm_utils
 from open_instruct.actor_manager import ActorManager
-from open_instruct.data_types import CollatedBatchData, GenerationResult, PromptRequest, RequestInfo, TokenStatistics
+from open_instruct.data_types import (
+    CollatedBatchData,
+    GenerationResult,
+    PromptRequest,
+    RequestInfo,
+    ShutdownSentinel,
+    TokenStatistics,
+)
 from open_instruct.dataset_transformation import (
     GROUND_TRUTHS_KEY,
     INPUT_IDS_PROMPT_KEY,
@@ -135,10 +142,6 @@ logger = logger_utils.setup_logger(__name__)
 
 INVALID_LOGPROB = 1.0
 CHECKPOINT_COMPLETE_MARKER = ".checkpoint_complete"
-
-
-class ShutdownSentinel:
-    """Sentinel value to signal thread shutdown via queue."""
 
 
 @dataclass


### PR DESCRIPTION
Moves  `ShutdownSentinel` into `data_types.py`. Done in preparation for #1202. 