### PR TITLE
Add GRPO callbacks for OLMo-core Trainer (GRPO olmo-core: PR 3 of 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - Tensor parallelism (TP) support for OLMo-core DPO training (https://github.com/allenai/open-instruct/pull/1467).
+- Pulls out weight sync code from GRPO into a more generic function (https://github.com/allenai/open-instruct/pull/1411#pullrequestreview-3694117967)
+- Adds callbacks for GRPO training with Olmo-core's trainer (https://github.com/allenai/open-instruct/pull/1397).
+- Adds FSDP2 block-by-block weight gathering support for vLLM weight sync.
 
 ### Fixed
 - Fixed GPU test failures: DPO `get_num_tokens` attention mask matching, DPO forward pass logps computation, mock model interface in `test_dpo_utils_gpu.py`, patch target in `test_olmo_core_callbacks_gpu.py`, reference logprobs cache `drop_last`, and flaky streaming dataloader tool test (https://github.com/allenai/open-instruct/pull/1514).

--- a/open_instruct/grpo_callbacks.py
+++ b/open_instruct/grpo_callbacks.py
@@ -1,0 +1,189 @@
+"""
+GRPO-specific callbacks for OLMo-core Trainer.
+
+These callbacks handle:
+- vLLM weight synchronization after each training step
+- Reference policy Polyak updates
+"""
+
+import contextlib
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import ray
+import ray.exceptions
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+from olmo_core.train.callbacks import Callback
+from olmo_core.train.train_module import TransformerTrainModule
+from torch.distributed._composable.fsdp import FSDPModule
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+from open_instruct import logger_utils, vllm_utils
+
+logger = logger_utils.setup_logger(__name__)
+
+_BLOCK_PATTERN = re.compile(r"blocks\.(\d+)\.(.*)")
+_OLMO_CORE_TO_HF_LAYER_MAPPINGS = {
+    "attention.w_q.weight": "self_attn.q_proj.weight",
+    "attention.w_k.weight": "self_attn.k_proj.weight",
+    "attention.w_v.weight": "self_attn.v_proj.weight",
+    "attention.w_out.weight": "self_attn.o_proj.weight",
+    "attention.q_norm.weight": "self_attn.q_norm.weight",
+    "attention.k_norm.weight": "self_attn.k_norm.weight",
+    "feed_forward.w1.weight": "mlp.gate_proj.weight",
+    "feed_forward.w2.weight": "mlp.down_proj.weight",
+    "feed_forward.w3.weight": "mlp.up_proj.weight",
+    "attention_norm.weight": "input_layernorm.weight",
+    "feed_forward_norm.weight": "post_attention_layernorm.weight",
+}
+
+
+def olmo_core_to_hf_name(name: str) -> str:
+    """Convert OLMo-core parameter name to HuggingFace format for Qwen3/LLaMA models."""
+    if name == "embeddings.weight":
+        return "model.embed_tokens.weight"
+    if name == "lm_head.norm.weight":
+        return "model.norm.weight"
+    if name == "lm_head.w_out.weight":
+        return "lm_head.weight"
+
+    layer_match = _BLOCK_PATTERN.match(name)
+    if layer_match:
+        layer_idx = layer_match.group(1)
+        rest = layer_match.group(2)
+        if rest in _OLMO_CORE_TO_HF_LAYER_MAPPINGS:
+            return f"model.layers.{layer_idx}.{_OLMO_CORE_TO_HF_LAYER_MAPPINGS[rest]}"
+
+    return name
+
+
+@dataclass
+class VLLMWeightSyncCallback(Callback):
+    """Callback to synchronize weights from training model to vLLM inference engines.
+
+    After each training step, this callback:
+    1. Pauses vLLM actors via actor_manager
+    2. Gathers FSDP-sharded parameters using summon_full_params
+    3. Broadcasts weights from rank 0 to vLLM engines
+    4. Resumes vLLM actors
+    """
+
+    vllm_engines: list[ray.actor.ActorHandle]
+    model_update_group: dist.ProcessGroup | None = None
+    actor_manager: ray.actor.ActorHandle | None = None
+    sync_interval: int = 1
+    name_mapper: Callable[[str], str] | None = None
+
+    @property
+    def train_module(self) -> TransformerTrainModule:
+        return cast(TransformerTrainModule, self.trainer.train_module)
+
+    def post_step(self) -> None:
+        if self.trainer.global_step % self.sync_interval != 0:
+            return
+
+        torch.cuda.empty_cache()
+
+        if self.actor_manager is not None:
+            ray.get(self.actor_manager.set_should_stop.remote(True))
+
+        model = self.train_module.model
+
+        try:
+            self._broadcast_weights(model)
+        finally:
+            if self.actor_manager is not None:
+                ray.get(self.actor_manager.set_should_stop.remote(False))
+
+    def _broadcast_weights(self, model: nn.Module) -> None:
+        """Broadcast weights from training model to vLLM engines."""
+        refs = vllm_utils.broadcast_weights_to_vllm(
+            model=model,
+            vllm_engines=self.vllm_engines,
+            model_update_group=self.model_update_group,
+            name_mapper=self.name_mapper,
+        )
+        if refs:
+            ray.get(refs)
+
+
+@dataclass
+class RefPolicyUpdateCallback(Callback):
+    """Callback to update reference policy using Polyak averaging.
+
+    Updates reference policy parameters as:
+        ref_param = (1 - alpha) * ref_param + alpha * policy_param
+
+    This is used for KL divergence computation in GRPO.
+    """
+
+    ref_policy: nn.Module
+    alpha: float = 0.6
+    update_interval: int = 1
+    _fsdp2_submodules: list[FSDPModule] | None = field(default=None, init=False, repr=False)
+
+    @property
+    def train_module(self) -> TransformerTrainModule:
+        return cast(TransformerTrainModule, self.trainer.train_module)
+
+    def _get_fsdp2_submodules(self, model: nn.Module) -> list[FSDPModule]:
+        if self._fsdp2_submodules is None:
+            self._fsdp2_submodules = [m for _, m in vllm_utils._get_fsdp2_submodules(model)]
+        return self._fsdp2_submodules
+
+    def post_step(self) -> None:
+        if self.trainer.global_step % self.update_interval != 0:
+            return
+
+        model = self.train_module.model
+
+        if isinstance(model, FSDP):
+            ctx = FSDP.summon_full_params(model, writeback=False, rank0_only=False)
+        else:
+            ctx = contextlib.nullcontext()
+
+        fsdp2_submodules: list[FSDPModule] = []
+        if isinstance(model, FSDPModule):
+            fsdp2_submodules = self._get_fsdp2_submodules(model)
+            for m in fsdp2_submodules:
+                m.unshard()
+
+        try:
+            with ctx:
+                for ref_param, param in zip(self.ref_policy.parameters(), model.parameters(), strict=True):
+                    ref_param.data.mul_(1.0 - self.alpha).add_(param.data, alpha=self.alpha)
+        finally:
+            for m in fsdp2_submodules:
+                m.reshard()
+
+
+@dataclass
+class DataPreparationActorCheckpointCallback(Callback):
+    """Callback to save and restore DataPreparationActor state during checkpointing."""
+
+    data_prep_actor_name: str = "data_prep_singleton"
+
+    def state_dict(self) -> dict[str, Any]:
+        """Save DataPreparationActor state before checkpointing."""
+        try:
+            data_prep_actor = ray.get_actor(self.data_prep_actor_name)
+            return {"data_prep_state": ray.get(data_prep_actor.get_state.remote())}
+        except (ray.exceptions.RayError, ValueError) as e:
+            logger.warning(f"Failed to get DataPreparationActor state: {e}")
+            return {}
+
+    def load_state_dict(self, state_dict: dict[str, Any]) -> None:
+        """Restore DataPreparationActor state after loading checkpoint."""
+        if "data_prep_state" not in state_dict:
+            return
+
+        try:
+            data_prep_actor = ray.get_actor(self.data_prep_actor_name)
+            ray.get(data_prep_actor.restore_state.remote(state_dict["data_prep_state"]))
+            logger.info("Restored DataPreparationActor state from checkpoint")
+        except (ray.exceptions.RayError, ValueError) as e:
+            logger.warning(f"Failed to restore DataPreparationActor state: {e}")

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -447,7 +447,6 @@ class PolicyTrainerRayProcess(RayProcess):
             model=self.model.module,
             vllm_engines=self.vllm_engines,
             model_update_group=self.model_update_group,
-            deepspeed_stage=self.args.deepspeed_stage,
             gather_whole_model=self.args.gather_whole_model,
         )
 

--- a/open_instruct/test_vllm_utils_gpu.py
+++ b/open_instruct/test_vllm_utils_gpu.py
@@ -1,0 +1,118 @@
+"""GPU tests for FSDP2 weight broadcasting in vllm_utils.
+
+To run:
+    ./scripts/train/build_image_and_launch.sh scripts/test/run_gpu_tests.sh
+"""
+
+import os
+import unittest
+
+import datasets
+import ray
+import torch
+from olmo_core.nn.transformer import TransformerConfig
+from ray.util import queue as ray_queue
+from ray.util.placement_group import placement_group
+from transformers import AutoTokenizer
+
+from open_instruct import logger_utils, vllm_utils
+from open_instruct.ground_truth_utils import RewardConfig
+from open_instruct.test_grpo_fast import TestGrpoFastBase
+from open_instruct.utils import maybe_update_beaker_description
+from open_instruct.vllm_utils import create_vllm_engines
+
+logger = logger_utils.setup_logger(__name__)
+
+maybe_update_beaker_description()
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA not available")
+class TestFSDP2BroadcastWithVLLM(TestGrpoFastBase):
+    """Integration test for FSDP2 weight broadcast with real vLLM engine on single GPU."""
+
+    def test_broadcast_olmo_core_fsdp2_weights_to_vllm(self):
+        """Test broadcasting OLMo-core FSDP2 model weights to a real vLLM engine."""
+        tokenizer_name = "Qwen/Qwen3-0.6B"
+        AutoTokenizer.from_pretrained(tokenizer_name)
+
+        master_address = ray._private.services.get_node_ip_address()
+        master_port = 29502
+
+        os.environ["MASTER_ADDR"] = master_address
+        os.environ["MASTER_PORT"] = str(master_port)
+        if not torch.distributed.is_initialized():
+            torch.distributed.init_process_group(backend="nccl", world_size=1, rank=0)
+
+        config = TransformerConfig.llama_like(d_model=256, vocab_size=1000, n_layers=2, n_heads=4)
+        model = config.build(init_device="cuda")
+        model.apply_fsdp()
+
+        param_prompt_Q = ray_queue.Queue(maxsize=100)
+        inference_results_Q = ray_queue.Queue(maxsize=100)
+        eval_results_Q = ray_queue.Queue(maxsize=100)
+        self._ray_queues.extend([param_prompt_Q, inference_results_Q, eval_results_Q])
+
+        pg = placement_group([{"GPU": 1, "CPU": 1}], strategy="PACK")
+        ray.get(pg.ready())
+
+        train_dataset = datasets.Dataset.from_dict(
+            {"ground_truth": [["4"]], "dataset": ["test"], "prompt": ["test"], "index": [0]}
+        )
+
+        engines = create_vllm_engines(
+            num_engines=1,
+            tensor_parallel_size=1,
+            enforce_eager=True,
+            tokenizer_name_or_path=tokenizer_name,
+            pretrain=tokenizer_name,
+            revision="main",
+            seed=42,
+            enable_prefix_caching=False,
+            max_model_len=512,
+            vllm_gpu_memory_utilization=0.3,
+            single_gpu_mode=True,
+            pg=pg,
+            prompt_queue=param_prompt_Q,
+            results_queue=inference_results_Q,
+            eval_results_queue=eval_results_Q,
+            reward_config=RewardConfig(),
+            train_dataset=train_dataset,
+        )
+        ray.get(engines[0].ready.remote())
+
+        model_update_group = vllm_utils.init_process_group(
+            backend="gloo",
+            init_method=f"tcp://{master_address}:{master_port + 1}",
+            world_size=2,
+            rank=0,
+            group_name="test_fsdp2_broadcast",
+        )
+
+        ray.get(
+            engines[0].init_process_group.remote(
+                master_address=master_address,
+                master_port=master_port + 1,
+                rank_offset=1,
+                world_size=2,
+                group_name="test_fsdp2_broadcast",
+                backend="gloo",
+            )
+        )
+
+        refs = vllm_utils.broadcast_weights_to_vllm(
+            model=model,
+            vllm_engines=engines,
+            model_update_group=model_update_group,
+            name_mapper=None,
+            gather_whole_model=True,
+        )
+
+        self.assertGreater(len(refs), 0)
+        ray.get(refs)
+
+        torch.distributed.destroy_process_group(model_update_group)
+        torch.distributed.destroy_process_group()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -25,7 +25,7 @@ import sys
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from concurrent import futures
 from datetime import timedelta
 from typing import Any
@@ -43,6 +43,7 @@ import vllm
 from ray.util import queue as ray_queue
 from ray.util.placement_group import PlacementGroup, placement_group
 from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+from torch.distributed._composable.fsdp import FSDPModule
 from torch.distributed.distributed_c10d import (
     Backend,
     PrefixStore,
@@ -53,6 +54,7 @@ from torch.distributed.distributed_c10d import (
     default_pg_timeout,
     rendezvous,
 )
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from vllm.entrypoints.openai.api_server import build_app, init_app_state
 from vllm.entrypoints.openai.cli_args import make_arg_parser
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -1283,7 +1285,6 @@ def create_vllm_engines(
                 scheduling_strategy=scheduling_strategy,
                 runtime_env=ray.runtime_env.RuntimeEnv(
                     env_vars={
-                        **dict(os.environ),
                         "VLLM_ENABLE_V1_MULTIPROCESSING": "0",
                         "TORCH_CUDA_ARCH_LIST": get_cuda_arch_list(),
                         "RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO": "0",
@@ -1335,13 +1336,12 @@ def create_vllm_engines(
 def _send_to_vllm(
     name: str,
     param: torch.nn.Parameter,
+    shape: torch.Size,
     is_last: bool,
-    deepspeed_stage: int,
     vllm_engines: list[ray.actor.ActorHandle],
     model_update_group: torch.distributed.ProcessGroup,
 ) -> list[ray.ObjectRef]:
     """Send a parameter to vLLM engines via broadcast."""
-    shape = param.ds_shape if deepspeed_stage == 3 else param.shape
     refs = [
         engine.update_weight.remote(name, dtype=str(param.dtype), shape=shape, empty_cache=is_last)
         for engine in vllm_engines
@@ -1350,24 +1350,79 @@ def _send_to_vllm(
     return refs
 
 
+def _get_fsdp2_submodules(model: torch.nn.Module) -> list[tuple[str, FSDPModule]]:
+    """Get all FSDP2-wrapped submodules (excluding the root if it's FSDP2)."""
+    fsdp_modules = []
+    for name, module in model.named_modules():
+        if isinstance(module, FSDPModule) and module is not model:
+            fsdp_modules.append((name, module))
+    return fsdp_modules
+
+
+def _broadcast_fsdp2_block_params(
+    block_name: str,
+    block: FSDPModule,
+    vllm_engines: list[ray.actor.ActorHandle],
+    model_update_group: torch.distributed.ProcessGroup,
+    name_mapper: Callable[[str], str] | None,
+    is_last_block: bool,
+    is_rank_0: bool,
+) -> list[ray.ObjectRef]:
+    """Broadcast parameters from one FSDP2 block to vLLM engines.
+
+    All ranks must call this (unshard/reshard are collective ops).
+    Only rank 0 actually sends to vLLM.
+    """
+    block.unshard()
+    try:
+        refs: list[ray.ObjectRef] = []
+        if is_rank_0:
+            params = list(block.named_parameters())
+            num_params = len(params)
+            for i, (name, param) in enumerate(params):
+                full_name = f"{block_name}.{name}" if block_name else name
+                mapped_name = name_mapper(full_name) if name_mapper else full_name
+                is_last = is_last_block and (i == num_params - 1)
+                refs.extend(_send_to_vllm(mapped_name, param, param.shape, is_last, vllm_engines, model_update_group))
+        return refs
+    finally:
+        block.reshard()
+
+
+def _broadcast_params_to_vllm(
+    params: list[tuple[str, torch.nn.Parameter]],
+    vllm_engines: list[ray.actor.ActorHandle],
+    model_update_group: torch.distributed.ProcessGroup,
+    name_mapper: Callable[[str], str] | None,
+) -> list[ray.ObjectRef]:
+    """Broadcast parameters to vLLM engines. Must be called on rank 0 only."""
+    refs: list[ray.ObjectRef] = []
+    num_params = len(params)
+    for i, (name, param) in enumerate(params):
+        mapped_name = name_mapper(name) if name_mapper else name
+        shape = getattr(param, "ds_shape", param.shape)
+        refs.extend(_send_to_vllm(mapped_name, param, shape, i == num_params - 1, vllm_engines, model_update_group))
+    return refs
+
+
 def broadcast_weights_to_vllm(
     model: torch.nn.Module,
     vllm_engines: list[ray.actor.ActorHandle],
     model_update_group: torch.distributed.ProcessGroup | None,
-    deepspeed_stage: int,
+    name_mapper: Callable[[str], str] | None = None,
     gather_whole_model: bool = True,
 ) -> list[ray.ObjectRef]:
-    """Broadcast DeepSpeed model weights to vLLM engines.
+    """Broadcast model weights to vLLM engines.
 
-    Must be called on ALL ranks when using DeepSpeed stage 3, since
-    GatheredParameters is a collective operation. Only rank 0 actually
-    sends weights to vLLM.
+    Supports both DeepSpeed and FSDP sharded models. Must be called on ALL ranks
+    when using DeepSpeed stage 3 or FSDP, since gathering is a collective operation.
+    Only rank 0 actually sends weights to vLLM.
 
     Args:
-        model: The unwrapped model (model.module from DeepSpeed engine)
+        model: The unwrapped model (model.module from DeepSpeed/FSDP engine)
         vllm_engines: List of vLLM engine actor handles
         model_update_group: Process group for distributed broadcast (only needed on rank 0)
-        deepspeed_stage: DeepSpeed ZeRO stage (3 requires GatheredParameters)
+        name_mapper: Optional function to map parameter names (e.g., OLMo-core to HF format)
         gather_whole_model: If True, gather all params at once (more memory, faster).
             If False, gather each param individually (less memory, slower).
 
@@ -1375,27 +1430,44 @@ def broadcast_weights_to_vllm(
         List of Ray ObjectRefs for the weight update calls (empty on non-rank-0)
     """
     is_rank_0 = torch.distributed.get_rank() == 0
+
+    if isinstance(model, FSDP) and not gather_whole_model:
+        raise ValueError("FSDP1 does not support per-parameter gathering. Set gather_whole_model=True.")
+
+    if isinstance(model, FSDPModule):
+        fsdp_submodules = _get_fsdp2_submodules(model)
+        if not fsdp_submodules:
+            raise ValueError("FSDP2 model has no FSDP submodules.")
+        all_refs: list[ray.ObjectRef] = []
+        num_blocks = len(fsdp_submodules)
+        for i, (block_name, block) in enumerate(fsdp_submodules):
+            refs = _broadcast_fsdp2_block_params(
+                block_name, block, vllm_engines, model_update_group, name_mapper, i == num_blocks - 1, is_rank_0
+            )
+            all_refs.extend(refs)
+        return all_refs
+
     params = list(model.named_parameters())
-    num_params = len(params)
-    all_refs: list[ray.ObjectRef] = []
+    deepspeed_stage_3 = any(hasattr(p, "ds_id") for p in model.parameters())
 
     if gather_whole_model:
-        with deepspeed.zero.GatheredParameters(model.parameters(), enabled=deepspeed_stage == 3):
+        if isinstance(model, FSDP):
+            ctx = FSDP.summon_full_params(model, writeback=False, rank0_only=False)
+        else:
+            ctx = deepspeed.zero.GatheredParameters(model.parameters(), enabled=deepspeed_stage_3)
+        with ctx:
             if is_rank_0:
-                for i, (name, param) in enumerate(params):
-                    all_refs.extend(
-                        _send_to_vllm(
-                            name, param, i == num_params - 1, deepspeed_stage, vllm_engines, model_update_group
-                        )
-                    )
+                return _broadcast_params_to_vllm(params, vllm_engines, model_update_group, name_mapper)
+            return []
     else:
+        all_refs: list[ray.ObjectRef] = []
+        num_params = len(params)
         for i, (name, param) in enumerate(params):
-            with deepspeed.zero.GatheredParameters([param], enabled=deepspeed_stage == 3):
+            with deepspeed.zero.GatheredParameters([param], enabled=deepspeed_stage_3):
                 if is_rank_0:
+                    mapped_name = name_mapper(name) if name_mapper else name
+                    shape = getattr(param, "ds_shape", param.shape)
                     all_refs.extend(
-                        _send_to_vllm(
-                            name, param, i == num_params - 1, deepspeed_stage, vllm_engines, model_update_group
-                        )
+                        _send_to_vllm(mapped_name, param, shape, i == num_params - 1, vllm_engines, model_update_group)
                     )
-
-    return all_refs
+        return all_refs


### PR DESCRIPTION
Adds callbacks for GRPO training with OLMo-core's Trainer:
- `VLLMWeightSyncCallback`: syncs weights to vLLM engines after each step
- `RefPolicyUpdateCallback`: Polyak averaging for reference policy updates

Based on PR #1412 (GRPOTrainModule)

GPU_TESTS=[01KFKCWJQKNEB71EZSA93XRKWF](https://beaker.org/orgs/ai2/workspaces/open-instruct-dev/work/01KFY0HAY4NGENR6XGA3Q0VPCS?taskId=01KFY0HAY99NJWX6EZFTGZ98KM&jobId=01KFY2M70ZKT2VEYZ8QK0GVMEC)