### PR TITLE
Add validation reward tracking for GRPO training

### DIFF
--- a/docs/VALIDATION_REWARD_TRACKING.md
+++ b/docs/VALIDATION_REWARD_TRACKING.md
@@ -1,0 +1,75 @@
+# Validation Reward Tracking
+
+This document describes the validation reward tracking feature for GRPO training.
+
+## Overview
+
+When training with GRPO (or similar RL methods), it's important to monitor performance on held-out data to detect overfitting. The `validation_holdout_ratio` parameter enables this by splitting your training data into:
+
+- **Training set**: Used for policy gradient updates
+- **Validation set**: Used for tracking rewards during training (appears as `eval/` metrics)
+
+## Usage
+
+Add the `--validation_holdout_ratio` parameter to your training script:
+
+```bash
+uv run python open_instruct/grpo_fast.py \
+    --model_name_or_path your_model \
+    --dataset_mixer_list your_dataset 1000 \
+    --validation_holdout_ratio 0.1 \  # Hold out 10% for validation
+    ... other args
+```
+
+### Parameters
+
+- `validation_holdout_ratio`: Float between 0.0 and 0.5 (exclusive)
+  - `0.0` (default): No validation holdout
+  - `0.1`: 10% of training data held out for validation
+  - `0.2`: 20% of training data held out for validation
+
+### What happens
+
+1. **Data splitting**: Training data is shuffled (using the seed) and split into train + validation
+2. **Evaluation**: Validation samples are evaluated every `local_eval_every` steps
+3. **Metrics**: Validation metrics appear under the `eval/` prefix in wandb/logs
+
+### Example output
+
+```
+🎯 Validation holdout: split 300 samples into 270 train + 30 validation (ratio=0.1)
+🎯 Using validation holdout (30 samples) for evaluation metrics. This tracks accuracy on held-out training data to detect overfitting.
+```
+
+## Relationship with eval_dataset
+
+The validation holdout is separate from the standard `dataset_mixer_eval_list` (test set evaluation):
+
+- **Validation (holdout)**: Same distribution as training data, used to track overfitting
+- **Eval (test set)**: Different data split (typically test set), used to track generalization
+
+When `validation_holdout_ratio > 0`:
+- The validation holdout is used for `eval/` metrics
+- If `dataset_mixer_eval_list` is also specified, a warning is logged and validation takes precedence
+
+## Monitoring for Overfitting
+
+To detect overfitting, compare training and validation metrics:
+
+| Scenario | Train Reward | Eval Reward | Interpretation |
+|----------|--------------|-------------|----------------|
+| Learning | ↑ | ↑ | Model is improving on both |
+| Overfitting | ↑ | → or ↓ | Model memorizing training data |
+| Underfitting | → | → | Model not learning |
+
+## Limitations
+
+- **Eval timeout**: During training, evaluation uses a short timeout (0.01s) to avoid blocking. This means eval metrics may not appear on every `local_eval_every` step. This is a known limitation of the current eval system.
+  - **Workaround**: Increase `local_eval_every` to reduce eval frequency, or use a smaller validation set
+  - **Future work**: A dedicated validation path with configurable timeout could address this
+- **Dataset size**: With small datasets, validation holdout further reduces training data. Consider using at least 100+ samples in total.
+- **Single eval source**: When validation holdout is enabled, it replaces the standard eval_dataset. You cannot track both simultaneously in the current implementation.
+
+## Example Script (DGX Spark)
+
+See `scripts/train/dgx-spark/grpo_smollm_gsm8k.sh` for a complete example using validation reward tracking with SmolLM2-135M on GSM8K.

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -315,6 +315,12 @@ class StreamingDataLoaderConfig:
     shuffle_eval_dataset: bool = False
     system_prompt_override_file: str | None = None
 
