### PR TITLE
Clarify activation checkpointing budget guidance in DPO config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Documentation and runtime warning for `dataset_mixer_list` format (float=proportion, int=count) (https://github.com/allenai/open-instruct/pull/1434).
 
 ### Changed
+- Clarified `activation_memory_budget` guidance in DPO utils with a practical default (`0.5`) and memory/speed tradeoff notes (https://github.com/allenai/open-instruct/pull/1460).
 - Let TransformerTrainModule handle FSDP parallelism instead of manual application in DPO (https://github.com/allenai/open-instruct/pull/1458).
 - Refactored DPOTrainModule to inherit from TransformerTrainModule (https://github.com/allenai/open-instruct/pull/1456)
 - Increased vLLM health check timeout from 30s to 600s (10 minutes) (https://github.com/allenai/open-instruct/pull/1452).

--- a/open_instruct/dpo_utils.py
+++ b/open_instruct/dpo_utils.py
@@ -145,7 +145,13 @@ class TrainingConfig:
     max_train_steps: int | None = None
     """If set, overrides the number of training steps. Otherwise, num_epochs is used."""
     activation_memory_budget: float = 1.0
-    """Memory budget for activation checkpointing (0.0-1.0). 1.0 disables checkpointing (default), values < 1.0 enable budget-mode checkpointing. See: https://pytorch.org/blog/activation-checkpointing-techniques/."""
+    """Memory budget for activation checkpointing (0.0-1.0).
+
+    A practical "just turn it on" default is `0.5` (somewhat arbitrary, but works well in practice):
+    any value < 1.0 enables budget-mode checkpointing. Higher values use more memory and are
+    typically faster; lower values use less memory and are typically slower, so use the highest
+    value your hardware can support. See: https://pytorch.org/blog/activation-checkpointing-techniques/.
+    """
     use_8bit_optimizer: bool = False
     """Use 8bit optimizer from bitsandbytes."""
     dpo_use_paged_optimizer: bool = False


### PR DESCRIPTION
### Motivation
- Clarify the intent and a practical default for `activation_memory_budget` so users know how to enable budget-mode checkpointing and understand the memory/speed tradeoff.

### Description
- Updated the `activation_memory_budget` docstring in `open_instruct/dpo_utils.py` to recommend a practical "turn it on" default of `0.5`, note that any value `< 1.0` enables budget-mode checkpointing, and explain that higher values use more memory and are typically faster while lower values use less memory and are typically slower; added a `CHANGELOG.md` entry referencing this PR (`#1460`).

### Testing
- Ran `make style && make quality`, which succeeded.
- Ran `uv run pytest open_instruct/test_dpo_utils.py`, which completed successfully (`11 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6984df1b0bc0832d855b5aa0f9a9156d)