### PR TITLE
Fix ruff src config to prevent local directories affecting import categorization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,16 +102,10 @@ filterwarnings = [
 line-length = 119
 target-version = ['py310']
 
-[tool.isort]
-known_first_party = ["open_instruct"]
-profile = "black"
-src_paths = ["open_instruct"]
-
 [tool.ruff]
 target-version = "py310"
 line-length = 119
-# do both . and open_instruct to make sure known-first-party below works
-src = [".", "open_instruct"]
+src = ["open_instruct"]
 exclude = ["wandb"]
 
 [tool.ruff.format]
@@ -142,7 +136,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.isort]
-known-first-party = ["open-instruct"]
+known-first-party = ["open_instruct", "mason"]
 # case insensitive to match isort --profile black
 case-sensitive = false
 # Disable split-on-trailing-comma to work with skip-magic-trailing-comma


### PR DESCRIPTION
## Summary

- Remove `.` from ruff `src` config, keeping only `open_instruct`
- Fix `known-first-party` typo: `open-instruct` → `open_instruct` (underscore not hyphen)

## Problem

The `src = [".", "open_instruct"]` setting caused ruff to scan the entire repo for first-party packages. When running experiments locally, wandb creates a `wandb/` directory which ruff detected as first-party. This made `import wandb` categorized differently locally vs CI:

- **Local** (with `wandb/` dir): `import wandb` = first-party → allowed after `from` imports
- **CI** (fresh clone, no `wandb/` dir): `import wandb` = third-party → must come before `from` imports → **failure**

## Test plan

- [x] `make style-check && make quality-check` passes locally
- [ ] CI Quality check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)