### PR TITLE
Add CHANGELOG entry for cache version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- Bump DATASET_CACHE_VERSION to v4 to invalidate corrupted v3 weka cache (https://github.com/allenai/open-instruct/pull/1509).
 
 ### Removed


### PR DESCRIPTION
Follow-up to #1509 — adds the missing CHANGELOG entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a missing changelog entry; no code or runtime behavior is modified.
> 
> **Overview**
> Adds a `CHANGELOG.md` *Fixed* entry documenting the `DATASET_CACHE_VERSION` bump to v4 to invalidate the corrupted v3 weka cache (follow-up to #1509).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15d68394b2c8bdc6355f1b3279081580afc4c9c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->