### PR TITLE
Fix eval_on_step_0 never working in grpo_fast

### DIFF
--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1897,9 +1897,11 @@ def run_training(
         health_check_time = time.perf_counter() - health_check_start
 
         if (
-            training_step % args.local_eval_every == 0
-            and eval_data_loader is not None
-            and (args.eval_on_step_0 or training_step > 1)
+            eval_data_loader is not None
+            and (
+                (args.eval_on_step_0 and training_step == resume_training_step)
+                or (training_step % args.local_eval_every == 0 and training_step > 1)
+            )
         ):
             if not last_eval_collected:
                 logger.warning(


### PR DESCRIPTION
The training loop starts at `training_step=1` (no step 0). The old condition required `training_step % local_eval_every == 0`, so with `eval_on_step_0=True` and `local_eval_every > 1`, evaluation never ran on step 1.

Fix: Run evaluation when `eval_on_step_0=True` and `training_step == resume_training_step`, independent of `local_eval_every`.