+    # Validation holdout from training data
+    validation_holdout_ratio: float = 0.0
+    """Ratio of training data to hold out for validation (0.0-0.5). 0 means no holdout.
+    Example: 0.1 means 10% of training data is held out for validation reward tracking.
+    This is separate from eval_dataset (which uses a different data split like test set)."""
+
     # Generation
     temperature: float = 0.7
     stop_strings: list[str] | None = None
@@ -380,6 +386,12 @@ class StreamingDataLoaderConfig:
             )
         if self.async_steps < 1:
             raise ValueError("`async_steps` must be greater than 0. Fully synchronous training is not supported.")
+
+        if not (0.0 <= self.validation_holdout_ratio < 0.5):
+            raise ValueError(
+                f"validation_holdout_ratio must be in [0.0, 0.5), got {self.validation_holdout_ratio}. "
+                "Values >= 0.5 would leave too little data for training."
+            )
 
         assert self.apply_verifiable_reward or self.apply_r1_style_format_reward or self.non_stop_penalty, (
             "At least one reward must be applied!"

--- a/scripts/train/dgx-spark/grpo_smollm_gsm8k.sh
+++ b/scripts/train/dgx-spark/grpo_smollm_gsm8k.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# =============================================================================
+# GRPO Training: SmolLM2-135M on GSM8K with Validation Reward Tracking
+# =============================================================================
+#
+# Purpose: Test validation reward tracking feature on DGX Spark
+# Model: HuggingFaceTB/SmolLM2-135M (135M params - fast iteration)
+# Dataset: ai2-adapt-dev/rlvr_gsm8k_zs (GSM8K math problems)
+# Hardware: DGX Spark (GB10 Blackwell, 128GB unified memory)
+#
+# Validation Reward Tracking:
+#   This script tests the validation holdout feature. When validation_holdout_ratio > 0:
+#   - Training data is split into train (90%) + validation (10%)
+#   - The "eval/" metrics track accuracy on held-out validation data
+#   - This allows detecting overfitting (train reward up, eval reward flat/down)
+#
+# Key settings for DGX Spark:
+#   - single_gpu_mode: Collocate vLLM and policy on same GPU
+#   - vllm_enforce_eager: Disable CUDA graphs for compatibility
+#   - vllm_sync_backend gloo: Better than NCCL for single-GPU
+#   - attn_implementation sdpa: SDPA faster than flash-attn on Blackwell
+#   - vllm_gpu_memory_utilization 0.3: Conservative for unified memory
+#
+# Memory estimates (SmolLM2-135M):
+#   - Model: ~0.3GB (bf16)
+#   - vLLM inference: ~5GB with 0.3 utilization
+#   - Training: ~2-3GB
+#   - Total expected: <15GB (very safe)
+#
+# Usage:
+#   ./scripts/train/dgx-spark/grpo_smollm_gsm8k.sh
+#
+# =============================================================================
+
+set -e
+cd "$(dirname "$0")/../../.."
+
+echo "=============================================="
+echo "DGX Spark GRPO Training - SmolLM2-135M"
+echo "With Validation Reward Tracking"
+echo "=============================================="
+echo "Start time: $(date)"
+echo ""
+
+# Pre-flight memory check
+FREE_MEM_GB=$(awk '/MemAvailable/ {printf "%.0f", $2/1024/1024}' /proc/meminfo)
+echo "Available memory: ${FREE_MEM_GB}GB"
+if [ "$FREE_MEM_GB" -lt 30 ]; then
+    echo "WARNING: Less than 30GB free. Consider cleaning up."
+    echo "  pkill -9 -f 'ray::' && sleep 10"
+fi
+echo ""
+
+# Environment setup for DGX Spark
+export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True,max_split_size_mb:128"
+
+# Training parameters
+MODEL="HuggingFaceTB/SmolLM2-135M"
+DATASET="ai2-adapt-dev/rlvr_gsm8k_zs"
+TOTAL_EPISODES=500  # Small for initial testing
+BATCH_SIZE=1
+NUM_PROMPTS=4       # Per rollout
+NUM_SAMPLES=4       # Per prompt
+LEARNING_RATE=1e-6
+BETA=0.0            # No KL penalty initially
+VALIDATION_HOLDOUT=0.1  # 10% of training data held out for validation
+
+echo "Configuration:"
+echo "  Model: $MODEL"
+echo "  Dataset: $DATASET"
+echo "  Total episodes: $TOTAL_EPISODES"
+echo "  Batch size: $BATCH_SIZE"
+echo "  Prompts per rollout: $NUM_PROMPTS"
+echo "  Samples per prompt: $NUM_SAMPLES"
+echo "  Validation holdout: ${VALIDATION_HOLDOUT} (10%)"
+echo ""
+
+# Run training
+uv run python open_instruct/grpo_fast.py \
+    --model_name_or_path "$MODEL" \
+    --dataset_mixer_list "$DATASET" 300 \
+    --dataset_mixer_list_splits train \
+    --validation_holdout_ratio $VALIDATION_HOLDOUT \
+    --max_prompt_token_length 256 \
+    --response_length 256 \
+    --pack_length 512 \
+    --per_device_train_batch_size $BATCH_SIZE \
+    --num_unique_prompts_rollout $NUM_PROMPTS \
+    --num_samples_per_prompt_rollout $NUM_SAMPLES \
+    --stop_strings "</answer>" \
+    --apply_r1_style_format_reward \
+    --apply_verifiable_reward true \
+    --temperature 1.0 \
+    --filter_zero_std_samples false \
+    --ground_truths_key ground_truth \
+    --chat_template_name r1_simple_chat_postpend_think \
+    --learning_rate $LEARNING_RATE \
+    --total_episodes $TOTAL_EPISODES \
+    --deepspeed_stage 0 \
+    --num_epochs 1 \
+    --num_learners_per_node 1 \
+    --vllm_tensor_parallel_size 1 \
+    --beta $BETA \
+    --load_ref_policy false \
+    --seed 42 \
+    --local_eval_every 5 \
+    --save_freq 50 \
+    --single_gpu_mode \
+    --vllm_sync_backend gloo \
+    --vllm_gpu_memory_utilization 0.3 \
+    --vllm_enforce_eager \
+    --gradient_checkpointing \
+    --attn_implementation sdpa \
+    --output_dir /tmp/grpo_smollm_gsm8k \
+    --with_tracking \
+    --push_to_hub false \
+    --exp_name dgx_spark_grpo_validation_tracking
+
+echo ""
+echo "=============================================="
+echo "Training complete at: $(date)"
+echo "=============================================="


### PR DESCRIPTION
## Summary
- Add `validation_holdout_ratio` parameter to hold out a portion of training data for validation
- Track accuracy on held-out training data to detect overfitting during RL training
- Validation metrics appear under `eval/` prefix in wandb

## Changes
1. Add `validation_holdout_ratio` parameter to `StreamingDataLoaderConfig` (0.0-0.5)
2. Implement dataset splitting in `setup_datasets()` with proper index reset
3. Use validation holdout for eval metrics when enabled
4. Fix `create_tools()` to handle `tools=None` case
5. Add documentation and DGX Spark example script

## Usage
```bash
uv run python open_instruct/grpo_fast.py \
    --validation_holdout_ratio 0.1 \  # Hold out 10% for validation
    ...
```

## Test Results
- **wandb run**: https://wandb.ai/ai2-llm/open_instruct_internal/runs/4zypodwy
- Training completed successfully with 270 train + 30 validation samples
- Model achieved ~12% gsm8k_correct_rate during training

## Known Limitations
- Eval metrics may timeout during training due to short timeout (0.01s) - this is a pre-existing limitation of the eval system
- When validation holdout is enabled, it replaces the standard eval_dataset

## Documentation
See `docs/VALIDATION_REWARD_TRACKING.md` for full documentation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)