### PR TITLE
Fix argparse conflict for --save_traces argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 - Now, `large_test_script.sh` exercises the `tp > 1` code path (https://github.com/allenai/open-instruct/pull/1413).
 
 ### Fixed
-- Fixed argparse conflict error for `--save_traces` by removing duplicate field definitions from `StreamingDataLoaderConfig` (https://github.com/allenai/open-instruct/pull/XXXX).
+- Fixed argparse conflict error for `--save_traces` by removing duplicate field definitions from `StreamingDataLoaderConfig` (https://github.com/allenai/open-instruct/pull/1416).
 - Increased `MetricsTracker` max_metrics from 64 to 512 to fix `ValueError: Exceeded maximum number of metrics` when training with many tools or verifier functions (https://github.com/allenai/open-instruct/pull/1415).
 - Fixed JSON serialization error in `LocalDatasetTransformationCache.save_config` when caching datasets locally (https://github.com/allenai/open-instruct/pull/1402).
 - Now, we can support PRs from external contributors while still maintaining security for internal tokens (https://github.com/allenai/open-instruct/pull/1408).

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -353,8 +353,9 @@ class StreamingDataLoaderConfig:
     non_stop_penalty: bool = False
     non_stop_penalty_value: float = 0.0
 
-    # Rollout saving - these fields are set dynamically from ExperimentConfig to avoid argparse conflicts
-    # Do not define them here; they are set in grpo_fast.py: streaming_config.save_traces = args.save_traces
+    # Rollout saving
+    save_traces: bool = False
+    rollouts_save_path: str = "/weka/oe-adapt-default/allennlp/deletable_rollouts/"
 
     # Computed at post_init
     max_possible_score: float = 1.0
@@ -397,6 +398,9 @@ class StreamingDataLoaderConfig:
             self.max_possible_score += self.verification_reward
         if self.apply_r1_style_format_reward and self.additive_format_reward:
             self.max_possible_score += self.r1_style_format_reward
+
+        if self.save_traces and not self.rollouts_save_path:
+            raise ValueError("`rollouts_save_path` must be provided when `save_traces` is True.")
 
     def build_dataloader(
         self,

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2104,10 +2104,6 @@ def main(
 ):
     tokenizer = make_tokenizer(tc, model_config)
     args = setup_runtime_variables(args, streaming_config, tools_config)
-
-    streaming_config.save_traces = args.save_traces
-    streaming_config.rollouts_save_path = args.rollouts_save_path
-
     validate_configs(streaming_config, vllm_config, tuple(args.num_learners_per_node), args.sequence_parallel_size)
 
     if args.verbose:

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -135,10 +135,6 @@ class ExperimentConfig:
     """The url of the saved model in the Hugging Face Hub (will be autoset)"""
     output_dir: str = "output"
     """Where to save the model"""
-    save_traces: bool = False
-    """Whether to save learning data traces"""
-    rollouts_save_path: str = "/weka/oe-adapt-default/allennlp/deletable_rollouts/"
-    """Path to save rollouts (local/weka dir or gs:// path). Requires save_traces=True."""
     cache_dataset_only: bool = False
     """Immediately exit after caching the dataset"""
     keep_last_n_checkpoints: int = 3
@@ -219,5 +215,3 @@ class ExperimentConfig:
                 "When load_ref_policy=False, beta must be 0.0. "
                 f"Got beta={self.beta}. Set --beta 0.0 or --load_ref_policy to use KL penalty."
             )
-        if self.save_traces and not self.rollouts_save_path:
-            raise ValueError("`rollouts_save_path` must be provided when `save_traces` is True.")

--- a/open_instruct/test_data_loader.py
+++ b/open_instruct/test_data_loader.py
@@ -7,7 +7,6 @@ import parameterized
 import torch
 
 import open_instruct.data_loader
-import open_instruct.grpo_utils
 
 
 def single_example_collator(examples: list[dict]) -> dict:
@@ -350,17 +349,17 @@ class TestHFDataLoader(unittest.TestCase):
             loader.global_num_tokens_in_batch(batch_without_tokens)
 
 
-class TestExperimentConfigSaveTraces(unittest.TestCase):
+class TestStreamingDataLoaderConfigSaveTraces(unittest.TestCase):
     def test_save_traces_requires_rollouts_save_path(self):
         """Test that save_traces=True with empty rollouts_save_path raises ValueError."""
         with self.assertRaises(ValueError) as context:
-            open_instruct.grpo_utils.ExperimentConfig(save_traces=True, rollouts_save_path="")
+            open_instruct.data_loader.StreamingDataLoaderConfig(save_traces=True, rollouts_save_path="")
         self.assertIn("rollouts_save_path", str(context.exception))
         self.assertIn("save_traces", str(context.exception))
 
     def test_save_traces_with_valid_path_succeeds(self):
         """Test that save_traces=True with valid path succeeds."""
-        config = open_instruct.grpo_utils.ExperimentConfig(
+        config = open_instruct.data_loader.StreamingDataLoaderConfig(
             save_traces=True, rollouts_save_path="/tmp/rollouts"
         )
         self.assertTrue(config.save_traces)


### PR DESCRIPTION
## Summary
- Fixes argparse conflict error: `argument --save_traces/--save-traces: conflicting option strings`
- The `save_traces` and `rollouts_save_path` fields were defined in both `ExperimentConfig` and `StreamingDataLoaderConfig`, causing a conflict when both dataclasses are parsed together by `ArgumentParserPlus`

## Changes
- Just have save_traces in the dataloader config only, since thats where the logic lives.