### PR TITLE
Add PerfCallback and rename beaker_callback to olmo_core_callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
+- PerfCallback for MFU metrics in OLMo-core DPO training (https://github.com/allenai/open-instruct/pull/1442).
 - NVIDIA H200 GPU support in `GPU_SPECS` (https://github.com/allenai/open-instruct/pull/1441).
 - Documentation and runtime warning for `dataset_mixer_list` format (float=proportion, int=count) (https://github.com/allenai/open-instruct/pull/1434).
 

--- a/open_instruct/dpo.py
+++ b/open_instruct/dpo.py
@@ -31,7 +31,7 @@ from olmo_core.train.train_module.transformer import (
 
 from open_instruct import data_loader as data_loader_lib
 from open_instruct import dataset_transformation, dpo_utils, logger_utils, model_utils, olmo_core_utils, utils
-from open_instruct.beaker_callback import BeakerCallbackV2
+from open_instruct.olmo_core_callbacks import BeakerCallbackV2, PerfCallback
 from open_instruct.olmo_core_train_modules import DPOTrainModule
 from open_instruct.padding_free_collator import TensorDataCollatorWithFlatteningDPO
 
@@ -211,7 +211,7 @@ def _setup_optimizer_and_scheduler(args: dpo_utils.ExperimentConfig, model, num_
     return optim, scheduler
 
 
-def _setup_callbacks(args: dpo_utils.ExperimentConfig, model):
+def _setup_callbacks(args: dpo_utils.ExperimentConfig, model, dp_world_size: int):
     """Return callbacks dict."""
     json_config = dpo_utils.config_to_json_serializable(vars(args))
     trainer_callbacks: dict[str, callbacks.Callback] = {"beaker": BeakerCallbackV2(config=json_config)}
@@ -235,6 +235,13 @@ def _setup_callbacks(args: dpo_utils.ExperimentConfig, model):
         )
     checkpointing_steps = int(args.checkpointing_steps)
     trainer_callbacks["checkpointer"] = CheckpointerCallback(save_interval=checkpointing_steps, save_async=False)
+    model_dims = utils.ModelDims.from_hf_config(args.model_name_or_path)
+    trainer_callbacks["perf"] = PerfCallback(
+        model_dims=model_dims,
+        per_device_train_batch_size=args.per_device_train_batch_size,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        num_training_gpus=dp_world_size,
+    )
     return trainer_callbacks
 
 
@@ -271,7 +278,7 @@ def _handle_post_training(
         if args.with_tracking:
             wandb_tracker = trainer_callbacks.get("wandb")
             if wandb_tracker is not None and hasattr(wandb_tracker, "run") and wandb_tracker.run is not None:
-                wandb_url = wandb_tracker.run.url
+                wandb_url = wandb_tracker.run.get_url()
         if args.hf_repo_revision is not None:
             eval_path = hf_model_path
             if beaker_config is not None and beaker_config.beaker_dataset_ids:
@@ -447,7 +454,7 @@ def main(args: dpo_utils.ExperimentConfig, tc: dataset_transformation.TokenizerC
         max_grad_norm=max_grad_norm,
     )
 
-    trainer_callbacks = _setup_callbacks(args, model)
+    trainer_callbacks = _setup_callbacks(args, model, dp_world_size)
 
     trainer = train.TrainerConfig(
         save_folder=args.output_dir,

--- a/open_instruct/olmo_core_callbacks.py
+++ b/open_instruct/olmo_core_callbacks.py
@@ -1,6 +1,9 @@
-"""This module only exists because Olmo-core still uses Beaker v1, so we have to write our own BeakerCallback that works with v2.
+"""OLMo-core callbacks for training.
 
-This module will be deleted once Olmo-core switches to Beaker v2."""
+This module contains custom callbacks for OLMo-core training, including:
+- BeakerCallbackV2: Beaker v2 integration (will be deleted once OLMo-core switches to Beaker v2)
+- PerfCallback: MFU and tokens_per_second metrics calculation
+"""
 
 import json
 import os
@@ -17,7 +20,7 @@ from olmo_core.train.callbacks.comet import CometCallback
 from olmo_core.train.callbacks.wandb import WandBCallback
 from olmo_core.train.common import TrainingProgress
 
-from open_instruct import logger_utils
+from open_instruct import logger_utils, utils
 from open_instruct.utils import maybe_update_beaker_description
 
 logger = logger_utils.setup_logger(__name__)
@@ -91,7 +94,7 @@ class BeakerCallbackV2(Callback):
     def _get_tracking_url(self) -> str | None:
         for callback in self.trainer.callbacks.values():
             if isinstance(callback, WandBCallback) and callback.enabled and callback.run is not None:
-                return callback.run.url
+                return callback.run.get_url()
             elif isinstance(callback, CometCallback) and callback.enabled and callback.exp is not None:
                 return callback.exp.url
         return None
@@ -113,3 +116,67 @@ class BeakerCallbackV2(Callback):
             start_time=self._start_time,
             wandb_url=self._url,
         )
+
+
+@dataclass
+class PerfCallback(Callback):
+    """Calculates MFU and tokens_per_second using same formula as dpo_tune_cache.py."""
+
+    model_dims: utils.ModelDims
+    per_device_train_batch_size: int
+    gradient_accumulation_steps: int
+    num_training_gpus: int
+
+    _start_time: float = field(default=0.0, repr=False)
+    _interval_start_time: float = field(default=0.0, repr=False)
+    _total_tokens_processed: int = field(default=0, repr=False)
+    _last_step: int = field(default=0, repr=False)
+
+    def pre_train(self) -> None:
+        self._start_time = time.perf_counter()
+        self._interval_start_time = self._start_time
+        self._total_tokens_processed = 0
+        self._last_step = 0
+
+    def post_step(self) -> None:
+        if self.step % self.trainer.metrics_collect_interval != 0:
+            return
+        if self.step == self._last_step:
+            return
+
+        token_count_metric = self.trainer.get_metric("train/token_count")
+        if token_count_metric is None:
+            return
+        total_tokens_step = int(token_count_metric.item())
+
+        interval_end = time.perf_counter()
+        training_time = interval_end - self._interval_start_time
+        total_time_elapsed = interval_end - self._start_time
+
+        step_tokens_per_second = total_tokens_step / training_time if training_time > 0 else 0
+        self._total_tokens_processed += total_tokens_step
+        total_tokens_per_second = self._total_tokens_processed / total_time_elapsed
+
+        logging_steps = self.trainer.metrics_collect_interval
+        num_sequences = (
+            self.per_device_train_batch_size
+            * self.num_training_gpus
+            * self.gradient_accumulation_steps
+            * logging_steps
+            * 2  # * 2 for chosen + rejected
+        )
+        avg_sequence_length = total_tokens_step / num_sequences if num_sequences > 0 else 0
+
+        mfu_result = self.model_dims.approximate_learner_utilization(
+            total_tokens=total_tokens_step,
+            avg_sequence_length=avg_sequence_length,
+            training_time=training_time,
+            num_training_gpus=self.num_training_gpus,
+        )
+
+        self.trainer.record_metric("perf/mfu", mfu_result["mfu"], reduce_type=None)
+        self.trainer.record_metric("perf/tokens_per_second_step", step_tokens_per_second, reduce_type=None)
+        self.trainer.record_metric("perf/tokens_per_second_total", total_tokens_per_second, reduce_type=None)
+
+        self._interval_start_time = interval_end
+        self._last_step = self.step

--- a/open_instruct/test_olmo_core_callbacks.py
+++ b/open_instruct/test_olmo_core_callbacks.py
@@ -57,7 +57,7 @@ mock_callback.Callback = MockCallback
 sys.modules["olmo_core.train.callbacks.comet"].CometCallback = type("CometCallback", (), {"priority": 100})
 sys.modules["olmo_core.train.callbacks.wandb"].WandBCallback = type("WandBCallback", (), {"priority": 100})
 
-from open_instruct.beaker_callback import BeakerCallbackV2  # noqa: E402
+from open_instruct.olmo_core_callbacks import BeakerCallbackV2  # noqa: E402
 
 for _key in _MOCKED_MODULES:
     if _original_modules[_key] is None:
@@ -84,7 +84,7 @@ class TestBeakerCallbackPreTrain(unittest.TestCase):
         callback._trainer = trainer_mock
 
         with (
-            patch("open_instruct.beaker_callback.get_rank", return_value=0),
+            patch("open_instruct.olmo_core_callbacks.get_rank", return_value=0),
             patch.dict("os.environ", {"BEAKER_WORKLOAD_ID": "test-workload-123"}),
             patch("subprocess.run") as mock_subprocess,
         ):
@@ -113,7 +113,7 @@ class TestBeakerCallbackPreTrain(unittest.TestCase):
         callback._trainer = trainer_mock
 
         with (
-            patch("open_instruct.beaker_callback.get_rank", return_value=0),
+            patch("open_instruct.olmo_core_callbacks.get_rank", return_value=0),
             patch.dict("os.environ", {"BEAKER_WORKLOAD_ID": "test-workload-123"}),
             patch("subprocess.run"),
             patch.object(callback, "_get_tracking_url", return_value="https://wandb.ai/test/run/123"),
@@ -131,7 +131,7 @@ class TestBeakerCallbackPreTrain(unittest.TestCase):
         trainer_mock = Mock()
         callback._trainer = trainer_mock
 
-        with patch("open_instruct.beaker_callback.get_rank", return_value=0):
+        with patch("open_instruct.olmo_core_callbacks.get_rank", return_value=0):
             callback.pre_train()
 
         self.assertFalse(os.path.exists(f"{self.temp_dir.name}/olmo-core"))
@@ -160,7 +160,7 @@ class TestBeakerCallbackPostStep(unittest.TestCase):
         callback._step = step
 
         with (
-            patch("open_instruct.beaker_callback.get_rank", return_value=0),
+            patch("open_instruct.olmo_core_callbacks.get_rank", return_value=0),
             patch.object(callback, "_update") as mock_update,
         ):
             callback.post_step()
@@ -180,7 +180,7 @@ class TestBeakerCallbackPostTrain(unittest.TestCase):
         callback._trainer = trainer_mock
 
         with (
-            patch("open_instruct.beaker_callback.get_rank", return_value=0),
+            patch("open_instruct.olmo_core_callbacks.get_rank", return_value=0),
             patch.object(callback, "_update") as mock_update,
         ):
             callback.post_train()


### PR DESCRIPTION
## Summary
- Rename `beaker_callback.py` to `olmo_core_callbacks.py` with updated module docstring
- Add `PerfCallback` class for MFU and tokens_per_second metrics calculation
- Update imports in `dpo.py` and add `PerfCallback` instantiation in `_setup_callbacks()`
- Fix `wandb_tracker.run.url` to `wandb_tracker.run.get_url()`

**Note:** PerfCallback will be inactive until the `token_count` metric is recorded (it returns early if metric is None). This will be enabled by a future PR that adds microbatching support.

## Test plan
- [x] Run `make style && make quality`
- [x] Run `uv run pytest open_instruct/test_olmo_core_callbacks.py`

## Runs
- Single GPU DPO: [Beaker](https://beaker.org/ex/01KG8V29W2JCSHTAFGGXPPM5GT)
- Multi-node DPO: [Beaker](https://beaker.org/ex/01KG8V9VRGBCTR48X2HPMKPP0J)

🤖 Generated with [Claude Code](https://claude.com/claude-code)