### PR TITLE
Batch vLLM weight sync broadcasts to fix 32k timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 - OLMo-core GRPO actor with Ray-distributed FSDP2 training (https://github.com/allenai/open-instruct/pull/1398).
 
 ### Fixed
-- Fix `total_batch_size` logging to account for sequence parallelism (SP ranks share data, not independent) (https://github.com/allenai/open-instruct/pull/1542).
+- Batch vLLM weight sync broadcasts to reduce Ray RPCs from ~200+ to 1, fixing timeouts with 32k response lengths (https://github.com/allenai/open-instruct/pull/1535).
 - Fix `wandb_tracker.run.url` `AttributeError` on non-main processes in multi-node SFT training by guarding accesses with `accelerator.is_main_process` checks (https://github.com/allenai/open-instruct/pull/1539).
 - Fix `UnboundLocalError` for `beaker_config` in SFT tracking setup when `push_to_hub` is disabled (https://github.com/allenai/open-instruct/pull/1539).
 - Pre-download HF model on main process before Ray actors spawn to avoid hitting HuggingFace rate limits (https://github.com/allenai/open-instruct/pull/1528).

--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -829,9 +829,10 @@ class LLMRayActor:
         expected_dtype = str(self.llm_engine.model_config.dtype)
         assert dtype == expected_dtype, f"Mismatched dtype for {name}: received {dtype!r}, expected {expected_dtype!r}"
 
-    def update_weight(self, name: str, dtype: str, shape: tuple[int, ...]) -> None:
-        self._prepare_weight_update(name, dtype)
-        return self._run_async(self.llm_engine.collective_rpc("update_weight", args=(name, dtype, shape)))
+    def update_weights_batch(self, param_metadata: list[tuple[str, str, tuple[int, ...]]]) -> None:
+        for name, dtype, _ in param_metadata:
+            self._prepare_weight_update(name, dtype)
+        return self._run_async(self.llm_engine.collective_rpc("update_weights_batch", args=(param_metadata,)))
 
     def update_weight_cuda_ipc(self, name: str, dtype: str, shape: tuple[int, ...], ipc_handles: list[Any]) -> None:
         self._prepare_weight_update(name, dtype)
@@ -1330,15 +1331,15 @@ def create_vllm_engines(
 
 
 def _send_to_vllm(
-    name: str,
-    param: torch.nn.Parameter,
-    shape: torch.Size,
+    params: list[tuple[str, torch.nn.Parameter, torch.Size]],
     vllm_engines: list[ray.actor.ActorHandle],
     model_update_group: torch.distributed.ProcessGroup,
 ) -> list[ray.ObjectRef]:
-    """Send a parameter to vLLM engines via broadcast."""
-    refs = [engine.update_weight.remote(name, dtype=str(param.dtype), shape=shape) for engine in vllm_engines]
-    torch.distributed.broadcast(param.data, 0, group=model_update_group)
+    """Send parameters to vLLM engines via a single RPC + sequential NCCL broadcasts."""
+    param_metadata = [(name, str(param.dtype), tuple(shape)) for name, param, shape in params]
+    refs = [engine.update_weights_batch.remote(param_metadata) for engine in vllm_engines]
+    for _, param, _ in params:
+        torch.distributed.broadcast(param.data, 0, group=model_update_group)
     return refs
 
 
@@ -1368,10 +1369,12 @@ def _broadcast_fsdp2_block_params(
     try:
         refs: list[ray.ObjectRef] = []
         if is_rank_0:
+            batch_params = []
             for name, param in block.named_parameters():
                 full_name = f"{block_name}.{name}" if block_name else name
                 mapped_name = name_mapper(full_name) if name_mapper else full_name
-                refs.extend(_send_to_vllm(mapped_name, param, param.shape, vllm_engines, model_update_group))
+                batch_params.append((mapped_name, param, param.shape))
+            refs = _send_to_vllm(batch_params, vllm_engines, model_update_group)
         return refs
     finally:
         block.reshard()
@@ -1384,12 +1387,12 @@ def _broadcast_params_to_vllm(
     name_mapper: Callable[[str], str] | None,
 ) -> list[ray.ObjectRef]:
     """Broadcast parameters to vLLM engines. Must be called on rank 0 only."""
-    refs: list[ray.ObjectRef] = []
+    batch_params = []
     for name, param in params:
         mapped_name = name_mapper(name) if name_mapper else name
         shape = getattr(param, "ds_shape", param.shape)
-        refs.extend(_send_to_vllm(mapped_name, param, shape, vllm_engines, model_update_group))
-    return refs
+        batch_params.append((mapped_name, param, shape))
+    return _send_to_vllm(batch_params, vllm_engines, model_update_group)
 
 
 def broadcast_weights_to_vllm(
@@ -1446,11 +1449,17 @@ def broadcast_weights_to_vllm(
                 return _broadcast_params_to_vllm(params, vllm_engines, model_update_group, name_mapper)
             return []
     else:
-        all_refs: list[ray.ObjectRef] = []
-        for name, param in params:
+        if is_rank_0:
+            param_metadata = []
+            for name, param in params:
+                mapped_name = name_mapper(name) if name_mapper else name
+                shape = tuple(getattr(param, "ds_shape", param.shape))
+                param_metadata.append((mapped_name, str(param.dtype), shape))
+            all_refs = [engine.update_weights_batch.remote(param_metadata) for engine in vllm_engines]
+        else:
+            all_refs = []
+        for _name, param in params:
             with deepspeed.zero.GatheredParameters([param], enabled=deepspeed_stage_3):
                 if is_rank_0:
-                    mapped_name = name_mapper(name) if name_mapper else name
-                    shape = getattr(param, "ds_shape", param.shape)
-                    all_refs.extend(_send_to_vllm(mapped_name, param, shape, vllm_engines, model_update_group))
+                    torch.distributed.broadcast(param.data, 0, group=model_update_group)
         return all_refs

--- a/open_instruct/vllm_utils_workerwrap.py
+++ b/open_instruct/vllm_utils_workerwrap.py
@@ -59,9 +59,12 @@ class WorkerWrap:
             collective.broadcast(weight, 0, group_name=self._model_update_group)
         else:
             torch.distributed.broadcast(weight, 0, group=self._model_update_group)
-
         self.model_runner.model.load_weights(weights=[(name, weight)])
         del weight
+
+    def update_weights_batch(self, param_metadata):
+        for name, dtype, shape in param_metadata:
+            self.update_weight(name, dtype, shape)
 
     def update_weight_cuda_ipc(self, name, dtype, shape, ipc_handles=None):
         import torch


### PR DESCRIPTION
Weight sync was timing out (>120s) when training with 32k response lengths because each of the ~200+ model parameters required a separate Ray RPC and vLLM event loop scheduling.

## Why it was slow

The old per-parameter flow repeated this for every parameter:

1. Trainer fires `engine.update_weight.remote(name_i)` — Ray RPC overhead (serialization, scheduling, network)
2. LLMRayActor receives the RPC, submits `collective_rpc("update_weight")` to the vLLM async event loop — blocks until the event loop schedules it (with `inflight_updates=True` and 32k sequences, each inference step is slow, so event loop scheduling latency is high)
3. WorkerWrap allocates a tensor and calls `torch.distributed.broadcast()` — NCCL collective, blocks until the trainer also broadcasts
4. Trainer calls `torch.distributed.broadcast(param.data)` — actual GPU-to-GPU data transfer

The NCCL broadcasts (step 4) are fast (~0.5s total for all parameters). The overhead was steps 1-3 repeated 200+ times: ~200 Ray RPCs, ~200 event loop schedulings, ~200 `_run_async` round-trips.

## What changed

Replaced per-parameter RPCs with a single batched RPC. The trainer now sends one `engine.update_weights_batch.remote(metadata)` containing all parameter names/dtypes/shapes, then loops through the NCCL broadcasts. The worker receives one RPC, enters its own loop, and the two sides stay in lockstep via NCCL synchronization. This reduces overhead from `200 * (RPC + event_loop_wait)` to `1 * (RPC + event_loop_wait)`.

No change to memory usage — the worker still allocates and frees each weight tensor one at a time.

Also renamed to `update_weights_batch` to avoid conflicting with vLLM 0.16's built-in `update_weights` attribute on the Worker class.

## Results

Tested with Qwen3-4B at 32k response length on 2x8 GPU nodes (on `origin/finbarr/qwen-baseline`):

| Metric | Baseline | Batched | Speedup |
|---|---|---|---|
| **weight_sync (per-step)** | 8.8 – 12.2s | 0.40 – 0.49s | ~25x |
| **weight_sync_mean** | 1.5 – 1.9s | 0.21 – 0.24s | ~7-8x |
| **weight_sync_median** | 0.44 – 0.55s | 0.18 – 0.21s | ~2.5x |
| **weight_sync_max** | 8.8 – 12.0s | 0.40 – 0.49s | ~25x |

Runs:

1. Baseline (per-param, `origin/finbarr/qwen-baseline`): [Beaker](https://beaker.org/ex/01KM41GJ3B39EM5NEEVNJMERE3)
2. Batched (`batch-weight-sync` merged onto `origin/finbarr/qwen-baseline`): [Beaker](https://beaker.org/ex/01KM635K1Y0AY70WC0ZNFSJ8C2)

GPU_TESTS=bypass