### PR TITLE
Avoid sync CUDA transfer in data loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,6 @@ All notable changes to this project will be documented in this file.
 - Include tokenizer configuration in per-transform dataset cache fingerprints so rerunning transformations with a different tokenizer does not silently reuse stale cached outputs (https://github.com/allenai/open-instruct/pull/1518).
 - Fixed `grpo_fast` local eval rounds enqueueing 0 prompts after the first run by resetting `eval_data_loader` after each eval pass (stateful `DataLoaderBase` requires reset after epoch exhaustion); also switched eval prompt ID prefix from constant `0` to `training_step` to avoid cross-round metadata key collisions in vLLM request tracking (https://github.com/allenai/open-instruct/pull/1493).
 - Force `generation_config="vllm"` in vLLM engine kwargs to prevent model HF generation defaults from capping OpenAI request `max_tokens` (https://github.com/allenai/open-instruct/pull/1512).
-- Avoided synchronous CUDA transfers when moving batches to device (https://github.com/allenai/open-instruct/pull/0000).
+- Avoided synchronous CUDA transfers when moving batches to device (https://github.com/allenai/open-instruct/pull/1443).
 
 ### Removed

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -63,17 +63,7 @@ def to_device(batch: dict[str, Any], device: torch.device | None) -> dict[str, A
     """
     if device is None:
         return batch
-    moved: dict[str, Any] = {}
-    for key, value in batch.items():
-        if not isinstance(value, torch.Tensor):
-            moved[key] = value
-            continue
-        if value.device == device:
-            moved[key] = value
-            continue
-        non_blocking = device.type == "cuda" and value.device.type == "cpu"
-        moved[key] = value.to(device, non_blocking=non_blocking)
-    return moved
+    return {k: v.to(device, non_blocking=True) if isinstance(v, torch.Tensor) else v for k, v in batch.items()}
 
 
 class HFDataLoader(data_loader.DataLoaderBase):


### PR DESCRIPTION
### Motivation
- Prevent the runtime warning about synchronizing CUDA operations when moving batch tensors to the device by avoiding redundant transfers and enabling non-blocking device moves.

### Description
- Change `to_device` in `open_instruct/data_loader.py` to skip non-tensor entries, avoid re-moving tensors already on the target device, and use `non_blocking=True` when moving CPU tensors to a CUDA device; also add a changelog entry referencing this PR (`https://github.com/allenai/open-instruct/pull/0000`).

### Testing
- Ran `make style && make quality` which passed, and `uv run pytest` which finished with `495 passed, 6 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697d3f1946a0832d8107cbd0f0b2bdbc)