### PR TITLE
Add SLACK_EMAIL_ADDRESS Slack notification support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
+- Add `SLACK_EMAIL_ADDRESS` support for Slack alerts by emailing Slack, and pass the variable through `mason.py` into Beaker jobs (https://github.com/allenai/open-instruct/pull/1527).
 - Add `flash-attn-3` dependency for Flash Attention 3 support on H100/H800 GPUs. DPO training via olmo-core auto-detects FA3 at runtime (https://github.com/allenai/open-instruct/pull/1525).
 - Tensor parallelism (TP) support for OLMo-core DPO training (https://github.com/allenai/open-instruct/pull/1467).
 - Pulls out weight sync code from GRPO into a more generic function (https://github.com/allenai/open-instruct/pull/1411#pullrequestreview-3694117967)

--- a/mason.py
+++ b/mason.py
@@ -104,6 +104,8 @@ DEFAULT_ENV_VARS = {
     "VLLM_ATTENTION_BACKEND": "FLASH_ATTN",
 }
 
+PASSTHROUGH_ENV_VARS = ["SLACK_EMAIL_ADDRESS"]
+
 
 def get_args():
     parser = argparse.ArgumentParser()
@@ -299,6 +301,14 @@ def get_env_vars(
     # use the user's PATH; including the conda / python PATH
     if not pure_docker_mode:
         env_vars.extend([beaker.BeakerEnvVar(name="PATH", value=os.getenv("PATH"))])
+
+    env_vars.extend(
+        [
+            beaker.BeakerEnvVar(name=env_var, value=os.environ[env_var])
+            for env_var in PASSTHROUGH_ENV_VARS
+            if env_var in os.environ and env_var not in additional_env_var_names
+        ]
+    )
 
     # if all cluster is in weka, we mount the weka
     if all(c in launch_utils.WEKA_CLUSTERS for c in cluster):

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -293,12 +293,38 @@ class TestBeakerDescription(unittest.TestCase):
 
 
 class TestSlackMessage(unittest.TestCase):
-    @responses.activate
+    @mock.patch.dict(
+        os.environ,
+        {
+            "SLACK_EMAIL_ADDRESS": "alerts@example.com",
+            "ALERT_EMAIL_SENDER": "sender@example.com",
+            "SMTP_HOST": "smtp.example.com",
+            "SMTP_PORT": "2525",
+        },
+        clear=True,
+    )
     @mock.patch("open_instruct.utils.get_beaker_experiment_url")
-    @mock.patch("os.environ.get")
-    def test_send_slack_message_with_beaker_url(self, mock_environ_get, mock_get_beaker_url):
-        webhook_url = "https://hooks.slack.com/services/test"
-        mock_environ_get.return_value = webhook_url
+    @mock.patch("smtplib.SMTP")
+    def test_send_slack_message_with_email_address(self, mock_smtp, mock_get_beaker_url):
+        mock_get_beaker_url.return_value = "https://beaker.org/ex/test-456"
+
+        utils.send_slack_message("<!here> Disk is nearly full.")
+
+        mock_smtp.assert_called_once_with("smtp.example.com", 2525)
+        smtp_instance = mock_smtp.return_value.__enter__.return_value
+        smtp_instance.send_message.assert_called_once()
+        email_message = smtp_instance.send_message.call_args.args[0]
+        self.assertEqual(email_message["To"], "alerts@example.com")
+        self.assertEqual(email_message["From"], "sender@example.com")
+        self.assertEqual(email_message["Subject"], "open-instruct alert")
+        self.assertIn("Disk is nearly full", email_message.get_content())
+        self.assertIn("https://beaker.org/ex/test-456", email_message.get_content())
+
+    @responses.activate
+    @mock.patch.dict(os.environ, {"SLACK_WEBHOOK": "https://hooks.slack.com/services/test"}, clear=True)
+    @mock.patch("open_instruct.utils.get_beaker_experiment_url")
+    def test_send_slack_message_with_beaker_url(self, mock_get_beaker_url):
+        webhook_url = os.environ["SLACK_WEBHOOK"]
         mock_get_beaker_url.return_value = "https://beaker.org/ex/test-456"
 
         responses.add(responses.POST, webhook_url, json={"ok": True}, status=200)

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -40,6 +40,7 @@ import os
 import random
 import re
 import shutil
+import smtplib
 import socket
 import subprocess
 import sys
@@ -50,6 +51,7 @@ from collections.abc import Iterable
 from concurrent import futures
 from ctypes import CDLL, POINTER, Structure, c_char_p, c_int, c_ulong, c_void_p
 from dataclasses import dataclass
+from email.message import EmailMessage
 from multiprocessing import resource_tracker as _rt
 from typing import Any, NewType
 
@@ -2512,20 +2514,38 @@ def combine_reward_metrics(reward_metrics: list[dict[str, Any]]) -> dict[str, An
 
 
 def send_slack_message(message: str) -> None:
-    """Sends a message to a Slack webhook if configured.
+    """Sends a Slack alert using email or a webhook if configured.
 
     Args:
         message: Message body to send to Slack.
     """
-    slack_webhook_url = os.environ.get("SLACK_WEBHOOK")
-    if not slack_webhook_url:
-        logger.warning("SLACK_WEBHOOK environment variable not set. Skipping Slack alert.")
-        return
-
     beaker_url = get_beaker_experiment_url()
     beaker_suffix = f" Check it out: {beaker_url}" if beaker_url else ""
+    full_message = f"{message}{beaker_suffix}"
 
-    payload = {"text": f"{message}{beaker_suffix}"}
+    slack_email_address = os.environ.get("SLACK_EMAIL_ADDRESS")
+    if slack_email_address:
+        email_message = EmailMessage()
+        email_message["To"] = slack_email_address
+        email_message["Subject"] = "open-instruct alert"
+        email_message["From"] = os.environ.get("ALERT_EMAIL_SENDER", "open-instruct@localhost")
+        email_message.set_content(full_message)
+
+        smtp_host = os.environ.get("SMTP_HOST", "localhost")
+        smtp_port = int(os.environ.get("SMTP_PORT", "25"))
+        try:
+            with smtplib.SMTP(smtp_host, smtp_port) as smtp:
+                smtp.send_message(email_message)
+            return
+        except OSError as exc:
+            logger.warning("Failed to send Slack alert email due to SMTP error: %s", exc)
+
+    slack_webhook_url = os.environ.get("SLACK_WEBHOOK")
+    if not slack_webhook_url:
+        logger.warning("SLACK_EMAIL_ADDRESS and SLACK_WEBHOOK environment variables not set. Skipping Slack alert.")
+        return
+
+    payload = {"text": full_message}
     try:
         response = requests.post(slack_webhook_url, json=payload)
         if not response.ok:

--- a/test_mason.py
+++ b/test_mason.py
@@ -1,5 +1,7 @@
+import os
 import unittest
 from argparse import Namespace
+from unittest import mock
 
 import beaker
 import parameterized
@@ -179,6 +181,23 @@ class TestExperimentSpec(unittest.TestCase):
             expected_spec.host_networking = True
 
         self.assertEqual(actual_spec, expected_spec)
+
+
+class TestGetEnvVars(unittest.TestCase):
+    @mock.patch.dict(os.environ, {"SLACK_EMAIL_ADDRESS": "alerts@example.com"}, clear=True)
+    def test_slack_email_address_is_passed_through(self):
+        env_vars = mason.get_env_vars(
+            pure_docker_mode=True,
+            cluster=["ai2/jupiter"],
+            beaker_secrets=[],
+            whoami="test-user",
+            resumable=False,
+            num_nodes=1,
+            additional_env_vars=[],
+            additional_secrets=[],
+        )
+
+        self.assertIn(beaker.BeakerEnvVar(name="SLACK_EMAIL_ADDRESS", value="alerts@example.com"), env_vars)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- pass through `SLACK_EMAIL_ADDRESS` from the local environment into Beaker launches via `mason.py`
- send Slack alerts by email when `SLACK_EMAIL_ADDRESS` is configured, with webhook fallback retained
- add coverage for the email path and env passthrough

## Testing
- `uv run pytest test_mason.py::TestGetEnvVars::test_slack_email_address_is_passed_through`
- `uv run python -c "..."` smoke check for email delivery path
- `uv run python -c "..."` smoke check for webhook delivery path
- `make style`
- `make quality`

## Notes
- `open_instruct/test_utils.py` targeted pytest nodes did not complete in this environment, so the same code paths were validated with direct Python smoke checks.
