### PR TITLE
Initialize model init list once in grpo_fast

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2110,13 +2110,12 @@ def create_model_and_optimizer(
     bundles = [{"GPU": actor_num_gpus, "CPU": actor_num_gpus * 10} for actor_num_gpus in args.num_learners_per_node]
     pg = placement_group(bundles, strategy="STRICT_SPREAD")
     ray_get_with_progress([pg.ready()], desc="Waiting for placement group")
-    inits = []
     policy_group = ModelGroup(pg, PolicyTrainerRayProcess, args.num_learners_per_node, args.single_gpu_mode)
     wandb_url = wandb.run.get_url() if args.with_tracking else None
-    inits.extend(
+    inits = [
         model.from_pretrained.remote(args, model_config, beaker_config, wandb_url, tokenizer)
         for model in policy_group.models
-    )
+    ]
 
     # Set up tools
     max_len = args.max_prompt_token_length + args.response_length


### PR DESCRIPTION
### Motivation
- Simplify model initialization by constructing the initialization list in one step instead of creating an empty list then extending it.
- Reduce temporary mutable operations and make intent clearer in `create_model_and_optimizer`.
- Avoid subtle ordering/side-effect concerns when preparing remote `from_pretrained` calls for policy models.

### Description
- Replace `inits = []` + `inits.extend(...)` with `inits = [model.from_pretrained.remote(...) for model in policy_group.models]` in `open_instruct/grpo_fast.py`.
- The list comprehension directly gathers the remote initialization futures for each model in `policy_group.models`.
- File modified: `open_instruct/grpo_fast.py`.

### Testing
- Ran `make style && make quality`, which failed due to a `torch` wheel download error during dependency resolution.
- Ran `uv run pytest`, which failed for the same `torch` download error preventing the test environment from being set up.
- Both failures are dependency/download issues and not caused by the code change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69499335cdb0832d85ca05b32fb84d78)