### PR TITLE
Add Claude skill for updating PR body

### DIFF
--- a/.claude/skills/update-pr-body/SKILL.md
+++ b/.claude/skills/update-pr-body/SKILL.md
@@ -39,7 +39,7 @@ gh pr list --head "$(git branch --show-current)" --json number,url --jq '.[0]'
 
 View current PR body:
 ```bash
-gh pr view 1372 --json body --jq '.body'
+gh pr view 1372 --json body --jq -r '.body'
 ```
 
 Update PR body with new content:


### PR DESCRIPTION
## Summary
- Adds a Claude Code skill for updating GitHub PR body/description
- The skill provides instructions and examples for using `gh pr edit` to modify PR descriptions

## Test plan
- [x] Skill file created with proper frontmatter
- [x] Instructions include examples for common use cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)