### PR TITLE
add user_prompt_transform to allow easy formatting of prefix, suffix of prompts

### DIFF
--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -197,7 +197,10 @@ def setup_dataset(
 
     # Transform function arguments
     transform_fn_args = [
-        {},  # For rlvr_tokenize_v1
+        {
+            "system_prompt_override": None,
+            "user_prompt_transform": streaming_config.user_prompt_transform,
+        },  # For rlvr_tokenize_v1
         {"max_prompt_token_length": streaming_config.max_prompt_token_length},  # For rlvr_filter_v1
     ]
 

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -319,6 +319,7 @@ class StreamingDataLoaderConfig:
     dataset_mixer_list_splits: list[str] = field(default_factory=lambda: ["train"])
     dataset_mixer_eval_list_splits: list[str] = field(default_factory=lambda: ["test"])
     dataset_transform_fn: list[str] = field(default_factory=lambda: ["rlvr_tokenize_v1", "rlvr_max_length_filter_v1"])
+    user_prompt_transform: str | None = None
     dataset_cache_mode: Literal["hf", "local"] = "local"
     dataset_local_cache_dir: str = "local_dataset_cache"
     dataset_config_hash: str | None = None

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1410,6 +1410,7 @@ def rlvr_tokenize_v3(
     ground_truths_key: str = GROUND_TRUTHS_KEY,
     verifier_source_key: str = VERIFIER_SOURCE_KEY,
     system_prompt_override: str | None = None,
+    user_prompt_transform: str | None = None,
     tool_definitions: list[dict[str, Any]] | None = None,
     pass_tools_to_chat_template: bool = True,
 ):
@@ -1434,6 +1435,14 @@ def rlvr_tokenize_v3(
                 tools_for_template = filtered_tools
         else:
             tools_for_template = tool_definitions
+
+    if user_prompt_transform:
+        for message in reversed(prompt):
+            if message.get("role") != "user":
+                continue
+            content = message.get("content") or ""
+            message["content"] = user_prompt_transform.format(prompt=content)
+            break
 
     row[INPUT_IDS_PROMPT_KEY] = tokenizer.apply_chat_template(
         prompt,

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1115,6 +1115,7 @@ def setup_datasets(
     transform_fn_args = [
         {
             "system_prompt_override": system_prompt_override,
+            "user_prompt_transform": streaming_config.user_prompt_transform,
             "tool_definitions": tool_definitions,
             "pass_tools_to_chat_template": pass_tools_to_chat_template,
         },


### PR DESCRIPTION
## Summary
- Creates a dedicated branch containing only the open_instruct/*.py changes from smolzero
- Preserves the top-level Python file edits/additions/deletions for isolated review

## Validation
- make style
- make quality (fails on unresolved import because nested open_instruct/tools/*.py changes were intentionally excluded by scope)
- uv run pytest -q open_instruct/test_utils.py
