### PR TITLE
Add automatic type coercion for tool arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Now, `large_test_script.sh` exercises the `tp > 1` code path (https://github.com/allenai/open-instruct/pull/1413).
 
 ### Fixed
+- Added automatic type coercion for tool arguments via `safe_execute()` - prevents crashes when models send wrong types (e.g., bool instead of string) (https://github.com/allenai/open-instruct/pull/1418).
 - Fixed argparse conflict error for `--save_traces` by removing duplicate field definitions from `StreamingDataLoaderConfig` (https://github.com/allenai/open-instruct/pull/1416).
 - Increased `MetricsTracker` max_metrics from 64 to 512 to fix `ValueError: Exceeded maximum number of metrics` when training with many tools or verifier functions (https://github.com/allenai/open-instruct/pull/1415).
 - Fixed JSON serialization error in `LocalDatasetTransformationCache.save_config` when caching datasets locally (https://github.com/allenai/open-instruct/pull/1402).

--- a/open_instruct/tools/generic_mcp.py
+++ b/open_instruct/tools/generic_mcp.py
@@ -112,7 +112,7 @@ class GenericMCPTool(Tool):
         """Return the tool's parameter schema from MCP."""
         return self._tool_info.get("input_schema", {"type": "object", "properties": {}})
 
-    async def execute(self, **kwargs: Any) -> ToolOutput:
+    async def _execute(self, **kwargs: Any) -> ToolOutput:
         """Call the MCP tool with retry logic."""
         if self.tool_name is None:
             raise ValueError("tool_name must be set before execute")

--- a/open_instruct/tools/tools.py
+++ b/open_instruct/tools/tools.py
@@ -54,7 +54,7 @@ class PythonCodeTool(Tool):
         self.api_endpoint = api_endpoint
         self.timeout = timeout
 
-    async def execute(self, code: str) -> ToolOutput:
+    async def _execute(self, code: str) -> ToolOutput:
         """Execute Python code via the API."""
         if not code or not code.strip():
             result = ToolOutput(
@@ -128,7 +128,7 @@ class JinaBrowseTool(Tool):
         if not self.api_key:
             raise ValueError("Missing JINA_API_KEY environment variable.")
 
-    async def execute(self, url: str) -> ToolOutput:
+    async def _execute(self, url: str) -> ToolOutput:
         """Fetch webpage content via Jina Reader API."""
         if not url or not url.strip():
             result = ToolOutput(
@@ -214,7 +214,7 @@ class S2SearchTool(Tool):
         if not self.api_key:
             raise ValueError("Missing S2_API_KEY environment variable.")
 
-    async def execute(self, query: str) -> ToolOutput:
+    async def _execute(self, query: str) -> ToolOutput:
         """Search Semantic Scholar for documents matching the query."""
         if not query or not query.strip():
             result = ToolOutput(
@@ -289,7 +289,7 @@ class SerperSearchTool(Tool):
         if not self.api_key:
             raise ValueError("Missing SERPER_API_KEY environment variable.")
 
-    async def execute(self, query: str) -> ToolOutput:
+    async def _execute(self, query: str) -> ToolOutput:
         """Search Google via Serper for documents matching the query."""
         if not query or not query.strip():
             result = ToolOutput(
@@ -441,7 +441,7 @@ class Crawl4AIBrowseTool(Tool):
         with open(blocklist_path, encoding="utf-8") as f:
             self.blocklist = [line.strip() for line in f if line.strip()]
 
-    async def execute(self, url: str) -> ToolOutput:
+    async def _execute(self, url: str) -> ToolOutput:
         """Fetch webpage content via Crawl4AI Docker API."""
         if not url or not url.strip():
             result = ToolOutput(
@@ -557,7 +557,7 @@ class DrAgentMCPTool(Tool):
     def get_stop_strings(self) -> list[str]:
         return self.stop_strings
 
-    async def execute(self, text: str) -> ToolOutput:
+    async def _execute(self, text: str) -> ToolOutput:
         if not text or not text.strip():
             return ToolOutput(output="", error="Empty input", called=True, timeout=False, runtime=0)
 

--- a/open_instruct/tools/utils.py
+++ b/open_instruct/tools/utils.py
@@ -3,6 +3,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 
@@ -357,6 +358,55 @@ def get_openai_tool_definitions(tool: "Tool") -> dict[str, Any]:
     }
 
 
+def _coerce_bool(value: Any) -> bool:
+    """Coerce a value to boolean, handling string 'true'/'false' correctly."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        raise ValueError(f"Cannot coerce '{value}' to boolean")
+    return bool(value)
+
+
+# JSON schema type to Python coercion function
+_COERCERS: dict[str, Callable[[Any], Any]] = {
+    "string": str,
+    "number": float,
+    "integer": int,
+    "boolean": _coerce_bool,
+    "array": list,
+    "object": dict,
+}
+
+
+def coerce_args(properties: dict[str, Any], kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Coerce arguments to match the expected types in a JSON schema properties dict.
+
+    Args:
+        properties: The "properties" dict from a JSON schema.
+        kwargs: The keyword arguments to coerce.
+
+    Returns:
+        A new dict with coerced values.
+
+    Raises:
+        ValueError or TypeError if coercion fails.
+    """
+    coerced = dict(kwargs)
+    for name, value in kwargs.items():
+        if name not in properties:
+            continue
+        expected_type = properties[name].get("type")
+        if expected_type not in _COERCERS:
+            continue
+        coerced[name] = _COERCERS[expected_type](value)
+    return coerced
+
+
 class Tool(ABC):
     config_name: str
     """Name used to specify the tool in the CLI."""
@@ -395,13 +445,27 @@ class Tool(ABC):
         return get_openai_tool_definitions(self)
 
     @abstractmethod
-    async def execute(self, *args: Any, **kwargs: Any) -> ToolOutput:
-        """Execute the tool, must be implemented by subclasses."""
-        raise NotImplementedError("execute must be implemented by subclasses.")
+    async def _execute(self, *args: Any, **kwargs: Any) -> ToolOutput:
+        """Execute the tool. Must be implemented by subclasses."""
+        raise NotImplementedError("_execute must be implemented by subclasses.")
+
+    async def safe_execute(self, *args: Any, **kwargs: Any) -> ToolOutput:
+        """Coerce arguments and execute the tool.
+
+        This method coerces kwargs to match the tool's parameter schema types
+        before calling _execute(). Use this instead of _execute() when you want
+        automatic type coercion (e.g., when calling from Ray actors).
+        """
+        try:
+            properties = self.parameters.get("properties", {})
+            coerced_kwargs = coerce_args(properties, kwargs)
+        except (ValueError, TypeError) as e:
+            return ToolOutput(output="", error=f"Incorrect type: {e}", called=False, timeout=False, runtime=0)
+        return await self._execute(*args, **coerced_kwargs)
 
     async def __call__(self, *args: Any, **kwargs: Any) -> ToolOutput:
-        """Alias for execute, useful for inference scripts."""
-        return await self.execute(*args, **kwargs)
+        """Alias for safe_execute, useful for inference scripts."""
+        return await self.safe_execute(*args, **kwargs)
 
 
 @dataclass

--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -939,7 +939,9 @@ async def process_request(actor: LLMRayActor, sub_request_id: str, sampling_para
                 continue
 
             try:
-                tool_result: ToolOutput = await actor.tool_actor_map[tool_call.name].execute.remote(**tool_call.args)
+                tool_result: ToolOutput = await actor.tool_actor_map[tool_call.name].safe_execute.remote(
+                    **tool_call.args
+                )
             except TypeError as e:
                 # This can happen if the model generated a tool call with missing/wrong arguments
                 error_msg = f"Tool call '{tool_call.name}' failed: {e}. Args received: {tool_call.args}"


### PR DESCRIPTION
Adds safe_execute() method to Tool base class that coerces arguments to expected types based on JSON schema before calling execute(). This prevents crashes when models send wrong types (e.g. bool instead of string), and if the value can't be coerced, then we simply return the error to the model.