### PR TITLE
Add SLR-Bench (Scalable Logical Reasoning) verifier and dataset support for RLVR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
+- Add SLR-Bench support for RLVR training to improve logical reasoning via structured curricula and verifiable rewards. Learning curriculum with increasing difficulty. Verification via logic program execution with efficient and precise feedback with partial credit for partially correct reasoning. Includes SLRBenchVerifier, slr_bench_prepare_v1 dataset transform, SWI-Prolog Docker integration, colon-based HF dataset configs (e.g. AIML-TUDA/SLR-Bench:v1-All), and extra_scores tracking in VerificationResult.
 - Tensor parallelism (TP) support for OLMo-core DPO training (https://github.com/allenai/open-instruct/pull/1467).
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     sudo \
     nginx \
+    swi-prolog \
     && apt-get autoremove -y \
     && mkdir -p /etc/nginx/conf.d \
     && rm -rf /var/lib/apt/lists/*

--- a/docs/algorithms/slr_bench.md
+++ b/docs/algorithms/slr_bench.md
@@ -1,0 +1,53 @@
+# SLR-Bench: Scalable Logical Reasoning Benchmark
+
+[SLR-Bench](https://huggingface.co/datasets/AIML-TUDA/SLR-Bench) is a scalable benchmark for improving logical reasoning in LLMs via **structured curricula and verifiable rewards**.
+
+## Why SLR-Bench?
+
+Logical reasoning is a core capability for language models, yet it is difficult to train and evaluate reliably. SLR-Bench provides:
+
+- **Structured curricula** — 20 difficulty levels (basic → hard) so models learn reasoning incrementally.
+- **Verifiable rewards** — every task comes with a deterministic symbolic verifier that scores model outputs automatically, enabling RLVR training with precise, partial-credit feedback.
+- **Scalable task generation** — over 19,000 tasks with controllable complexity; new tasks can be synthesised automatically.
+
+Each task asks the model to discover a general rule that correctly classifies a set of labelled examples. Solutions are verified by executing them as logic programs, giving exact correctness signals rather than relying on LLM judges or exact string matching.
+
+For more details see the [paper (arXiv:2506.15787)](https://arxiv.org/abs/2506.15787) and the [SLR framework on GitHub](https://github.com/ml-research/ScalableLogicalReasoning).
+
+## Dataset
+
+Hosted on Hugging Face: [`AIML-TUDA/SLR-Bench`](https://huggingface.co/datasets/AIML-TUDA/SLR-Bench)
+
+Use the colon separator syntax to specify a config:
+
+```
+AIML-TUDA/SLR-Bench:v1-All
+```
+
+### Requirements
+
+- **SWI-Prolog** (`swipl`) must be installed and available on `$PATH`. The Docker image includes it by default.
+- No additional Python packages are required beyond core dependencies.
+
+## Verifier
+
+The `SLRBenchVerifier` evaluates model outputs by:
+
+1. **Extracting** the predicted rule (supports `[RULE]...[/RULE]` tags, fenced code blocks, etc.).
+2. **Executing** it against the task's validation program via SWI-Prolog.
+3. **Scoring** with partial credit (fraction of examples classified correctly) plus a simplicity bonus.
+
+Evaluation uses isomorphic matching (constant names are normalised), so the model must learn the underlying logical structure.
+
+## Usage with GRPO
+
+```bash
+python open_instruct/grpo_fast.py \
+    --dataset_mixer_list "AIML-TUDA/SLR-Bench:v1-All" 1.0 \
+    --dataset_transform_fn slr_bench_prepare_v1 rlvr_tokenize_v1 rlvr_max_length_filter_v1 \
+    --max_token_length 4096 \
+    --max_prompt_token_length 2048 \
+    ...
+```
+
+See [scripts/train/slr/example.sh](https://github.com/allenai/open-instruct/blob/main/scripts/train/slr/example.sh) for a complete example.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
     - algorithms/finetune.md
     - algorithms/dpo.md
     - algorithms/grpo.md
+    - algorithms/slr_bench.md
     - algorithms/ppo.md
     - algorithms/reward_modeling.md
   - Not Maintained:

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -55,7 +55,7 @@ from typing import Any, Literal
 import numpy as np
 import torch
 import transformers
-from datasets import Dataset, concatenate_datasets, load_dataset
+from datasets import Dataset, Value, concatenate_datasets, load_dataset
 from huggingface_hub import ModelCard, revision_exists
 from rich.console import Console
 from rich.text import Text
@@ -1444,6 +1444,40 @@ def rlvr_tokenize_v2(
     return row
 
 
+def slr_bench_prepare_v1(row: dict[str, Any], tokenizer: PreTrainedTokenizer, **kwargs: Any) -> dict[str, Any]:
+    """
+    Prepare a single AIML-TUDA/SLR-Bench row for RLVR training.
+
+    SLR-Bench provides scalable logical reasoning tasks with verifiable rewards
+    and structured curricula. This transform converts the raw dataset columns
+    (``prompt``, ``validation program``) into the standard RLVR format:
+    tokenised prompt, JSON-serialised ground truth, and verifier source tag.
+
+    Rows that already contain a ``messages`` column are returned unchanged.
+    """
+    if DEFAULT_SFT_MESSAGES_KEY in row:
+        return row
+    prompt = row.get("prompt")
+    validation_program = row.get("validation program") or row.get("validation_program")
+    if prompt is None or validation_program is None:
+        return row
+    prompt += (
+        "\n\nWrap your final Prolog rule in [RULE]...[/RULE] tags. "
+        "Only the content inside these tags will be evaluated. "
+        "Example: [RULE] eastbound(T) :- has_car(T,C), short(C). [/RULE]"
+    )
+    validation_program_dict = {
+        "validation_program": validation_program,
+        "evaluation_config": {"positive_predicate": "eastbound", "negative_predicate": "westbound"},
+    }
+    row[GROUND_TRUTHS_KEY] = json.dumps(validation_program_dict)
+    row[VERIFIER_SOURCE_KEY] = "slr_bench"
+    row[INPUT_IDS_PROMPT_KEY] = tokenizer.apply_chat_template(prompt, add_generation_prompt=True)
+    row[RAW_PROMPT_KEY] = prompt
+    row["id"] = str(row["id"]) + "_slr_bench"
+    return row
+
+
 def _resolve_tools_for_sample(
     row: dict[str, Any], tool_definitions: list[dict[str, Any]] | None, pass_tools: bool
 ) -> list[dict[str, Any]] | None:
@@ -1553,6 +1587,7 @@ TRANSFORM_FNS = {
     "preference_filter_v1": (preference_filter_v1, "filter"),
     "preference_tulu_tokenize_and_truncate_v1": (preference_tulu_tokenize_and_truncate_v1_2, "map"),
     "preference_tulu_filter_v1": (preference_tulu_filter_v1, "filter"),
+    "slr_bench_prepare_v1": (slr_bench_prepare_v1, "map"),
     "rlvr_tokenize_v1": (rlvr_tokenize_v3, "map"),
     "rlvr_max_length_filter_v1": (rlvr_max_length_filter_v2, "filter"),
 }
@@ -1631,16 +1666,28 @@ class DatasetConfig:
                 "parquet", data_files=self.dataset_name, split=self.dataset_split, num_proc=max_num_processes()
             )
         else:
+            # Support dataset name with config, e.g. "AIML-TUDA/SLR-Bench:v1-All"
+            name_for_load = self.dataset_name
+            hf_config = None
+            if ":" in name_for_load:
+                name_for_load, hf_config = name_for_load.split(":", 1)
             # commit hash only works for hf datasets
-            self.dataset_commit_hash = get_commit_hash(
-                self.dataset_name, self.dataset_revision, "README.md", "dataset"
-            )
-            dataset = load_dataset(
-                self.dataset_name,
-                split=self.dataset_split,
-                revision=self.dataset_revision,
-                num_proc=max_num_processes(),
-            )
+            self.dataset_commit_hash = get_commit_hash(name_for_load, self.dataset_revision, "README.md", "dataset")
+            if hf_config:
+                dataset = load_dataset(
+                    name_for_load,
+                    hf_config,
+                    split=self.dataset_split,
+                    revision=self.dataset_revision,
+                    num_proc=max_num_processes(),
+                )
+            else:
+                dataset = load_dataset(
+                    name_for_load,
+                    split=self.dataset_split,
+                    revision=self.dataset_revision,
+                    num_proc=max_num_processes(),
+                )
         assert isinstance(dataset, Dataset), f"Expected Dataset, got {type(dataset)}"
         self.dataset = dataset
         if self.dataset_range is None:
@@ -1754,7 +1801,21 @@ def get_dataset_v1(dc: DatasetConfig, tc: TokenizerConfig):
             raise ValueError(f"Unknown transform function type: {fn_type}")
 
     if len(dataset) == 0:
-        raise ValueError("No examples left after transformation")
+        max_pl = None
+        for d in dc.transform_fn_args or []:
+            if isinstance(d, dict) and "max_prompt_token_length" in d:
+                max_pl = d["max_prompt_token_length"]
+                break
+        hint = f" Try increasing --max_prompt_token_length (current: {max_pl})." if max_pl is not None else ""
+        raise ValueError(
+            f"No examples left after transformation for dataset '{dc.dataset_name}' split '{dc.dataset_split}'."
+            f" All rows may be filtered out by length or the split may be empty.{hint}"
+        )
+
+    # Cast int id to string so this dataset can be concatenated with others that use string id
+    if "id" in dataset.column_names:
+        dataset = dataset.cast_column("id", Value("string"))
+
     return dataset
 
 

--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -11,6 +11,7 @@ import copy
 import dataclasses
 import json
 import logging
+import math
 import os
 import re
 import string
@@ -95,10 +96,17 @@ class CodeVerifierConfig(VerifierConfig):
 
 
 @dataclasses.dataclass
+class SLRBenchVerifierConfig(VerifierConfig):
+    """Config for the SLR-Bench verifier (scalable logical reasoning with verifiable rewards)."""
+
+
+@dataclasses.dataclass
 class VerificationResult:
     score: float
     cost: float = 0.0
     reasoning: str | None = None
+    extra_scores: dict[str, float] | None = None
+    """Optional dict of additional scores for tracking (not used for training reward)."""
 
 
 @dataclasses.dataclass
@@ -1190,6 +1198,245 @@ class RubricVerifier(VerifierFunction):
         return RubricVerifierConfig
 
 
+class SLRBenchVerifier(VerifierFunction):
+    """
+    Verifier for SLR-Bench — scalable logical reasoning with verifiable rewards.
+
+    Each task asks the model to discover a rule that classifies labelled examples.
+    The verifier executes the predicted rule against the task's symbolic
+    validation program via SWI-Prolog (``swipl``) and returns a partial-credit
+    score based on how many examples are classified correctly, plus a simplicity
+    bonus.
+
+    Label format: JSON-serialised dict with:
+      - ``validation_program``: logic program defining positive/negative examples.
+      - ``evaluation_config``: dict with ``positive_predicate`` and
+        ``negative_predicate`` keys (e.g. ``"eastbound"`` / ``"westbound"``).
+    """
+
+    def __init__(self, verifier_config: SLRBenchVerifierConfig) -> None:
+        super().__init__("slr_bench", verifier_config=verifier_config, weight=1.0)
+        from open_instruct.slr.slr_verifier import evaluate_prediction  # noqa: PLC0415
+
+        self._evaluate_prediction = evaluate_prediction
+        logger.info("SLRBenchVerifier: loaded unified slr_verifier module.")
+
+    # Regex to extract content between [RULE] and [/RULE] tags (case-insensitive, dotall)
+    _RULE_TAG_PATTERN = re.compile(r"\[RULE\]\s*(.*?)\s*\[/RULE\]", re.IGNORECASE | re.DOTALL)
+    # Fallback: prolog-labelled code block, then any fenced code block
+    _PROLOG_BLOCK_PATTERN = re.compile(r"```prolog\s*(.*?)\s*```", re.IGNORECASE | re.DOTALL)
+    _CODE_BLOCK_PATTERN = re.compile(r"```(?:[a-zA-Z0-9]*\n)?(.*?)```", re.DOTALL)
+
+    @staticmethod
+    def _extract_prolog_rule(prediction: str) -> tuple[str, bool] | tuple[None, bool]:
+        """Extract the Prolog rule from model output.
+
+        Strips the thinking section, then tries extraction in priority order:
+
+        1. ``[RULE]...[/RULE]`` tags -> ``(content, True)``
+        2. ````prolog...```` fenced block -> ``(content, False)``
+        3. Any fenced code block -> ``(content, False)``
+        4. No match -> ``(None, False)`` (caller should return score 0.0)
+
+        Returns:
+            Tuple of ``(rule_text, format_ok)`` where ``format_ok`` is ``True``
+            only when the preferred ``[RULE]`` tags were used.
+        """
+        cleaned = remove_thinking_section(prediction)
+        if not cleaned.strip():
+            return None, False
+
+        # Tier 1: explicit [RULE] tags
+        match = SLRBenchVerifier._RULE_TAG_PATTERN.search(cleaned)
+        if match:
+            rule_text = match.group(1).strip()
+            if rule_text:
+                return rule_text, True
+
+        # Tier 2: ```prolog ... ``` code block
+        match = SLRBenchVerifier._PROLOG_BLOCK_PATTERN.search(cleaned)
+        if match:
+            rule_text = match.group(1).strip()
+            if rule_text:
+                return rule_text, False
+
+        # Tier 3: any fenced code block
+        match = SLRBenchVerifier._CODE_BLOCK_PATTERN.search(cleaned)
+        if match:
+            rule_text = match.group(1).strip()
+            if rule_text:
+                return rule_text, False
+
+        # No structured format found
+        return None, False
+
+    @staticmethod
+    def get_rule_simplicity_bonus(model_response: str) -> float:
+        """Compute a rule simplicity bonus in [0, 1].
+
+        Encourages concise rules by penalising excessive literals, rule count,
+        and total rule length.  The thresholds are calibrated for ILP domains
+        where correct rules typically require several body literals.
+
+        Returns:
+            Float in [0, 1]; higher means simpler.
+        """
+
+        if not model_response or not model_response.strip():
+            return 0.0
+
+        text = model_response.strip()
+
+        # Extract rule-like statements using regex
+        rule_pattern = r"[a-zA-Z_][a-zA-Z0-9_]*\s*\([^)]*\)\s*(?::-\s*[^.]+)?\."
+        rules = re.findall(rule_pattern, text)
+
+        # If no formal rules found, return neutral bonus
+        if not rules:
+            return 0.8  # neutral-safe default
+
+        num_rules = len(rules)
+        total_literals = 0
+        total_length = sum(len(r) for r in rules)
+
+        for rule in rules:
+            if ":-" in rule:
+                _, body = rule.split(":-", 1)
+                literals = [lit.strip() for lit in body.split(",") if lit.strip()]
+                total_literals += len(literals)
+            else:
+                total_literals += 1
+
+        # Gentle penalties suitable for complex ILP domains
+        literal_score = math.exp(-0.035 * max(0, total_literals - 6))
+        rule_count_score = math.exp(-0.08 * max(0, num_rules - 2))
+        length_score = math.exp(-0.001 * max(0, total_length - 120))
+
+        simplicity = 0.6 * literal_score + 0.25 * rule_count_score + 0.15 * length_score
+
+        return max(0.0, min(1.0, simplicity))
+
+    @staticmethod
+    def compute_reward(
+        accuracy: float,
+        partial_score: float,
+        syntax_score: float,
+        rule_simplicity_bonus: float,
+        k: int = 6,
+        partial_gate: float = 0.5,
+    ) -> float:
+        """Compute a scalar reward in [0, 1] for a predicted Prolog rule.
+
+        Full accuracy yields a score in [0.95, 1.0] with a small simplicity
+        modifier.  Partial credit (in [0, 0.9]) is only granted when
+        ``partial_score >= partial_gate``; the raw partial score is raised to
+        the power ``k`` to require near-complete coverage before any reward is
+        given.  ``syntax_score`` is not used in the reward computation.
+
+        Args:
+            accuracy: 1.0 if the rule is fully correct, else 0.0.
+            partial_score: Fraction of examples covered correctly, in [0, 1].
+            syntax_score: Whether the rule parsed successfully (tracked only).
+            rule_simplicity_bonus: Simplicity bonus from
+                :meth:`get_rule_simplicity_bonus`, in [0, 1].
+            k: Exponent applied to partial_score to compress partial credit.
+            partial_gate: Minimum partial_score required for any reward.
+
+        Returns:
+            Float in [0, 1].
+        """
+        if accuracy == 1.0:
+            # Full marks.  Apply a small simplicity modifier [0.95, 1.0]
+            return 0.95 + 0.05 * rule_simplicity_bonus
+
+        # Partial credit: only when the rule covers a meaningful fraction.
+        if partial_score < partial_gate:
+            return 0.0
+
+        # partial_score**k compresses the range: 0.5->0.016, 0.8->0.26, 0.95->0.74
+        # Scale into [0, 0.9] so partial is always strictly below full accuracy.
+        base = partial_score**k
+        # Multiplicative simplicity modifier: scales base by [0.9, 1.0]
+        simplicity_mod = 0.9 + 0.1 * rule_simplicity_bonus
+        return min(0.9, base * simplicity_mod)
+
+    def __call__(
+        self,
+        tokenized_prediction: list[int],
+        prediction: str,
+        label: str | dict,
+        query: str | None = None,
+        rollout_state: dict | None = None,
+    ) -> VerificationResult:
+        """
+        Score a predicted rule against the SLR-Bench validation program.
+
+        Executes the symbolic judge via SWI-Prolog and returns a partial-credit
+        score. Additional metrics are returned in ``extra_scores`` for logging.
+        """
+        zero = VerificationResult(score=0.0, extra_scores={"slr_bench_isomorphic": 0.0})
+        if not prediction:
+            return zero
+
+        ref = label
+        if isinstance(ref, str):
+            try:
+                ref = json.loads(ref)
+            except json.JSONDecodeError:
+                ref = ref
+        if not isinstance(ref, dict) or "validation_program" not in ref or "evaluation_config" not in ref:
+            logger.warning(
+                "SLRBenchVerifier expected label to be a dict with 'validation_program' and 'evaluation_config'."
+                " Got type=%s. with value %s",
+                type(ref).__name__,
+                ref,
+            )
+            return zero
+
+        rule, format_ok = self._extract_prolog_rule(prediction)
+
+        # If no structured content was found (no tags, no code blocks), return 0.0.
+        if rule is None:
+            return VerificationResult(score=0.0, extra_scores={"slr_bench_isomorphic": 0.0, "slr_bench_format": 0.0})
+
+        rule_simplicity_bonus = self.get_rule_simplicity_bonus(rule)
+
+        validation_program = ref["validation_program"]
+        eval_config = ref.get(
+            "evaluation_config", {"positive_predicate": "eastbound", "negative_predicate": "westbound"}
+        )
+
+        scores: dict[str, float] = {}
+        scores["slr_bench_format"] = 1.0 if format_ok else 0.0  # 1.0 = [RULE] tags used
+        try:
+            result = self._evaluate_prediction(rule, validation_program, eval_config, timeout=5, isomorphic=True)
+        except Exception as e:
+            logger.warning("[SLRBenchVerifier] isomorphic metric failed: %s", e, exc_info=True)
+            scores["slr_bench_isomorphic"] = 0.0
+            return VerificationResult(score=0.0, extra_scores=scores)
+        if result is None:
+            logger.warning("[SLRBenchVerifier] evaluate_prediction returned None.")
+            scores["slr_bench_isomorphic"] = 0.0
+            return VerificationResult(score=0.0, extra_scores=scores)
+        try:
+            accuracy = 1.0 if result["is_correct"] else 0.0
+            partial_score = result["partial_score"]
+            syntax_score = 1.0 if result["syntax_valid"] else 0.0
+            scores["slr_bench_isomorphic"] = self.compute_reward(
+                accuracy, partial_score, syntax_score, rule_simplicity_bonus
+            )
+            scores["slr_bench_solved"] = 1.0 if accuracy == 1.0 else 0.0
+        except (TypeError, ValueError, KeyError) as e:
+            logger.warning("[SLRBenchVerifier] could not read score from result %s: %s", result, e)
+            scores["slr_bench_isomorphic"] = 0.0
+
+        return VerificationResult(score=scores.get("slr_bench_isomorphic", 0.0), extra_scores=scores)
+
+    @classmethod
+    def get_config_class(cls) -> type:
+        return SLRBenchVerifierConfig
+
+
 def build_all_verifiers(args, streaming_config=None) -> dict[str, VerifierFunction]:
     """
     Build all verifiers with the given configs.
@@ -1213,6 +1460,11 @@ def build_all_verifiers(args, streaming_config=None) -> dict[str, VerifierFuncti
             instance = CodeVerifier(stdio_config)
             instance.name = "code_stdio"
             verifiers["code_stdio"] = instance
+
+        if subclass == SLRBenchVerifier:
+            instance = SLRBenchVerifier(verifier_config)
+            instance.name = "slr_bench"
+            verifiers["slr_bench"] = instance
 
     for judge_type in JUDGE_PROMPT_MAP:
         instance = LMJudgeVerifier(judge_type, LMJudgeVerifierConfig.from_args(args, streaming_config))
@@ -1311,6 +1563,12 @@ async def apply_verifiable_reward(
         response_per_func_rewards[response_idx][dataset] = (
             response_per_func_rewards[response_idx].get(dataset, 0) + weighted_reward
         )
+
+        # Collect extra tracking scores (e.g., both SLR judges)
+        if hasattr(result, "extra_scores") and result.extra_scores:
+            for key, val in result.extra_scores.items():
+                response_per_func_rewards[response_idx].setdefault(key, 0.0)
+                response_per_func_rewards[response_idx][key] += reward_mult * val * reward_weight
 
     return response_rewards, response_per_func_rewards
 

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2074,7 +2074,11 @@ def _discover_tools_from_datasets(dataset_mixer_list: list[str], dataset_mixer_l
     for i in range(0, len(dataset_mixer_list), 2):
         dataset_name = dataset_mixer_list[i]
         split = splits[i // 2]
-        ds = datasets.load_dataset(dataset_name, split=split)
+        # Support dataset name with config, e.g. "AIML-TUDA/SLR-Bench:v1-All"
+        hf_config = None
+        if ":" in dataset_name:
+            dataset_name, hf_config = dataset_name.split(":", 1)
+        ds = datasets.load_dataset(dataset_name, hf_config, split=split)
         if TOOLS_COLUMN_KEY in ds.column_names:
             for tools in ds[TOOLS_COLUMN_KEY]:
                 if tools:

--- a/open_instruct/slr/slr_verifier.py
+++ b/open_instruct/slr/slr_verifier.py
@@ -1,0 +1,156 @@
+import os
+import re
+import subprocess
+import tempfile
+import time
+
+from open_instruct import logger_utils
+
+logger = logger_utils.setup_logger(__name__)
+
+
+def prepare_validation_program(validation_program, positive_pred="eastbound", negative_pred="westbound"):
+    """
+    Normalise predicate names in the validation program by replacing the
+    domain-specific positive and negative predicates with the canonical
+    names ``pos`` and ``neg``.
+    """
+    validation_program = re.sub(rf"\b{positive_pred}\b", "pos", validation_program)
+    validation_program = re.sub(rf"\b{negative_pred}\b", "neg", validation_program)
+    return validation_program
+
+
+def prepare_validation_program_isomorphic(validation_program, positive_pred="eastbound", negative_pred="westbound"):
+    """
+    Normalise predicate and constant names for isomorphic evaluation.
+
+    Replaces domain-specific head predicates with ``pos``/``neg`` and
+    anonymises train/car constants (``train`` -> ``mytrain``, ``car`` ->
+    ``mycar``) so that structurally equivalent rules with different constant
+    names are judged as correct.
+    """
+    # anonymize train and car instances, and head predicates
+    validation_program = re.sub(rf"\b{positive_pred}\b", "pos", validation_program)
+    validation_program = re.sub(rf"\b{negative_pred}\b", "neg", validation_program)
+    # replace train with mytrain and car with mycar
+    # trains must follow a digit pattern train\d+ and cars must follow a pattern car\d+_\d+
+    validation_program = validation_program.replace("(train", "(mytrain")
+    validation_program = validation_program.replace("(car", "(mycar").replace(", car", ", mycar")
+    return validation_program
+
+
+def evaluate_prediction(prediction, validation_program, eval_config, timeout=5, isomorphic=True):
+    """
+    Evaluate a predicted rule against the SLR-Bench validation program.
+
+    Executes the predicted rule together with the task's labelled examples via
+    SWI-Prolog (``swipl``) and returns the fraction of examples classified
+    correctly, providing precise partial-credit feedback for RLVR training.
+
+    Args:
+        prediction: The predicted rule string.
+        validation_program: Logic program defining positive/negative examples.
+        eval_config: Dict with ``positive_predicate`` and ``negative_predicate`` keys.
+        timeout: Maximum seconds to wait for the Prolog subprocess.
+        isomorphic: If True, normalise constant names before evaluation.
+
+    Returns:
+        Dict with keys ``is_correct`` (bool), ``partial_score`` (float in [0,1]),
+        ``syntax_valid`` (bool), and ``error`` (str or None).
+    """
+
+    # Extract configuration
+    positive_pred = eval_config.get("positive_predicate", "eastbound")
+    negative_pred = eval_config.get("negative_predicate", "westbound")
+
+    if positive_pred not in prediction:
+        p = prediction.replace("\n", " ")
+        return {
+            "is_correct": False,
+            "partial_score": 0.0,
+            "syntax_valid": False,
+            "error": f"Invalid Syntax: Logic Rule not found for symbol '{positive_pred}': {p}",
+        }
+
+    pos_examples = re.findall(rf"{positive_pred}\(([^)]+)\)", validation_program)
+    neg_examples = re.findall(rf"{negative_pred}\(([^)]+)\)", validation_program)
+
+    # Determine arity by counting commas in first example plus 1
+    arity = 1  # default to unary
+    if pos_examples:
+        arity = pos_examples[0].count(",") + 1
+    elif neg_examples:
+        arity = neg_examples[0].count(",") + 1
+
+    # Create variables based on arity
+    vars = ", ".join([f"X{i}" for i in range(1, arity + 1)])
+
+    symbolic_judge = f"""
+% Dynamic evaluation predicates
+check({vars}) :- pos({vars}), {positive_pred}({vars}).      % positive covered
+check({vars}) :- neg({vars}), \\+ {positive_pred}({vars}).  % negative rejected
+% Count successful checks
+check_count(Count) :-
+    (setof(({vars}), ((pos({vars}); neg({vars})), check({vars})), CorrectExamples) ->
+        length(CorrectExamples, Count)
+    ;
+        Count = 0
+    ).
+check_all :- forall((pos({vars});neg({vars})), check({vars})).
+    """
+    # Add the rule to evaluate
+    if isomorphic:
+        validation_program = prepare_validation_program_isomorphic(validation_program, positive_pred, negative_pred)
+    else:
+        validation_program = prepare_validation_program(validation_program, positive_pred, negative_pred)
+
+    pos_negs = validation_program.count("pos(") + validation_program.count("neg(")
+    validation_program = "\n".join(sorted(validation_program.splitlines()))
+    full_program = validation_program + "\n\n" + symbolic_judge + "\n\n" + prediction + "\n\n"
+
+    with tempfile.NamedTemporaryFile(suffix=".pl", mode="w", delete=False) as f:
+        f.write(full_program)
+        temp_file = f.name
+
+    result = None
+    try:
+        eval_start_time = time.time()
+        # Execute the Prolog program
+        cmd = ["swipl", "-s", temp_file, "-g", "check_count(Count), writeln(Count)", "-t", "halt"]
+        result = subprocess.run(cmd, capture_output=True, timeout=timeout, text=True)
+        partial_score = 0.0 if result.stdout.strip() == "" else int(result.stdout.strip())
+        partial_score = partial_score / pos_negs if pos_negs > 0 else 0.0
+
+        is_correct = partial_score == 1.0
+
+        error = f'{result.stderr} -> Eval Rule "{prediction}"' if result.stderr else None
+        t1 = time.time()
+
+        return {
+            "is_correct": is_correct,
+            "partial_score": partial_score,
+            "syntax_valid": True,
+            "error": error,
+            "exec_time1": t1 - eval_start_time,
+        }
+
+    except subprocess.TimeoutExpired:
+        r = prediction.replace("\n", " ")
+        logger.warning(f"[SLR Reward Model] Evaluation timed out after {timeout} seconds for rule: '{r}'")
+        return {
+            "is_correct": False,
+            "partial_score": 0.0,
+            "syntax_valid": False,
+            "error": f"Evaluation timed out after {timeout} seconds for rule: '{r}'",
+        }
+    except Exception as e:
+        logger.warning(f"[SLR Reward Model] Error evaluating rule '{prediction}': {e}")
+        return {
+            "is_correct": False,
+            "partial_score": 0.0,
+            "syntax_valid": False,
+            "error": f"Error evaluating rule '{prediction}' returns: '{result.stdout.strip() if result else 'No error message'}' with error: {e}",
+        }
+    finally:
+        if os.path.exists(temp_file):
+            os.remove(temp_file)

--- a/open_instruct/slr/slr_verifier.py
+++ b/open_instruct/slr/slr_verifier.py
@@ -8,6 +8,78 @@ from open_instruct import logger_utils
 
 logger = logger_utils.setup_logger(__name__)
 
+# Prolog built-ins that must never appear in an LLM-predicted rule.
+# Executing untrusted Prolog without this check would allow RCE.
+_DANGEROUS_PREDICATES = frozenset(
+    {
+        # OS / process interaction
+        "shell",
+        "win_exec",
+        "process_create",
+        "exec",
+        # File I/O
+        "open",
+        "close",
+        "read",
+        "write",
+        "read_term",
+        "write_term",
+        "see",
+        "seen",
+        "tell",
+        "told",
+        "stream_property",
+        # Module / file loading
+        "consult",
+        "use_module",
+        "load_files",
+        "ensure_loaded",
+        "include",
+        "load_foreign_library",
+        # Environment
+        "getenv",
+        "setenv",
+        "environ",
+        # Process control
+        "halt",
+        "abort",
+        # Dynamic DB manipulation
+        "assert",
+        "asserta",
+        "assertz",
+        "retract",
+        "retractall",
+        "abolish",
+        # Meta-programming that could bypass restrictions
+        "atom_to_term",
+        "term_to_atom",
+        "term_string",
+        # Threading
+        "thread_create",
+        "thread_join",
+        # Networking
+        "http_open",
+        "tcp_connect",
+        "tcp_socket",
+    }
+)
+
+_TOKEN_RE = re.compile(r"\b([a-z_][a-z0-9_]*)\b")
+
+
+def _is_prediction_safe(prediction: str) -> tuple:
+    """Return ``(True, None)`` if *prediction* contains only safe Prolog constructs.
+
+    Returns ``(False, reason)`` when dangerous predicates or standalone
+    directives are detected.  This is *not* a sandbox — it is a fast reject
+    filter that blocks the most common injection vectors before ``swipl`` is
+    invoked.
+    """
+    tokens = set(_TOKEN_RE.findall(prediction.lower()))
+    dangerous = tokens & _DANGEROUS_PREDICATES
+    if dangerous:
+        return False, f"Dangerous predicates rejected: {sorted(dangerous)}"
+    return True, None
 
 def prepare_validation_program(validation_program, positive_pred="eastbound", negative_pred="westbound"):
     """
@@ -62,6 +134,12 @@ def evaluate_prediction(prediction, validation_program, eval_config, timeout=5, 
     # Extract configuration
     positive_pred = eval_config.get("positive_predicate", "eastbound")
     negative_pred = eval_config.get("negative_predicate", "westbound")
+
+    # Reject predictions containing dangerous Prolog built-ins before execution.
+    safe, reason = _is_prediction_safe(prediction)
+    if not safe:
+        logger.warning("[SLR Reward Model] Unsafe prediction rejected: %s", reason)
+        return {"is_correct": False, "partial_score": 0.0, "syntax_valid": False, "error": reason}
 
     if positive_pred not in prediction:
         p = prediction.replace("\n", " ")

--- a/open_instruct/slr/slr_verifier.py
+++ b/open_instruct/slr/slr_verifier.py
@@ -66,6 +66,18 @@ _DANGEROUS_PREDICATES = frozenset(
 
 _TOKEN_RE = re.compile(r"\b([a-z_][a-z0-9_]*)\b")
 
+# Minimal environment for the swipl subprocess.  We intentionally do NOT
+# inherit the parent environment so that API keys, tokens, and other secrets
+# (e.g. from ``secrets.env``) are never visible to untrusted Prolog code.
+_SWIPL_ENV: dict[str, str] = {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+
+# Prolog preamble injected at the top of every evaluation program.
+# * ``allow_dot_in_atom`` – disabled to prevent atom-concat tricks.
+# * ``sandboxed_load`` – SWI-Prolog flag that restricts directive execution
+#   during file loading (e.g. :- shell(...) is rejected).  MUST be last
+#   because it blocks all subsequent :- set_prolog_flag(...) directives.
+_PROLOG_SANDBOX_PREAMBLE = ":- set_prolog_flag(allow_dot_in_atom, false).\n:- set_prolog_flag(sandboxed_load, true).\n"
+
 
 def _is_prediction_safe(prediction: str) -> tuple:
     """Return ``(True, None)`` if *prediction* contains only safe Prolog constructs.
@@ -80,6 +92,7 @@ def _is_prediction_safe(prediction: str) -> tuple:
     if dangerous:
         return False, f"Dangerous predicates rejected: {sorted(dangerous)}"
     return True, None
+
 
 def prepare_validation_program(validation_program, positive_pred="eastbound", negative_pred="westbound"):
     """
@@ -184,7 +197,9 @@ check_all :- forall((pos({vars});neg({vars})), check({vars})).
 
     pos_negs = validation_program.count("pos(") + validation_program.count("neg(")
     validation_program = "\n".join(sorted(validation_program.splitlines()))
-    full_program = validation_program + "\n\n" + symbolic_judge + "\n\n" + prediction + "\n\n"
+    full_program = (
+        _PROLOG_SANDBOX_PREAMBLE + "\n" + validation_program + "\n\n" + symbolic_judge + "\n\n" + prediction + "\n\n"
+    )
 
     with tempfile.NamedTemporaryFile(suffix=".pl", mode="w", delete=False) as f:
         f.write(full_program)
@@ -193,9 +208,24 @@ check_all :- forall((pos({vars});neg({vars})), check({vars})).
     result = None
     try:
         eval_start_time = time.time()
-        # Execute the Prolog program
-        cmd = ["swipl", "-s", temp_file, "-g", "check_count(Count), writeln(Count)", "-t", "halt"]
-        result = subprocess.run(cmd, capture_output=True, timeout=timeout, text=True)
+        # Execute the Prolog program in a sandboxed subprocess:
+        # --nosignals  : prevent Prolog from intercepting OS signals
+        # --no-tty     : disable terminal interaction
+        # -f none      : skip user .swiplrc init file
+        cmd = [
+            "swipl",
+            "--nosignals",
+            "--no-tty",
+            "-f",
+            "none",
+            "-s",
+            temp_file,
+            "-g",
+            "check_count(Count), writeln(Count)",
+            "-t",
+            "halt",
+        ]
+        result = subprocess.run(cmd, capture_output=True, timeout=timeout, text=True, env=_SWIPL_ENV)
         partial_score = 0.0 if result.stdout.strip() == "" else int(result.stdout.strip())
         partial_score = partial_score / pos_negs if pos_negs > 0 else 0.0
 

--- a/open_instruct/slr/slr_verifier.py
+++ b/open_instruct/slr/slr_verifier.py
@@ -34,8 +34,8 @@ def prepare_validation_program_isomorphic(validation_program, positive_pred="eas
     validation_program = re.sub(rf"\b{negative_pred}\b", "neg", validation_program)
     # replace train with mytrain and car with mycar
     # trains must follow a digit pattern train\d+ and cars must follow a pattern car\d+_\d+
-    validation_program = validation_program.replace("(train", "(mytrain")
-    validation_program = validation_program.replace("(car", "(mycar").replace(", car", ", mycar")
+    validation_program = re.sub(r"\b(train)(\d+)\b", r"mytrain\2", validation_program)
+    validation_program = re.sub(r"\b(car)(\d+_\d+)\b", r"mycar\2", validation_program)
     return validation_program
 
 

--- a/scripts/train/slr/example.sh
+++ b/scripts/train/slr/example.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Olmo 3 7B Think RL + SLR-Bench: Improve reasoning via structured curricula
+# and verifiable rewards.
+#
+# This extends the standard Olmo 3 7B Think RL recipe by adding SLR-Bench —
+# a scalable logical reasoning benchmark with deterministic symbolic evaluation.
+# By training on both the existing Dolci RL data and SLR-Bench together, the
+# model gets stronger reasoning capabilities through precise, partial-credit
+# feedback across 20 difficulty levels.
+#
+# See docs/algorithms/slr_bench.md for details on the dataset and verifier.
+#
+# Prerequisites:
+#   - SWI-Prolog (`swipl`) on $PATH (included in the Docker image).
+#
+# Usage:
+#   ./scripts/train/build_image_and_launch.sh scripts/train/slr/example.sh
+
+BEAKER_IMAGE=${1:-nathanl/open_instruct_auto}
+
+python mason.py \
+    --budget ai2/oe-adapt \
+    --cluster ai2/jupiter \
+    --image "$BEAKER_IMAGE" \
+    --pure_docker_mode \
+    --workspace ai2/olmo-instruct \
+    --priority urgent \
+    --preemptible \
+    --num_nodes 4 \
+    --gpus 8 \
+    --max_retries 0 \
+    --env RAY_CGRAPH_get_timeout=300 \
+    --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
+    --env HOSTED_VLLM_API_BASE=http://ceres-cs-aus-447.reviz.ai2.in:8001/v1 \
+    -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
+        --exp_name slr_bench_7b_olmo3_thinker \
+        --beta 0.0 \
+        --num_samples_per_prompt_rollout 8 \
+        --num_unique_prompts_rollout 64 \
+        --num_mini_batches 1 \
+        --num_epochs 1 \
+        --learning_rate 1e-6 \
+        --per_device_train_batch_size 1 \
+        --output_dir /output \
+        --kl_estimator 2 \
+        --dataset_mixer_list allenai/Dolci-Think-RL-7B 1.0 "AIML-TUDA/SLR-Bench:v1-All" 1.0 \
+        --dataset_mixer_list_splits train train \
+        --dataset_transform_fn slr_bench_prepare_v1 rlvr_tokenize_v1 rlvr_max_length_filter_v1 \
+        --dataset_mixer_eval_list allenai/Dolci-Think-RL-7B 8 \
+        --dataset_mixer_eval_list_splits train \
+        --max_token_length 10240 \
+        --max_prompt_token_length 2048 \
+        --response_length 32768 \
+        --pack_length 35840 \
+        --model_name_or_path allenai/Olmo-3-7B-Think-DPO \
+        --chat_template_name olmo_thinker \
+        --stop_strings "[/RULE]" \
+        --non_stop_penalty False \
+        --mask_truncated_completions False \
+        --temperature 1.0 \
+        --ground_truths_key ground_truth \
+        --sft_messages_key messages \
+        --total_episodes 10000000 \
+        --deepspeed_stage 3 \
+        --num_learners_per_node 8 8 \
+        --vllm_num_engines 16 \
+        --vllm_tensor_parallel_size 1 \
+        --lr_scheduler_type constant \
+        --apply_verifiable_reward true \
+        --seed 1 \
+        --local_eval_every 50 \
+        --save_freq 25 \
+        --beaker_eval_freq 50 \
+        --eval_priority urgent \
+        --try_launch_beaker_eval_jobs_on_weka True \
+        --gradient_checkpointing \
+        --with_tracking \
+        --llm_judge_model hosted_vllm/Qwen/Qwen3-32B \
+        --llm_judge_timeout 600 \
+        --llm_judge_max_tokens 2048 \
+        --llm_judge_max_context_length 32768 \
+        --clip_higher 0.272 \
+        --code_api_url https://p9f1719l7f.execute-api.us-west-2.amazonaws.com/prod/test_program \
+        --code_pass_rate_reward_threshold 0.99 \
+        --oe_eval_max_length 32768 \
+        --checkpoint_state_freq 100 \
+        --backend_timeout 1200 \
+        --inflight_updates true \
+        --async_steps 8 \
+        --advantage_normalization_type centered \
+        --truncated_importance_sampling_ratio_cap 2.0


### PR DESCRIPTION
Add SLR-Bench support for RLVR training to further boost logical reasoning via structured curricula and verifiable rewards. Provides a learning curriculum with increasing difficulty. Verifiable Rewards via logic program execution with efficient and precise feedback and partial credit for partially correct reasoning. 

Huggingface: [AIML-TUDA/SLR-Bench](https://huggingface.co/datasets/AIML-TUDA/SLR-Bench), Arxiv: [2506.15787](https://arxiv.org/abs/2506.15787)

New files:
- open_instruct/slr/__init__.py, slr_verifier.py: Prolog-based symbolic judge that evaluates predicted rules against a validation program using SWI-Prolog. Supports both isomorphic and base evaluation modes.
- docs/algorithms/slr_bench.md: Documentation for the SLR-Bench dataset and verifier usage with GRPO training.
- scripts/train/slr/example.sh: Example Beaker training script for SLR-Bench with GRPO.

Modified files:
- ground_truth_utils.py: Add SLRBenchVerifierConfig, SLRBenchVerifier class with tiered rule extraction ([RULE] tags, code blocks), reward computation with simplicity bonus, and extra_scores on VerificationResult for tracking both isomorphic and base judge scores.
- dataset_transformation.py: Add slr_bench_prepare_v1 transform function to convert SLR-Bench HF dataset columns to RLVR format. Support ':' separator in dataset names for HF configs (e.g. 'AIML-TUDA/SLR-Bench:v1-All'). Cast id column to string for cross-dataset compatibility. Improve error message when all examples are filtered out.
- data_loader.py: Add slr_reward config field ('isomorphic' or 'base').
- grpo_fast.py: Support ':' separator in dataset names for tool discovery.
- Dockerfile: Add swi-prolog package for Prolog rule evaluation.
- mkdocs.yml: Add SLR-Bench docs page.
- CHANGELOG.md: Document the new feature.