### PR TITLE
Refactor Legacy and DRTulu parsers to use tool_definitions instead of tool_actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Documentation and runtime warning for `dataset_mixer_list` format (float=proportion, int=count) (https://github.com/allenai/open-instruct/pull/1434).
 
 ### Changed
+- Refactor Legacy and DRTulu tool parsers to use OpenAI-format `tool_definitions` instead of Ray `tool_actors`. Removes `import ray` from `parsers.py`, fixes DRTulu parser which was broken after the pool refactor, and fixes `--tool_parser_type` typo in dr_tulu debug script (https://github.com/allenai/open-instruct/pull/1491).
 - Replaces lambda collators with a "single_example_collator" (https://github.com/allenai/open-instruct/pull/1472).
 - Clarified `activation_memory_budget` guidance in DPO utils with a practical default (`0.5`) and memory/speed tradeoff notes (https://github.com/allenai/open-instruct/pull/1460).
 - Let TransformerTrainModule handle FSDP parallelism instead of manual application in DPO (https://github.com/allenai/open-instruct/pull/1458).

--- a/open_instruct/environments/tools/parsers.py
+++ b/open_instruct/environments/tools/parsers.py
@@ -18,7 +18,6 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-import ray
 from transformers import PreTrainedTokenizer, PreTrainedTokenizerFast
 from vllm.entrypoints.openai.protocol import ChatCompletionRequest
 from vllm.tool_parsers import ToolParser as VllmNativeToolParser
@@ -55,14 +54,11 @@ class OpenInstructLegacyToolParser(ToolParser):
     Tools are invoked via <tool_name>content</tool_name> tags.
     The content between tags is passed to the tool's first required parameter.
     Only works for tools that take a single string parameter.
+
+    Tool names and parameter names are derived from OpenAI-format tool definitions.
     """
 
-    def __init__(
-        self,
-        tool_actors: list[ray.actor.ActorHandle] | None = None,
-        output_wrap_name: str = "output",
-        tool_definitions: list[dict[str, Any]] | None = None,
-    ):
+    def __init__(self, tool_definitions: list[dict[str, Any]] | None = None, output_wrap_name: str = "output"):
         self.output_wrap_name = output_wrap_name
 
         if tool_definitions:
@@ -78,17 +74,6 @@ class OpenInstructLegacyToolParser(ToolParser):
                 else:
                     properties = params.get("properties", {})
                     self.tool_param_names[name] = next(iter(properties)) if properties else "text"
-        elif tool_actors:
-            self.tool_names = [ray.get(actor.get_call_name.remote()) for actor in tool_actors]
-            self.tool_param_names = {}
-            for actor, tool_name in zip(tool_actors, self.tool_names):
-                params = ray.get(actor.get_parameters.remote())
-                required = params.get("required", [])
-                if required:
-                    self.tool_param_names[tool_name] = required[0]
-                else:
-                    properties = params.get("properties", {})
-                    self.tool_param_names[tool_name] = next(iter(properties)) if properties else "text"
         else:
             self.tool_names = []
             self.tool_param_names = {}
@@ -288,21 +273,23 @@ class DRTuluToolParser(ToolParser):
     """
     Parser for DR Tulu style tool calls. Delegates actual parsing to the tool itself.
     Only detects that a tool call occurred (via stop strings) and passes text to the tool.
+
+    Requires exactly one tool (dr_agent_mcp) in tool_definitions.
     """
 
-    def __init__(self, tool_actors: list[ray.actor.ActorHandle]):
-        if len(tool_actors) != 1:
-            raise ValueError(f"DRTuluToolParser requires exactly one tool (dr_agent_mcp), got {len(tool_actors)}")
+    def __init__(self, tool_definitions: list[dict[str, Any]], stop_sequences: list[str]):
+        if len(tool_definitions) != 1:
+            raise ValueError(f"DRTuluToolParser requires exactly one tool (dr_agent_mcp), got {len(tool_definitions)}")
 
-        actor = tool_actors[0]
-        self.tool_call_name = ray.get(actor.get_call_name.remote())
+        self.tool_call_name = tool_definitions[0]["function"]["name"]
 
         if self.tool_call_name != "dr_agent_mcp":
             raise ValueError(f"DRTuluToolParser requires dr_agent_mcp tool, got {self.tool_call_name}")
 
-        stop_strings = ray.get(actor.get_stop_strings.remote())
-        # Use dict.fromkeys to deduplicate while preserving order
-        self.stop_sequences = list(dict.fromkeys(stop_strings)) if stop_strings else []
+        self.stop_sequences = list(dict.fromkeys(stop_sequences)) if stop_sequences else []
+
+        if not self.stop_sequences:
+            logger.warning("DRTuluToolParser initialized with no stop sequences — tool calls will never be detected")
 
     def get_tool_calls(self, text: str) -> list[EnvCall]:
         for stop in self.stop_sequences:
@@ -322,8 +309,8 @@ def get_available_parsers() -> list[str]:
 def create_tool_parser(
     parser_type: str,
     tokenizer: PreTrainedTokenizer | PreTrainedTokenizerFast,
-    tool_actors: list[ray.actor.ActorHandle],
     tool_definitions: list[dict[str, Any]] | None = None,
+    stop_sequences: list[str] | None = None,
 ) -> ToolParser:
     """Create a tool parser instance by type.
 
@@ -333,8 +320,8 @@ def create_tool_parser(
             - "dr_tulu": DRTuluToolParser for <call_tool name="...">content</call_tool> format
             - "vllm_*": VllmToolParser variants (vllm_hermes, vllm_llama3_json, vllm_olmo3)
         tokenizer: Tokenizer for the model (required for all parser types).
-        tool_actors: List of Ray actor handles for the tools.
-        tool_definitions: OpenAI-format tool definitions (required for vllm_* parsers).
+        tool_definitions: OpenAI-format tool definitions.
+        stop_sequences: a list of stop sequences to use for stopping generations.
 
     Returns:
         A ToolParser instance configured for the specified type.
@@ -343,12 +330,12 @@ def create_tool_parser(
         ValueError: If parser_type is unknown.
     """
     if parser_type == "legacy":
-        return OpenInstructLegacyToolParser(
-            tool_actors=tool_actors, output_wrap_name="output", tool_definitions=tool_definitions
-        )
+        return OpenInstructLegacyToolParser(tool_definitions=tool_definitions, output_wrap_name="output")
 
     if parser_type == "dr_tulu":
-        return DRTuluToolParser(tool_actors)
+        if tool_definitions is None or stop_sequences is None:
+            raise ValueError("dr_tulu parser requires both tool_definitions and stop_sequences")
+        return DRTuluToolParser(tool_definitions=tool_definitions, stop_sequences=stop_sequences)
 
     if parser_type in VLLM_PARSERS:
         return create_vllm_parser(parser_type, tokenizer, tool_definitions=tool_definitions)

--- a/open_instruct/environments/tools/utils.py
+++ b/open_instruct/environments/tools/utils.py
@@ -422,5 +422,9 @@ class Tool(RLEnvironment):
         """Get the tool's parameter schema."""
         return self.parameters
 
+    def get_stop_strings(self) -> list[str]:
+        """Get stop strings for this tool. Override in subclasses that define custom stop sequences."""
+        return []
+
     def get_tool_definitions(self) -> list[dict[str, Any]]:
         return [get_openai_tool_definitions(self)]

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1237,6 +1237,7 @@ def create_model_and_optimizer(
     tools_config: EnvsConfig | None = None,
     base_env_config: dict | None = None,
     pools: dict[str, ray.actor.ActorHandle] | None = None,
+    tool_stop_sequences: list[str] | None = None,
 ) -> tuple[
     ModelGroup, list[vllm_utils.LLMRayActor], int, int, ray.actor.ActorHandle, utils.ModelDims, ray.actor.ActorHandle
 ]:
@@ -1318,6 +1319,7 @@ def create_model_and_optimizer(
         pg=pg if args.single_gpu_mode else None,
         tool_parser_type=tools_config.tool_parser_type if tools_config else "legacy",
         tool_definitions=tool_definitions,
+        tool_stop_sequences=tool_stop_sequences,
         max_steps=tools_config.max_steps if tools_config else 5,
         mask_tool_use=streaming_config.mask_tool_use,
         pools=pools,
@@ -2093,21 +2095,37 @@ def initialize_tools_and_envs(
 
     tools_config.tool_call_names = tool_call_names
 
-    # Collect tool definitions from all pools
+    # Collect tool definitions and stop strings from all pools (batched for parallelism)
+    acquire_refs = [pool.acquire.remote() for pool in pools.values()]
+    actors = ray.get(acquire_refs)
+
+    def_refs = [actor.get_tool_definitions.remote() for actor in actors]
+    stop_refs = (
+        [actor.get_stop_strings.remote() for actor in actors] if tools_config.tool_parser_type == "dr_tulu" else []
+    )
+    all_results = ray.get(def_refs + stop_refs)
+    def_results = all_results[: len(def_refs)]
+    stop_results = all_results[len(def_refs) :]
+
     tool_definitions: list[dict[str, Any]] = []
-    for pool in pools.values():
-        actor = ray.get(pool.acquire.remote())
-        defs = ray.get(actor.get_tool_definitions.remote())
-        pool.release.remote(actor)
+    for defs in def_results:
         tool_definitions.extend(defs)
+
+    tool_stop_strings: list[str] = []
+    for stop_strings in stop_results:
+        if stop_strings:
+            tool_stop_strings.extend(stop_strings)
+
+    for pool, actor in zip(pools.values(), actors):
+        pool.release.remote(actor)
 
     stop_sequences: list[str] = []
     if pools:
         stop_sequences = create_tool_parser(
             parser_type=tools_config.tool_parser_type,
-            tool_actors=[],
             tokenizer=tokenizer,
             tool_definitions=tool_definitions,
+            stop_sequences=tool_stop_strings,
         ).stop_sequences
 
     logger.info(
@@ -2152,12 +2170,6 @@ def main(
         dataset_mixer_list=streaming_config.dataset_mixer_list,
         dataset_mixer_list_splits=streaming_config.dataset_mixer_list_splits,
     )
-    # TODO: Refactor DRTuluToolParser to work with tool_definitions instead of tool_actors.
-    if pools and tools_config.tool_parser_type == "dr_tulu":
-        raise ValueError(
-            "Parser type 'dr_tulu' requires tool_actors which are no longer created (pools are used instead). "
-            "Use --tool_parser_type legacy or --tool_parser_type vllm_hermes."
-        )
     if tool_stop_sequences:
         logger.info(f"Adding tool stop sequences to config: {tool_stop_sequences}")
         streaming_config.stop_strings.extend(tool_stop_sequences)
@@ -2247,6 +2259,7 @@ def main(
             tools_config,
             base_env_config,
             pools,
+            tool_stop_sequences,
         )
     )
 

--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -556,6 +556,7 @@ class LLMRayActor:
         *args,
         tool_parser_type: str = "legacy",
         tool_definitions: list[dict] | None = None,
+        tool_stop_sequences: list[str] | None = None,
         max_steps: int = 5,
         mask_tool_use: bool = True,
         pools: dict[str, ray.actor.ActorHandle] | None = None,
@@ -572,6 +573,7 @@ class LLMRayActor:
     ):
         assert_threaded_actor(self)
         self._tool_definitions = tool_definitions
+        self._tool_stop_sequences = tool_stop_sequences
         self._init_config(
             max_steps, mask_tool_use, pools, inflight_updates, reward_config, train_dataset, eval_dataset
         )
@@ -636,9 +638,9 @@ class LLMRayActor:
     def _init_tool_parser(self, tool_parser_type: str) -> None:
         self.tool_parser = create_tool_parser(
             parser_type=tool_parser_type,
-            tool_actors=[],
             tokenizer=self.llm_engine.tokenizer,
             tool_definitions=self._tool_definitions,
+            stop_sequences=self._tool_stop_sequences,
         )
 
     def _setup_gpu_visibility(self, noset_visible_devices: bool, distributed_executor_backend: str) -> None:
@@ -1084,6 +1086,7 @@ def create_vllm_engines(
     pg: PlacementGroup | None = None,
     tool_parser_type: str = "legacy",
     tool_definitions: list[dict] | None = None,
+    tool_stop_sequences: list[str] | None = None,
     max_steps: int = 5,
     mask_tool_use: bool = True,
     pools: dict[str, ray.actor.ActorHandle] | None = None,
@@ -1171,6 +1174,7 @@ def create_vllm_engines(
                 actor_manager=actor_manager,
                 tool_parser_type=tool_parser_type,
                 tool_definitions=tool_definitions,
+                tool_stop_sequences=tool_stop_sequences,
                 max_steps=max_steps,
                 mask_tool_use=mask_tool_use,
                 pools=pools,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,8 @@ code = [
 ]
 dr-tulu = [
     "dr_agent",
+    "authlib",
+    "scipy",
 ]
 
 [tool.uv]

--- a/scripts/train/debug/tools/dr_tulu_parser_debug.sh
+++ b/scripts/train/debug/tools/dr_tulu_parser_debug.sh
@@ -64,7 +64,7 @@ VLLM_ALLOW_INSECURE_SERIALIZATION=1 uv run --extra dr-tulu open_instruct/grpo_fa
     --gradient_checkpointing \
     --system_prompt_override_file scripts/train/debug/tools/dr_tulu_system_prompt.txt \
     --tools dr_agent_mcp \
-    --tool_parser dr_tulu \
+    --tool_parser_type dr_tulu \
     --tool_configs '{"tool_names": "snippet_search,google_search,browse_webpage", "parser_name": "v20250824", "host": "'"$MCP_HOST"'", "port": '"$MCP_PORT"'}' \
     --max_steps 5 \
     --pass_tools_to_chat_template false \

--- a/uv.lock
+++ b/uv.lock
@@ -2687,7 +2687,9 @@ code = [
     { name = "requests", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
 ]
 dr-tulu = [
+    { name = "authlib", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "dr-agent", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "scipy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
 ]
 
 [package.dev-dependencies]
@@ -2708,6 +2710,7 @@ requires-dist = [
     { name = "accelerate", specifier = ">=1.10.1" },
     { name = "ai2-olmo-core", specifier = "==2.3.0" },
     { name = "antlr4-python3-runtime", specifier = "==4.11" },
+    { name = "authlib", marker = "extra == 'dr-tulu'" },
     { name = "backoff", specifier = ">=2.2.1" },
     { name = "bitsandbytes", marker = "sys_platform != 'darwin'", specifier = ">=0.44.1" },
     { name = "datasets", specifier = ">=4.0.0" },
@@ -2733,6 +2736,7 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'code'", specifier = ">=2.0.0" },
     { name = "ray", extras = ["default"], specifier = ">=2.49.2" },
     { name = "requests", marker = "extra == 'code'", specifier = ">=2.28.0" },
+    { name = "scipy", marker = "extra == 'dr-tulu'" },
     { name = "setuptools", specifier = ">=75.6.0,<80.0.0" },
     { name = "tensorboard", specifier = ">=2.18.0" },
     { name = "torch", marker = "sys_platform != 'linux'", specifier = ">=2.9.0,<2.10" },


### PR DESCRIPTION
## Summary

- **Legacy parser**: Removes the `tool_actors` code path and uses only OpenAI-format `tool_definitions` to derive tool names and parameter names for `<tool_name>content</tool_name>` tag parsing.
- **DRTulu parser**: Replaces `tool_actors` dependency with `tool_definitions` + explicit `stop_sequences`. Stop sequences are now fetched from the EnvironmentPool during initialization in `grpo_fast.py`, then plumbed through `create_vllm_engines` → `LLMRayActor` → `create_tool_parser`.
- **Removes `import ray` from `parsers.py`** since neither parser needs direct Ray actor access anymore.
- **Removes the blocking error** in `grpo_fast.py` that prevented `--tool_parser_type dr_tulu` from being used.
- **Updates all tests** to use `tool_definitions` instead of mock Ray actors.

## Context

After the EnvironmentPool refactor (#1479), the parsers still had code paths using `tool_actors` (Ray actor handles). For the Legacy parser this was dead code (it already had a `tool_definitions` path). For the DRTulu parser it was completely broken — there was a hard error at startup blocking `dr_tulu` parser usage.

## Test plan

- [x] Verify Legacy parser tests pass (uses `tool_definitions` only)
- [x] Verify DRTulu parser tests pass (uses `tool_definitions` + `stop_sequences`)
- [x] Verify `create_tool_parser` factory tests pass for all parser types
- [x] Run dr_tulu debug script (`scripts/train/debug/tools/dr_tulu_parser_debug.sh`) on GPU
- [x] Run legacy debug script (`scripts/train/debug/tools/legacy_parser_debug.sh`) on GPU


Made with [Cursor](https://cursor.com)