### PR TITLE
Make streaming dataloader iterable

### DIFF
--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -381,6 +381,19 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
         self.num_training_steps = num_training_steps
         self.training_step = 0
         self.current_epoch = 0
+        self._current_iter: Iterator[dict[str, Any]] | None = None
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        return iter(self._iter_batches())
+
+    def __next__(self) -> dict[str, Any]:
+        if self._current_iter is None:
+            self._current_iter = iter(self)
+        try:
+            return next(self._current_iter)
+        except StopIteration:
+            self._current_iter = None
+            raise
 
     @property
     def total_batches(self) -> int | None:

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -363,7 +363,7 @@ class PolicyTrainerRayProcess(RayProcess):
         self._args = args
         self.streaming_config = streaming_config
         self.vllm_config = vllm_config
-        self._streaming_dataloader = streaming_config.build_dataloader(
+        self._dataloader = streaming_config.build_dataloader(
             data_prep_actor_name=data_prep_actor_name,
             tokenizer=tokenizer,
             dp_rank=rank,
@@ -372,13 +372,12 @@ class PolicyTrainerRayProcess(RayProcess):
             work_dir=args.output_dir,
             dp_world_size=world_size,
         )
-        self.dataloader = iter(self._streaming_dataloader)
 
     def get_dataloader_state(self) -> dict[str, Any]:
-        return self._streaming_dataloader.state_dict()
+        return self._dataloader.state_dict()
 
     def load_dataloader_state(self, state_dict: dict[str, Any]) -> None:
-        self._streaming_dataloader.load_state_dict(state_dict)
+        self._dataloader.load_state_dict(state_dict)
 
     def from_pretrained(
         self,
@@ -731,7 +730,7 @@ class PolicyTrainerRayProcess(RayProcess):
         Returns:
             Tuple of (metrics_list, array_metrics) from training.
         """
-        batch_data = next(self.dataloader)
+        batch_data = next(self._dataloader)
         data_BT = batch_data["batch"]
         if len(data_BT) == 0:
             logger.warning("[Training] Empty batch received, skipping training step")


### PR DESCRIPTION
### Motivation

- Allow the streaming dataloader to be consumed directly with `next()` by making it implement the iterator protocol. 
- Simplify trainer code by consuming batches directly from the dataloader instead of maintaining an external iterator. 
- Rename the trainer attribute for clarity from the former streaming name to `_dataloader` to reflect its new iterable behavior. 

### Description

- Implemented iterator protocol on `StreamingDataLoader` by adding `__iter__`, `__next__`, and an internal `_current_iter` to manage iteration. 
- Replaced the trainer's `self._streaming_dataloader` with `self._dataloader` in `PolicyTrainerRayProcess` and removed the external `iter(...)` alias. 
- Updated dataloader usage sites to call `next(self._dataloader)` and adjusted `get_dataloader_state` / `load_dataloader_state` to use `_dataloader`. 

### Testing

- Ran `make style` which completed successfully. 
- Ran `make quality` (ruff, compile checks, and typing) which completed successfully and reported all checks passed. 
- Attempted `uv run pytest open_instruct/test_streaming_data_loader_gpu.py -k StreamingDataLoader --maxfail=1` but the run was interrupted and no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695e69f59b60832d9ff5ae9dbf1f613e)