### PR TITLE
Set the `--no_auto_dataset_cache` flag so that we can launch `large_test_script.sh` on Mac.

### DIFF
--- a/scripts/train/debug/large_test_script.sh
+++ b/scripts/train/debug/large_test_script.sh
@@ -17,7 +17,7 @@ uv run python mason.py \
         --max_retries 0 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
         --budget ai2/oe-adapt \
-	--no_auto_dataset_cache \
+        --no_auto_dataset_cache \
         --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\&python open_instruct/grpo_fast.py \
         --exp_name ${exp_name} \
         --beta 0.0 \


### PR DESCRIPTION
Successful run: [Beaker](https://beaker.allen.ai/orgs/ai2/workspaces/open-instruct-dev/work/01KEYV6Z5MW9C98K1S8H5VA25A?taskId=01KEYV6Z5TN84TDDPJBTK733HG&jobId=01KEYV6Z9J1YCE47AFBZGA0HWK).