### PR TITLE
Add pre-commit hook for requirements export

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
     hooks:
       - id: export-requirements
         name: Export requirements.txt from uv.lock
-        entry: uv export --format requirements-txt --no-hashes --all-extras --no-emit-project --output requirements.txt
+        entry: uv export --format requirements-txt --no-hashes --all-extras --no-emit-project --output-file requirements.txt
         language: system
         pass_filenames: false
         files: ^uv\.lock$


### PR DESCRIPTION
Added a local pre-commit hook that exports requirements.txt when uv.lock changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a local pre-commit hook that exports requirements.txt whenever uv.lock changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a7e53b65be37d74d03775241fc26b888eb647b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->