### PR TITLE
RLVR: fixing logprob divergence

### DIFF
--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -655,6 +655,11 @@ def accumulate_inference_batches(
         )
 
         example = dataset[result.index]
+        assert example["index"] == result.index, (
+            f"Dataset index mismatch: dataset[{result.index}] has index column value "
+            f"{example['index']}. This usually means the dataset was shuffled without "
+            f"re-indexing."
+        )
         query = example[INPUT_IDS_PROMPT_KEY]
         ground_truth = example[GROUND_TRUTHS_KEY]
         dataset_name = example[VERIFIER_SOURCE_KEY]

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1137,6 +1137,8 @@ def setup_datasets(
     _validate_and_log_dataset_tools(train_dataset, configured_tool_call_names, "train_dataset")
     train_dataset = train_dataset.shuffle(seed=args.seed)
 
+    train_dataset = train_dataset.remove_columns(["index"]).add_column("index", list(range(len(train_dataset))))
+
     if len(streaming_config.dataset_mixer_eval_list) > 0:
         eval_dataset = get_cached_dataset_tulu(
             dataset_mixer_list=streaming_config.dataset_mixer_eval_list,
@@ -1155,6 +1157,7 @@ def setup_datasets(
         _validate_and_log_dataset_tools(eval_dataset, configured_tool_call_names, "eval_dataset")
         if streaming_config.shuffle_eval_dataset:
             eval_dataset = eval_dataset.shuffle(seed=args.seed)
+            eval_dataset = eval_dataset.remove_columns(["index"]).add_column("index", list(range(len(eval_dataset))))
     else:
         eval_dataset = None
 


### PR DESCRIPTION
fix data indexing, leading to a mismatch between prompt-responses, and thus to logprob divergence between trainer and actor during GRPO with RLVR. (Issue #1473 )