### PR TITLE
Add Crawl4AIBrowseTool for fetching webpage content

### DIFF
--- a/open_instruct/tools/tests/test_tools.py
+++ b/open_instruct/tools/tests/test_tools.py
@@ -1,13 +1,17 @@
-"""Tests for tools (PythonCodeTool, JinaBrowseTool, S2SearchTool, and SerperSearchTool from tools.py)."""
+"""Tests for tools (PythonCodeTool, JinaBrowseTool, S2SearchTool, SerperSearchTool, and Crawl4AIBrowseTool from tools.py)."""
 
 import asyncio
 import dataclasses
+import os
+import tempfile
 import unittest
 from unittest.mock import patch
 
 from parameterized import parameterized
 
 from open_instruct.tools.tools import (
+    Crawl4AIBrowseTool,
+    Crawl4AIBrowseToolConfig,
     JinaBrowseTool,
     JinaBrowseToolConfig,
     PythonCodeTool,
@@ -840,6 +844,384 @@ class TestSerperSearchToolConfig(unittest.TestCase):
     def test_tool_class_attribute(self):
         """Test tool_class is set to SerperSearchTool."""
         self.assertEqual(SerperSearchToolConfig.tool_class, SerperSearchTool)
+
+
+class TestCrawl4AIBrowseToolInit(unittest.TestCase):
+    """Tests for Crawl4AIBrowseTool initialization and properties."""
+
+    def setUp(self):
+        """Create a temporary blocklist file for tests."""
+        fd, self.blocklist_path = tempfile.mkstemp(suffix=".txt")
+        with os.fdopen(fd, "w") as f:
+            f.write("blocked-domain.com\nspam-site.net\n")
+
+    def tearDown(self):
+        """Clean up temporary blocklist file."""
+        os.unlink(self.blocklist_path)
+
+    @parameterized.expand([("defaults", None, 180), ("custom_values", 60, 60)])
+    def test_initialization(self, name, timeout, expected_timeout):
+        """Test tool initializes with correct values."""
+        with patch.dict(
+            "os.environ",
+            {
+                "CRAWL4AI_API_URL": "http://localhost:11235",
+                "CRAWL4AI_API_KEY": "test_key",
+                "CRAWL4AI_BLOCKLIST_PATH": self.blocklist_path,
+            },
+        ):
+            kwargs = {"call_name": "browse"}
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            tool = Crawl4AIBrowseTool(**kwargs)
+
+            self.assertEqual(tool.timeout, expected_timeout)
+            self.assertEqual(tool.call_name, "browse")
+            self.assertEqual(tool.config_name, "crawl4ai_browse")
+            self.assertEqual(tool.api_url, "http://localhost:11235")
+            self.assertEqual(tool.api_key, "test_key")
+            self.assertEqual(tool.blocklist, ["blocked-domain.com", "spam-site.net"])
+
+    def test_tool_description(self):
+        """Test tool description is set correctly."""
+        with patch.dict(
+            "os.environ",
+            {
+                "CRAWL4AI_API_URL": "http://localhost:11235",
+                "CRAWL4AI_API_KEY": "test_key",
+                "CRAWL4AI_BLOCKLIST_PATH": self.blocklist_path,
+            },
+        ):
+            tool = Crawl4AIBrowseTool(call_name="browse")
+            self.assertEqual(tool.description, "Fetches and converts webpage content to clean markdown using Crawl4AI")
+
+    def test_tool_parameters_schema(self):
+        """Test tool parameters schema is correct."""
+        with patch.dict(
+            "os.environ",
+            {
+                "CRAWL4AI_API_URL": "http://localhost:11235",
+                "CRAWL4AI_API_KEY": "test_key",
+                "CRAWL4AI_BLOCKLIST_PATH": self.blocklist_path,
+            },
+        ):
+            tool = Crawl4AIBrowseTool(call_name="browse")
+            params = tool.parameters
+
+            self.assertEqual(params["type"], "object")
+            self.assertIn("url", params["properties"])
+            self.assertIn("url", params["required"])
+            self.assertEqual(params["properties"]["url"]["description"], "The URL of the webpage to fetch")
+
+    def test_get_openai_tool_definitions(self):
+        """Test OpenAI tool definition format."""
+        with patch.dict(
+            "os.environ",
+            {
+                "CRAWL4AI_API_URL": "http://localhost:11235",
+                "CRAWL4AI_API_KEY": "test_key",
+                "CRAWL4AI_BLOCKLIST_PATH": self.blocklist_path,
+            },
+        ):
+            tool = Crawl4AIBrowseTool(call_name="browse")
+            definition = get_openai_tool_definitions(tool)
+
+            self.assertEqual(definition["type"], "function")
+            self.assertEqual(definition["function"]["name"], "browse")
+            self.assertIn("parameters", definition["function"])
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_missing_api_url_raises_error_on_init(self):
+        """Test that missing CRAWL4AI_API_URL raises a ValueError on initialization."""
+        with self.assertRaisesRegex(ValueError, "Missing CRAWL4AI_API_URL environment variable."):
+            Crawl4AIBrowseTool(call_name="browse")
+
+    @patch.dict("os.environ", {"CRAWL4AI_API_URL": "http://localhost:11235"}, clear=True)
+    def test_missing_api_key_raises_error_on_init(self):
+        """Test that missing CRAWL4AI_API_KEY raises a ValueError on initialization."""
+        with self.assertRaisesRegex(ValueError, "Missing CRAWL4AI_API_KEY environment variable."):
+            Crawl4AIBrowseTool(call_name="browse")
+
+    @patch.dict(
+        "os.environ", {"CRAWL4AI_API_URL": "http://localhost:11235", "CRAWL4AI_API_KEY": "test_key"}, clear=True
+    )
+    def test_missing_blocklist_raises_error_on_init(self):
+        """Test that missing CRAWL4AI_BLOCKLIST_PATH raises a ValueError on initialization."""
+        with self.assertRaisesRegex(ValueError, "Missing CRAWL4AI_BLOCKLIST_PATH environment variable."):
+            Crawl4AIBrowseTool(call_name="browse")
+
+
+class TestCrawl4AIBrowseToolExecution(unittest.TestCase):
+    """Tests for Crawl4AIBrowseTool execution (async execute)."""
+
+    def setUp(self):
+        """Set up test fixture."""
+        fd, self.blocklist_path = tempfile.mkstemp(suffix=".txt")
+        with os.fdopen(fd, "w") as f:
+            f.write("blocked-domain.com\n")
+
+        patcher = patch.dict(
+            "os.environ",
+            {
+                "CRAWL4AI_API_URL": "http://localhost:11235",
+                "CRAWL4AI_API_KEY": "test_key",
+                "CRAWL4AI_BLOCKLIST_PATH": self.blocklist_path,
+            },
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.addCleanup(lambda: os.unlink(self.blocklist_path))
+        self.tool = Crawl4AIBrowseTool(call_name="browse", timeout=180)
+
+    @parameterized.expand([("empty", ""), ("whitespace", "   \n\t  "), ("none", None)])
+    def test_empty_url_returns_error(self, name, url_input):
+        """Test that empty/whitespace/None URL returns an error without calling API."""
+        result = asyncio.run(self.tool.execute(url_input))
+
+        self.assertIsInstance(result, ToolOutput)
+        self.assertEqual(result.output, "")
+        self.assertEqual(result.error, "Empty URL. Please provide a URL to fetch.")
+        self.assertTrue(result.called)
+        self.assertFalse(result.timeout)
+
+    @parameterized.expand(
+        [
+            (
+                "with_title",
+                {
+                    "results": [
+                        {
+                            "success": True,
+                            "markdown": "This is the page content.",
+                            "metadata": {"title": "Example Page"},
+                        }
+                    ]
+                },
+                ["# Example Page", "This is the page content."],
+            ),
+            (
+                "without_title",
+                {"results": [{"success": True, "markdown": "Just content without a title.", "metadata": {}}]},
+                ["Just content without a title."],
+            ),
+            (
+                "fit_markdown_preferred",
+                {
+                    "results": [
+                        {
+                            "success": True,
+                            "markdown": {"raw_markdown": "Full content here.", "fit_markdown": "Pruned content here."},
+                            "metadata": {"title": "Test"},
+                        }
+                    ]
+                },
+                ["Pruned content here."],
+            ),
+        ]
+    )
+    @patch("open_instruct.tools.tools.make_api_request")
+    def test_successful_fetch(self, name, api_data, expected_in_output, mock_api_request):
+        """Test successful webpage fetch with various response types."""
+        from open_instruct.tools.utils import APIResponse
+
+        async def mock_response(*args, **kwargs):
+            return APIResponse(data=api_data)
+
+        mock_api_request.side_effect = mock_response
+
+        result = asyncio.run(self.tool.execute("https://example.com"))
+
+        self.assertIsInstance(result, ToolOutput)
+        for expected in expected_in_output:
+            self.assertIn(expected, result.output)
+        self.assertEqual(result.error, "")
+        self.assertTrue(result.called)
+        self.assertFalse(result.timeout)
+
+    @patch("open_instruct.tools.tools.make_api_request")
+    def test_crawl4ai_api_error_response(self, mock_api_request):
+        """Test handling of Crawl4AI API error response (success=False)."""
+        from open_instruct.tools.utils import APIResponse
+
+        async def mock_response(*args, **kwargs):
+            return APIResponse(data={"results": [{"success": False, "error_message": "Failed to fetch URL"}]})
+
+        mock_api_request.side_effect = mock_response
+
+        result = asyncio.run(self.tool.execute("https://invalid-url"))
+
+        self.assertTrue(result.called)
+        self.assertIn("Crawl4AI error", result.error)
+        self.assertIn("Failed to fetch URL", result.error)
+        self.assertIn("Crawl4AI error", result.output)
+
+    @parameterized.expand(
+        [
+            ("timeout", {"error": "Timeout after 180 seconds", "timed_out": True}, True, "Timeout after 180 seconds"),
+            (
+                "connection_error",
+                {"error": "Connection error: Connection refused", "timed_out": False},
+                False,
+                "Connection error",
+            ),
+            (
+                "http_error",
+                {"error": "HTTP error: 500 Internal Server Error", "timed_out": False},
+                False,
+                "HTTP error",
+            ),
+        ]
+    )
+    @patch("open_instruct.tools.tools.make_api_request")
+    def test_error_handling(self, name, api_response, expected_timeout, expected_error_contains, mock_api_request):
+        """Test error handling for various API error types."""
+        from open_instruct.tools.utils import APIResponse
+
+        async def mock_response(*args, **kwargs):
+            return APIResponse(**api_response)
+
+        mock_api_request.side_effect = mock_response
+
+        result = asyncio.run(self.tool.execute("https://example.com"))
+
+        self.assertTrue(result.called)
+        self.assertEqual(result.timeout, expected_timeout)
+        self.assertIn(expected_error_contains, result.error)
+        self.assertIn(expected_error_contains, result.output)
+
+    @patch("open_instruct.tools.tools.make_api_request")
+    def test_uses_post_method_and_correct_endpoint(self, mock_api_request):
+        """Test that Crawl4AIBrowseTool uses POST method and correct endpoint."""
+        from open_instruct.tools.utils import APIResponse
+
+        async def mock_response(*args, **kwargs):
+            return APIResponse(data={"results": [{"success": True, "markdown": "OK", "metadata": {}}]})
+
+        mock_api_request.side_effect = mock_response
+
+        asyncio.run(self.tool.execute("https://example.com"))
+
+        mock_api_request.assert_called_once()
+        call_args = mock_api_request.call_args
+        self.assertEqual(call_args[1]["url"], "http://localhost:11235/crawl")
+
+    @patch("open_instruct.tools.tools.make_api_request")
+    def test_payload_contains_url(self, mock_api_request):
+        """Test that the request payload contains the URL in a list."""
+        from open_instruct.tools.utils import APIResponse
+
+        async def mock_response(*args, **kwargs):
+            return APIResponse(data={"results": [{"success": True, "markdown": "OK", "metadata": {}}]})
+
+        mock_api_request.side_effect = mock_response
+
+        asyncio.run(self.tool.execute("https://example.com/page"))
+
+        mock_api_request.assert_called_once()
+        call_args = mock_api_request.call_args
+        self.assertEqual(call_args[1]["json_payload"]["urls"], ["https://example.com/page"])
+
+    @patch("open_instruct.tools.tools.make_api_request")
+    def test_api_key_in_headers(self, mock_api_request):
+        """Test that API key is included in headers."""
+        from open_instruct.tools.utils import APIResponse
+
+        async def mock_response(*args, **kwargs):
+            return APIResponse(data={"results": [{"success": True, "markdown": "OK", "metadata": {}}]})
+
+        mock_api_request.side_effect = mock_response
+
+        asyncio.run(self.tool.execute("https://example.com"))
+
+        mock_api_request.assert_called_once()
+        call_args = mock_api_request.call_args
+        self.assertEqual(call_args[1]["headers"]["x-api-key"], "test_key")
+
+    @patch("open_instruct.tools.tools.make_api_request")
+    def test_content_truncation(self, mock_api_request):
+        """Test that content is truncated when exceeding max_content_length."""
+        from open_instruct.tools.utils import APIResponse
+
+        tool = Crawl4AIBrowseTool(call_name="browse", max_content_length=50)
+
+        long_content = "A" * 100
+
+        async def mock_response(*args, **kwargs):
+            return APIResponse(data={"results": [{"success": True, "markdown": long_content, "metadata": {}}]})
+
+        mock_api_request.side_effect = mock_response
+
+        result = asyncio.run(tool.execute("https://example.com"))
+
+        self.assertLess(len(result.output), 100)
+        self.assertTrue(result.output.startswith("A" * 50))
+        self.assertIn("[Content truncated]", result.output)
+
+    @patch("open_instruct.tools.tools.make_api_request")
+    def test_no_truncation_when_under_limit(self, mock_api_request):
+        """Test that content is not truncated when under max_content_length."""
+        from open_instruct.tools.utils import APIResponse
+
+        tool = Crawl4AIBrowseTool(call_name="browse", max_content_length=100)
+
+        short_content = "A" * 50
+
+        async def mock_response(*args, **kwargs):
+            return APIResponse(data={"results": [{"success": True, "markdown": short_content, "metadata": {}}]})
+
+        mock_api_request.side_effect = mock_response
+
+        result = asyncio.run(tool.execute("https://example.com"))
+
+        self.assertEqual(result.output, short_content)
+        self.assertNotIn("[Content truncated]", result.output)
+
+    @patch("open_instruct.tools.tools.make_api_request")
+    def test_no_truncation_when_limit_is_none(self, mock_api_request):
+        """Test that content is not truncated when max_content_length is None."""
+        from open_instruct.tools.utils import APIResponse
+
+        tool = Crawl4AIBrowseTool(call_name="browse", max_content_length=None)
+
+        long_content = "A" * 10000
+
+        async def mock_response(*args, **kwargs):
+            return APIResponse(data={"results": [{"success": True, "markdown": long_content, "metadata": {}}]})
+
+        mock_api_request.side_effect = mock_response
+
+        result = asyncio.run(tool.execute("https://example.com"))
+
+        self.assertEqual(result.output, long_content)
+        self.assertNotIn("[Content truncated]", result.output)
+
+
+class TestCrawl4AIBrowseToolConfig(unittest.TestCase):
+    """Tests for Crawl4AIBrowseToolConfig."""
+
+    def test_config_default_values(self):
+        """Test config has correct default values."""
+        config = Crawl4AIBrowseToolConfig()
+        self.assertEqual(config.timeout, 180)
+        self.assertTrue(config.ignore_links)
+        self.assertFalse(config.bypass_cache)
+        self.assertFalse(config.include_html)
+        self.assertEqual(config.max_content_length, 5000)
+
+    def test_config_custom_values(self):
+        """Test config accepts custom values."""
+        config = Crawl4AIBrowseToolConfig(
+            timeout=60, ignore_links=False, bypass_cache=True, include_html=True, max_content_length=10000
+        )
+        self.assertEqual(config.timeout, 60)
+        self.assertFalse(config.ignore_links)
+        self.assertTrue(config.bypass_cache)
+        self.assertTrue(config.include_html)
+        self.assertEqual(config.max_content_length, 10000)
+
+    def test_tool_class_attribute(self):
+        """Test tool_class is set to Crawl4AIBrowseTool."""
+        self.assertEqual(Crawl4AIBrowseToolConfig.tool_class, Crawl4AIBrowseTool)
 
 
 class TestToolsConfig(unittest.TestCase):

--- a/open_instruct/tools/tools.py
+++ b/open_instruct/tools/tools.py
@@ -166,7 +166,6 @@ class JinaBrowseTool(Tool):
             content = inner_data.get("content") or ""
             title = inner_data.get("title") or ""
 
-            # Format output with title if available
             if title and content:
                 content = f"# {title}\n\n{content}"
         else:
@@ -354,10 +353,169 @@ class SerperSearchToolConfig(BaseToolConfig):
     """Timeout in seconds for the API request."""
 
 
+def _parse_crawl4ai_response(data: dict, include_html: bool, max_content_length: int | None) -> tuple[str, str]:
+    """Parse Crawl4AI API response and extract content.
+
+    Returns:
+        Tuple of (content, error). If successful, error is empty.
+    """
+    results = data.get("results", [])
+    if not results:
+        return "", f"Crawl4AI error: {data.get('error', 'No results returned')}"
+
+    result_data = results[0]
+    if not result_data.get("success", False):
+        error_msg = result_data.get("error_message", result_data.get("error", "Unknown error"))
+        return "", f"Crawl4AI error: {error_msg}"
+
+    # Prefer fit_markdown (pruned), then markdown, then html
+    markdown_data = result_data.get("markdown", "")
+    if isinstance(markdown_data, dict):
+        content = markdown_data.get("fit_markdown") or markdown_data.get("raw_markdown") or ""
+    else:
+        content = markdown_data or ""
+
+    if not content and include_html:
+        content = result_data.get("html") or result_data.get("cleaned_html") or ""
+
+    metadata = result_data.get("metadata", {})
+    title = metadata.get("title", "") if isinstance(metadata, dict) else ""
+    if title and content:
+        content = f"# {title}\n\n{content}"
+
+    if max_content_length and len(content) > max_content_length:
+        content = content[:max_content_length] + "\n\n[Content truncated]"
+
+    return content, ""
+
+
+class Crawl4AIBrowseTool(Tool):
+    """
+    Tool for fetching webpage content using Crawl4AI Docker API.
+    Requires CRAWL4AI_API_URL, CRAWL4AI_API_KEY, and CRAWL4AI_BLOCKLIST_PATH environment variables.
+
+    This tool uses the Docker version with AI2 configuration by default.
+    Based on: https://github.com/rlresearch/dr-tulu/blob/main/agent/dr_agent/tool_interface/mcp_tools.py
+    """
+
+    config_name = "crawl4ai_browse"
+    description = "Fetches and converts webpage content to clean markdown using Crawl4AI"
+    parameters = {
+        "type": "object",
+        "properties": {"url": {"type": "string", "description": "The URL of the webpage to fetch"}},
+        "required": ["url"],
+    }
+
+    def __init__(
+        self,
+        call_name: str,
+        timeout: int = 180,
+        ignore_links: bool = True,
+        bypass_cache: bool = False,
+        include_html: bool = False,
+        max_content_length: int | None = 5000,
+    ) -> None:
+        self.call_name = call_name
+        self.timeout = timeout
+        self.ignore_links = ignore_links
+        self.bypass_cache = bypass_cache
+        self.include_html = include_html
+        self.max_content_length = max_content_length
+
+        self.api_url = os.environ.get("CRAWL4AI_API_URL")
+        if not self.api_url:
+            raise ValueError("Missing CRAWL4AI_API_URL environment variable.")
+        self.api_key = os.environ.get("CRAWL4AI_API_KEY")
+        if not self.api_key:
+            raise ValueError("Missing CRAWL4AI_API_KEY environment variable.")
+
+        blocklist_path = os.environ.get("CRAWL4AI_BLOCKLIST_PATH")
+        if not blocklist_path:
+            raise ValueError("Missing CRAWL4AI_BLOCKLIST_PATH environment variable.")
+        if not os.path.exists(blocklist_path):
+            raise FileNotFoundError(f"Blocklist file not found: {blocklist_path}")
+        with open(blocklist_path, encoding="utf-8") as f:
+            self.blocklist = [line.strip() for line in f if line.strip()]
+
+    async def execute(self, url: str) -> ToolOutput:
+        """Fetch webpage content via Crawl4AI Docker API."""
+        if not url or not url.strip():
+            result = ToolOutput(
+                output="", error="Empty URL. Please provide a URL to fetch.", called=True, timeout=False, runtime=0
+            )
+            _log_tool_call(self.call_name, url or "", result)
+            return result
+
+        start_time = time.time()
+
+        # Build request payload matching Crawl4AI Docker API format
+        # See: https://docs.crawl4ai.com/core/docker-deployment/
+        crawler_params: dict = {
+            "cache_mode": "bypass" if self.bypass_cache else "enabled",
+            "word_count_threshold": 10,
+            "exclude_social_media_links": True,
+            "excluded_tags": ["form", "header", "footer", "nav"],
+            "page_timeout": (self.timeout - 1) * 1000,  # Convert to ms, leave 1s buffer
+            "exclude_domains": self.blocklist,
+        }
+
+        if self.ignore_links:
+            crawler_params["exclude_external_links"] = True
+
+        payload = {
+            "urls": [url.strip()],
+            "browser_config": {"type": "BrowserConfig", "params": {"headless": True}},
+            "crawler_config": {"type": "CrawlerRunConfig", "params": crawler_params},
+        }
+
+        headers = {"Content-Type": "application/json", "x-api-key": self.api_key}
+
+        crawl_endpoint = f"{self.api_url.rstrip('/')}/crawl"
+        api_response = await make_api_request(
+            url=crawl_endpoint, timeout_seconds=self.timeout, json_payload=payload, headers=headers
+        )
+
+        if api_response.error:
+            result = ToolOutput(
+                output=api_response.error,
+                called=True,
+                error=api_response.error,
+                timeout=api_response.timed_out,
+                runtime=time.time() - start_time,
+            )
+            _log_tool_call(self.call_name, url, result)
+            return result
+
+        content, error = _parse_crawl4ai_response(api_response.data, self.include_html, self.max_content_length)
+        output = error if error else content
+        result = ToolOutput(output=output, called=True, error=error, timeout=False, runtime=time.time() - start_time)
+        _log_tool_call(self.call_name, url, result)
+        return result
+
+
+@dataclass
+class Crawl4AIBrowseToolConfig(BaseToolConfig):
+    """Configuration for the Crawl4AI browse tool."""
+
+    tool_class: ClassVar[type[Tool]] = Crawl4AIBrowseTool
+
+    timeout: int = 180
+    """Timeout in seconds for webpage fetching."""
+    ignore_links: bool = True
+    """Whether to exclude external and social media links from the content."""
+    bypass_cache: bool = False
+    """Whether to bypass the cache and fetch fresh content."""
+    include_html: bool = False
+    """Whether to include HTML content as fallback if markdown is unavailable."""
+    max_content_length: int | None = 5000
+    """Maximum content length in characters. None means no limit."""
+
+
 # Tool Registry: Maps tool names to their config classes
 TOOL_REGISTRY: dict[str, type[BaseToolConfig]] = {
     PythonCodeToolConfig.tool_class.config_name: PythonCodeToolConfig,
     JinaBrowseToolConfig.tool_class.config_name: JinaBrowseToolConfig,
     S2SearchToolConfig.tool_class.config_name: S2SearchToolConfig,
     SerperSearchToolConfig.tool_class.config_name: SerperSearchToolConfig,
+    Crawl4AIBrowseToolConfig.tool_class.config_name: Crawl4AIBrowseToolConfig,
 }


### PR DESCRIPTION
Add a new browse tool that uses the Crawl4AI Docker API to fetch and convert webpage content to clean markdown. 

This Docker API is actually a proxy server for crawl4ai, which is useful since (a) jina costs money, but we can host crawl4ai ourself; (b) ips can get burned when crawling so we always want to access crawl4ai through a proxy service. The proxy service itself was developed as part of the Dr Tulu project.

Based on: https://github.com/rlresearch/dr-tulu/blob/main/agent/dr_agent/tool_interface/mcp_tools.py