### PR TITLE
Adds a `mason.py` version of the SFT tokenization script. 

### DIFF
--- a/scripts/train/olmo3/7b-hybrid-sft-tokenization.sh
+++ b/scripts/train/olmo3/7b-hybrid-sft-tokenization.sh
@@ -32,7 +32,7 @@ uv run python mason.py \
          allenai/olmo-toolu-s2-sft-m5v2-thinking-id-fixed 3.0 \
          allenai/olmo-toolu_deepresearch_thinking_DRv4-modified-system-prompts 3.0 \
       --tokenizer_name_or_path $tokenizer_path \
-      --output_dir /weka/oe-adapt-default/nathanl/dataset/olmo-hybrid \
+      --output_dir /weka/oe-adapt-default/${BEAKER_USER}/dataset/olmo-hybrid \
       --visualize True \
       --chat_template_name "olmo123" \
       --max_seq_length 32768


### PR DESCRIPTION
Hopefully we don't have to do this too much longer! When https://github.com/allenai/open-instruct/pull/1327 is merged, we won't have a separate tokenization step (well, we will, but it'll be automated). 

Successful run: [Beaker](https://beaker.org/orgs/ai2/workspaces/olmo-instruct/work/01KG009HP80X0PKK3S11BMA0DX?taskId=01KG009HPDVRN34HV1RC99HFH2&jobId=01KG009HSZ4YTVK23S8GB5X3Z3). 