### PR TITLE
Remove intermediate variable in concatenated_forward functions

### DIFF
--- a/open_instruct/dpo_utils.py
+++ b/open_instruct/dpo_utils.py
@@ -284,8 +284,7 @@ def concatenated_forward(
         all_logps = _get_batch_logps(
             logits, concatenated_batch["concatenated_labels"], average_log_prob=average_log_prob
         )
-        chosen_input_ids: torch.Tensor = batch["chosen_input_ids"]  # type: ignore[assignment]
-        bs = chosen_input_ids.shape[0]
+        bs = batch["chosen_input_ids"].shape[0]  # type: ignore[union-attr]
     else:
         all_logps = pf_get_batch_logps(
             logits,
@@ -402,8 +401,7 @@ def concatenated_forward_olmo(
         all_logps = _get_batch_logps(
             logits, concatenated_batch["concatenated_labels"], average_log_prob=average_log_prob
         )
-        chosen_input_ids: torch.Tensor = batch["chosen_input_ids"]  # type: ignore[assignment]
-        bs = chosen_input_ids.shape[0]
+        bs = batch["chosen_input_ids"].shape[0]  # type: ignore[union-attr]
     else:
         all_logps = pf_get_batch_logps(
             logits,


### PR DESCRIPTION
## Summary
- Simplify code by accessing `batch["chosen_input_ids"].shape[0]` directly instead of storing it in an intermediate variable
- Applied to both `concatenated_forward` and `concatenated_forward_olmo` functions in `dpo_utils.py`

## Test plan
- [ ] Run existing tests to verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)