### PR TITLE
Replace deprecated wandb.get_url() usages with run.url

### DIFF
--- a/open_instruct/beaker_callback.py
+++ b/open_instruct/beaker_callback.py
@@ -91,7 +91,7 @@ class BeakerCallbackV2(Callback):
     def _get_tracking_url(self) -> str | None:
         for callback in self.trainer.callbacks.values():
             if isinstance(callback, WandBCallback) and callback.enabled and callback.run is not None:
-                return callback.run.get_url()
+                return callback.run.url
             elif isinstance(callback, CometCallback) and callback.enabled and callback.exp is not None:
                 return callback.exp.url
         return None

--- a/open_instruct/dpo.py
+++ b/open_instruct/dpo.py
@@ -271,7 +271,7 @@ def _handle_post_training(
         if args.with_tracking:
             wandb_tracker = trainer_callbacks.get("wandb")
             if wandb_tracker is not None and hasattr(wandb_tracker, "run") and wandb_tracker.run is not None:
-                wandb_url = wandb_tracker.run.get_url()
+                wandb_url = wandb_tracker.run.url
         if args.hf_repo_revision is not None:
             eval_path = hf_model_path
             if beaker_config is not None and beaker_config.beaker_dataset_ids:

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -214,7 +214,7 @@ def main(args: dpo_utils.ExperimentConfig, tc: TokenizerConfig):
     if args.with_tracking:
         wandb_tracker = accelerator.get_tracker("wandb")
         if accelerator.is_main_process:
-            maybe_update_beaker_description(wandb_url=wandb_tracker.run.get_url())
+            maybe_update_beaker_description(wandb_url=wandb_tracker.run.url)
     else:
         wandb_tracker = None
 
@@ -676,7 +676,7 @@ def main(args: dpo_utils.ExperimentConfig, tc: TokenizerConfig):
                             current_step=completed_steps,
                             total_steps=args.max_train_steps,
                             start_time=start_time,
-                            wandb_url=None if wandb_tracker is None else wandb_tracker.run.get_url(),
+                            wandb_url=None if wandb_tracker is None else wandb_tracker.run.url,
                         )
                     # Reset the local metrics
                     local_metrics.metrics.zero_()
@@ -732,7 +732,7 @@ def main(args: dpo_utils.ExperimentConfig, tc: TokenizerConfig):
             path=args.output_dir,
             leaderboard_name=args.hf_repo_revision,
             oe_eval_max_length=args.oe_eval_max_length,
-            wandb_url=wandb_tracker.run.get_url() if args.with_tracking else None,
+            wandb_url=wandb_tracker.run.url if args.with_tracking else None,
             oe_eval_tasks=args.oe_eval_tasks,
             gs_bucket_path=args.gs_bucket_path,
             eval_workspace=args.eval_workspace,

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -440,7 +440,7 @@ def main(args: FlatArguments, tc: TokenizerConfig):
             },
         )
         wandb_tracker = accelerator.get_tracker("wandb")
-        maybe_update_beaker_description(wandb_url=wandb_tracker.run.get_url())
+        maybe_update_beaker_description(wandb_url=wandb_tracker.run.url)
     else:
         wandb_tracker = None  # for later eval launching
 
@@ -892,7 +892,7 @@ def main(args: FlatArguments, tc: TokenizerConfig):
                         current_step=completed_steps,
                         total_steps=args.max_train_steps,
                         start_time=start_time,
-                        wandb_url=wandb_tracker.run.get_url() if wandb_tracker is not None else None,
+                        wandb_url=wandb_tracker.run.url if wandb_tracker is not None else None,
                     )
                     total_loss = 0
                     total_aux_loss = 0
@@ -946,7 +946,7 @@ def main(args: FlatArguments, tc: TokenizerConfig):
             path=args.output_dir,
             leaderboard_name=args.hf_repo_revision,
             oe_eval_max_length=args.oe_eval_max_length,
-            wandb_url=wandb_tracker.run.get_url() if wandb_tracker is not None else None,
+            wandb_url=wandb_tracker.run.url if wandb_tracker is not None else None,
             oe_eval_tasks=args.oe_eval_tasks,
             gs_bucket_path=args.gs_bucket_path,
         )

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1149,7 +1149,7 @@ def setup_experiment_tracking(args: grpo_utils.ExperimentConfig, tc: TokenizerCo
             save_code=True,
             tags=[args.exp_name] + get_wandb_tags(),
         )
-        wandb_url = wandb.run.get_url()
+        wandb_url = wandb.run.url
         maybe_update_beaker_description(wandb_url=wandb_url)
 
     return beaker_config, wandb_url
@@ -1367,7 +1367,7 @@ def create_model_and_optimizer(
     # Create policy group and start model loading BEFORE vLLM engines (matches main branch order).
     # This ensures policy trainer actors are scheduled first, which affects how Ray schedules
     # the vLLM placement group and prevents port collisions during vLLM initialization.
-    wandb_url = wandb.run.get_url() if args.with_tracking else None
+    wandb_url = wandb.run.url if args.with_tracking else None
     policy_group = ModelGroup(
         pg,
         PolicyTrainerRayProcess,


### PR DESCRIPTION
### Motivation

- Remove deprecation warnings from Weights & Biases by replacing the deprecated `get_url()` accessor with the supported `run.url` attribute in the training and tracking flows.

### Description

- Replaced all occurrences of `callback.run.get_url()` / `wandb_tracker.run.get_url()` / `wandb.run.get_url()` with the `run.url` attribute across tracking and post-train logic.
- Updated `BeakerCallbackV2._get_tracking_url` to return `callback.run.url` for W&B callbacks and preserved Comet handling.
- Updated calls that pass W&B URLs into `maybe_update_beaker_description` and evaluation-launch helpers in `finetune.py`, `grpo_fast.py`, `dpo_tune_cache.py`, and `dpo.py` so they use `.run.url` consistently.
- No functional changes beyond using the supported W&B API property; behavior of description updates and eval launches is unchanged.

### Testing

- Ran code style and quality checks with `make style && make quality`, which completed successfully.
- Ran the full test suite with `uv run pytest`, resulting in `495 passed, 6 skipped` and no test failures.
- Ran the single GPU GRPO script: [Beaker](https://beaker.org/orgs/ai2/workspaces/open-instruct-dev/work/01KG5D8GKS1K5REDA98ME8M8BC?taskId=01KG5D8GM0GT060H4CVC0S21W2&jobId=01KG5D8GQKPY6BSP431DYZ4EAS)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697b900d51fc832dbff1125770bc1b70)