### PR TITLE
Bump DATASET_CACHE_VERSION to v4

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -936,8 +936,8 @@ TOOLS_COLUMN_KEY = "tools"
 ENV_CONFIG_KEY = "env_config"
 
 # Cache version: increment this when transformation logic changes significantly
-# to invalidate old caches. v3: Added per-sample env tool injection in rlvr_tokenize_v3.
-DATASET_CACHE_VERSION = "v3"
+# to invalidate old caches. v4: Invalidate corrupted v3 weka cache.
+DATASET_CACHE_VERSION = "v4"
 
 
 def validate_dataset_tools(dataset: Dataset, configured_tool_names: list[str], dataset_name: str = "dataset") -> None:


### PR DESCRIPTION
PR #1479 bumped DATASET_CACHE_VERSION from v2 to v3. An early development run with v3 wrote corrupted/garbled tokenized data into the shared HuggingFace .map() cache on weka (`HF_DATASETS_CACHE=/weka/oe-adapt-default/allennlp/.cache/huggingface`). Since every subsequent v3 run hits this corrupted cache entry (keyed by a fingerprint that includes DATASET_CACHE_VERSION), all v3 runs produce garbled prompts, zero rewards, and active_sampling rejects every batch.

Bumping to v4 changes the fingerprint, bypassing the corrupted cache. Verified: v4 freshly recomputes correct data (verifiable_reward=3.48, code_correct_rate=0.60) and training completes successfully (https://beaker.org/ex/01KJZSGXNTMK051ANH4DFK8H1N).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Forces regeneration of all HuggingFace `.map()`/tokenized dataset caches, which can increase compute/time and storage usage across training runs, but does not change transformation logic.
> 
> **Overview**
> Bumps `DATASET_CACHE_VERSION` from `v3` to `v4` in `dataset_transformation.py` to invalidate existing cached tokenization/map results.
> 
> This changes the dataset fingerprint/config hash used for caching so subsequent runs bypass previously produced (corrupted) cache entries and recompute fresh transformed datasets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09cbd2c74b81cdc5afddf8b80114f06eb0661f8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->