### PR TITLE
Rename num_unique_prompts_rollout and num_samples_per_prompt_rollout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 
+### Changed
+- Rename `num_unique_prompts_rollout` → `num_unique_prompts` and `num_samples_per_prompt_rollout` → `num_samples_per_prompt` (https://github.com/allenai/open-instruct/pull/1538).
+
 ### Added
 - Add Muon optimizer support to DPO training via OLMo-core's native MuonConfig (https://github.com/allenai/open-instruct/pull/1533).
 - Add documentation for Slack alert integrations in GRPO and DPO training (https://github.com/allenai/open-instruct/pull/1529).

--- a/open_instruct/actor_manager.py
+++ b/open_instruct/actor_manager.py
@@ -123,8 +123,8 @@ class ActorManager:
                 "timing_stats": self.get_timing_stats(),
                 "concurrency_per_engine": self._kv_cache_max_concurrency,
                 "total_concurrency": self._kv_cache_max_concurrency * self._vllm_config.vllm_num_engines,
-                "batch_size": self._streaming_config.num_unique_prompts_rollout
-                * self._streaming_config.num_samples_per_prompt_rollout,
+                "batch_size": self._streaming_config.num_unique_prompts
+                * self._streaming_config.num_samples_per_prompt,
             }
 
         def run_server():

--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -111,9 +111,9 @@ def save_benchmark_results_to_csv(
         "git_commit": git_commit,
         "model": model_config.model_name_or_path,
         "total_batches": len(results),
-        "batch_size": streaming_config.num_unique_prompts_rollout * streaming_config.num_samples_per_prompt_rollout,
-        "num_unique_prompts_rollout": streaming_config.num_unique_prompts_rollout,
-        "num_samples_per_prompt_rollout": streaming_config.num_samples_per_prompt_rollout,
+        "batch_size": streaming_config.num_unique_prompts * streaming_config.num_samples_per_prompt,
+        "num_unique_prompts": streaming_config.num_unique_prompts,
+        "num_samples_per_prompt": streaming_config.num_samples_per_prompt,
         "response_length": streaming_config.response_length,
         "total_time": total_time,
         "total_generation_time": agg_results["total_generation_time"],
@@ -129,11 +129,7 @@ def save_benchmark_results_to_csv(
         "avg_generation_time_per_batch": agg_results["avg_generation_time"],
         "avg_weight_sync_time_per_batch": agg_results["avg_weight_sync_time"],
         "avg_new_tokens_per_sample": agg_results["total_num_new_tokens"]
-        / (
-            len(results)
-            * streaming_config.num_unique_prompts_rollout
-            * streaming_config.num_samples_per_prompt_rollout
-        ),
+        / (len(results) * streaming_config.num_unique_prompts * streaming_config.num_samples_per_prompt),
     }
 
     csv_path: pathlib.Path = DATA_DIR / "generator_benchmark_results.csv"
@@ -361,7 +357,7 @@ def run_benchmark(
 ) -> list[dict[str, Any]]:
     """Run the full benchmark."""
     logger.info(
-        f"Starting benchmark with 1 warmup batch + {num_batches - 1} main batches of size {streaming_config.num_unique_prompts_rollout}"
+        f"Starting benchmark with 1 warmup batch + {num_batches - 1} main batches of size {streaming_config.num_unique_prompts}"
     )
 
     # Create sampling parameters with 'n' for multiple samples per prompt
@@ -369,7 +365,7 @@ def run_benchmark(
         temperature=streaming_config.temperature,
         max_tokens=streaming_config.response_length,
         top_p=vllm_config.vllm_top_p,
-        n=streaming_config.num_samples_per_prompt_rollout,
+        n=streaming_config.num_samples_per_prompt,
         seed=args.seed,
         logprobs=1,
     )
@@ -384,7 +380,7 @@ def run_benchmark(
     # Submit warmup batch first
     logger.info("Submitting warmup batch...")
     warmup_start_idx = 0
-    warmup_end_idx = min(streaming_config.num_unique_prompts_rollout, len(dataset))
+    warmup_end_idx = min(streaming_config.num_unique_prompts, len(dataset))
     warmup_data = dataset[warmup_start_idx:warmup_end_idx]
     warmup_prompts = warmup_data[dataset_transformation.INPUT_IDS_PROMPT_KEY]
     # Create individual PromptRequest for each warmup prompt
@@ -434,7 +430,7 @@ def run_benchmark(
             dataset,
             generation_config,
             stop_event,
-            streaming_config.num_unique_prompts_rollout,
+            streaming_config.num_unique_prompts,
             1,
             num_batches - 1,
         )
@@ -445,7 +441,7 @@ def run_benchmark(
                 submission_future.result()
 
             # Collect all results for this batch (one per prompt) using non-blocking polling
-            num_prompts = streaming_config.num_unique_prompts_rollout
+            num_prompts = streaming_config.num_unique_prompts
             batch_results = []
             batch_deadline = time.time() + 1200
             while len(batch_results) < num_prompts:
@@ -503,7 +499,7 @@ def run_benchmark(
                 all_prompt_lengths,
                 batch_generation_time,
                 response_lengths=all_response_lengths,
-                samples_per_prompt=streaming_config.num_samples_per_prompt_rollout,
+                samples_per_prompt=streaming_config.num_samples_per_prompt,
                 num_gpus=num_inference_gpus,
             )
 
@@ -511,7 +507,7 @@ def run_benchmark(
                 all_prompt_lengths,
                 batch_generation_time,
                 response_lengths=all_response_lengths,
-                samples_per_prompt=streaming_config.num_samples_per_prompt_rollout,
+                samples_per_prompt=streaming_config.num_samples_per_prompt,
                 num_engines=num_engines,
                 num_gpus_per_engine=num_gpus_per_engine,
             )
@@ -601,9 +597,7 @@ def print_summary(
     """Print benchmark summary statistics."""
 
     agg_results = aggregate_results(results)
-    total_samples = (
-        len(results) * streaming_config.num_unique_prompts_rollout * streaming_config.num_samples_per_prompt_rollout
-    )
+    total_samples = len(results) * streaming_config.num_unique_prompts * streaming_config.num_samples_per_prompt
     avg_new_tokens_per_sample = agg_results["total_num_new_tokens"] / total_samples
 
     print("\n" + "=" * 60)
@@ -611,11 +605,9 @@ def print_summary(
     print("=" * 60)
     print(f"Model: {model_config.model_name_or_path}")
     print(f"Main benchmark batches: {len(results)} (after 1 warmup batch)")
-    print(
-        f"Batch size: {streaming_config.num_unique_prompts_rollout * streaming_config.num_samples_per_prompt_rollout}"
-    )
-    print(f"Unique prompts per batch: {streaming_config.num_unique_prompts_rollout}")
-    print(f"Num rollouts: {streaming_config.num_samples_per_prompt_rollout}")
+    print(f"Batch size: {streaming_config.num_unique_prompts * streaming_config.num_samples_per_prompt}")
+    print(f"Unique prompts per batch: {streaming_config.num_unique_prompts}")
+    print(f"Num rollouts: {streaming_config.num_samples_per_prompt}")
     print(f"Max tokens: {streaming_config.response_length}")
     print("-" * 60)
     print(f"Total time (main benchmark): {agg_results['total_generation_time']:.2f}s")

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -409,8 +409,8 @@ class StreamingDataLoaderConfig:
 
     # Batching
     async_steps: int = 1
-    num_samples_per_prompt_rollout: int = 4
-    num_unique_prompts_rollout: int = 16
+    num_samples_per_prompt: int = 4
+    num_unique_prompts: int = 16
 
     # GRPO sampling/filtering
     active_sampling: bool = False
@@ -494,9 +494,9 @@ class StreamingDataLoaderConfig:
         assert self.pack_length >= self.max_prompt_token_length + self.response_length, (
             "The `pack_length` needs to be greater than the sum of `max_prompt_token_length` and `response_length`!"
         )
-        assert self.num_samples_per_prompt_rollout > 0, "Number of samples per prompt must be greater than 0!"
-        if self.num_samples_per_prompt_rollout == 1:
-            logger.warning("num_samples_per_prompt_rollout is 1. This reduces GRPO to REINFORCE.")
+        assert self.num_samples_per_prompt > 0, "Number of samples per prompt must be greater than 0!"
+        if self.num_samples_per_prompt == 1:
+            logger.warning("num_samples_per_prompt is 1. This reduces GRPO to REINFORCE.")
 
         if self.active_sampling:
             assert self.async_steps > 1, (
@@ -508,9 +508,9 @@ class StreamingDataLoaderConfig:
                 "filter_zero_std_samples must be True when active_sampling is True. "
                 "Active sampling requires filtering to work correctly."
             )
-        if self.num_samples_per_prompt_rollout == 1 and self.filter_zero_std_samples:
+        if self.num_samples_per_prompt == 1 and self.filter_zero_std_samples:
             raise ValueError(
-                "`filter_zero_std_samples` cannot be True when `num_samples_per_prompt_rollout` is 1, "
+                "`filter_zero_std_samples` cannot be True when `num_samples_per_prompt` is 1, "
                 "as the reward standard deviation will always be 0, causing all samples to be filtered."
             )
         if self.async_steps < 1:
@@ -550,7 +550,7 @@ class StreamingDataLoaderConfig:
             data_prep_actor_name=data_prep_actor_name,
             tokenizer=tokenizer,
             work_dir=work_dir,
-            global_batch_size=self.num_unique_prompts_rollout,
+            global_batch_size=self.num_unique_prompts,
             num_training_steps=num_training_steps,
             dp_world_size=dp_world_size,
             dp_rank=dp_rank,
@@ -1255,11 +1255,11 @@ class DataPreparationActor:
             assert batch is not None
             assert batch_stats is not None
             scores = np.array(batch.scores)
-            scores_per_prompt = scores.reshape(-1, self.config.num_samples_per_prompt_rollout)
+            scores_per_prompt = scores.reshape(-1, self.config.num_samples_per_prompt)
             mean_grouped_rewards = scores_per_prompt.mean(axis=-1)
-            mean_grouped_rewards = np.repeat(mean_grouped_rewards, self.config.num_samples_per_prompt_rollout, axis=0)
+            mean_grouped_rewards = np.repeat(mean_grouped_rewards, self.config.num_samples_per_prompt, axis=0)
             std_grouped_rewards = scores_per_prompt.std(axis=-1)
-            std_grouped_rewards = np.repeat(std_grouped_rewards, self.config.num_samples_per_prompt_rollout, axis=0)
+            std_grouped_rewards = np.repeat(std_grouped_rewards, self.config.num_samples_per_prompt, axis=0)
 
             if self.config.advantage_normalization_type == "standard":
                 advantages = (scores - mean_grouped_rewards) / (std_grouped_rewards + 1e-8)
@@ -1276,7 +1276,7 @@ class DataPreparationActor:
                     batch,
                     result,
                     advantages,
-                    self.config.num_samples_per_prompt_rollout,
+                    self.config.num_samples_per_prompt,
                     self.total_samples_written,
                 )
                 self.total_samples_written += len(batch.queries)
@@ -1327,7 +1327,7 @@ class DataPreparationActor:
                 step_metrics = {"time/generation_idle_waiting_for_trainer": generation_idle_wait_time}
             else:
                 real_num_responses = len(result.responses)
-                expected_num_responses = self.config.num_samples_per_prompt_rollout * self.global_batch_size
+                expected_num_responses = self.config.num_samples_per_prompt * self.global_batch_size
                 unsolved_num_responses = (scores < self.config.max_possible_score).sum()
                 sequence_lengths = np.array([len(response) for response in result.responses])
                 sequence_length_solved = (
@@ -1352,7 +1352,7 @@ class DataPreparationActor:
                     "unsolved_batch_size_ratio": unsolved_num_responses / real_num_responses,
                     "packed_ratio": len(packed_sequences.query_responses) / real_num_responses,
                     "val/solve_rate_hist": batch_stats.percent_solved_hist,
-                    "val/total_reward_groups": real_num_responses / self.config.num_samples_per_prompt_rollout,
+                    "val/total_reward_groups": real_num_responses / self.config.num_samples_per_prompt,
                     "val/sequence_lengths": sequence_lengths.mean(),
                     "val/sequence_lengths_min": sequence_lengths.min(),
                     "val/sequence_lengths_max": sequence_lengths.max(),

--- a/open_instruct/environments/tools/utils.py
+++ b/open_instruct/environments/tools/utils.py
@@ -61,7 +61,7 @@ class EnvsConfig:
     """Pass tool definitions to the chat template. Set to False if using a custom system prompt."""
 
     pool_size: int | None = None
-    """Number of actors per tool pool. Defaults to num_unique_prompts_rollout * num_samples_per_prompt_rollout."""
+    """Number of actors per tool pool. Defaults to num_unique_prompts * num_samples_per_prompt."""
 
     _parsed_tools: list[ParsedEnvConfig] = field(default_factory=list, init=False)
     """Parsed tool configurations. Populated during __post_init__."""

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1000,17 +1000,17 @@ def validate_configs(
     sequence_parallel_size: int,
 ) -> None:
     """Validate cross-cutting config constraints."""
-    if streaming_config.num_unique_prompts_rollout < vllm_config.vllm_num_engines:
+    if streaming_config.num_unique_prompts < vllm_config.vllm_num_engines:
         logger.warning(
-            f"With num_unique_prompts_rollout={streaming_config.num_unique_prompts_rollout} < "
+            f"With num_unique_prompts={streaming_config.num_unique_prompts} < "
             f"vllm_num_engines={vllm_config.vllm_num_engines}, vllm will be generating data for multiple "
             "batches simultaneously. This is fine but might be unexpected behaviour."
         )
     assert (
-        streaming_config.num_samples_per_prompt_rollout * streaming_config.num_unique_prompts_rollout
+        streaming_config.num_samples_per_prompt * streaming_config.num_unique_prompts
         >= sum(num_learners_per_node) // sequence_parallel_size
     ), (
-        "num_samples_per_prompt_rollout * num_unique_prompts_rollout must be greater than or equal to world_size // sequence_parallel_size to ensure we have a batch for each rank in distributed training."
+        "num_samples_per_prompt * num_unique_prompts must be greater than or equal to world_size // sequence_parallel_size to ensure we have a batch for each rank in distributed training."
     )
 
 
@@ -1033,7 +1033,7 @@ def setup_runtime_variables(
         )
     args.world_size = sum(args.num_learners_per_node)
     args.num_training_steps = args.total_episodes // (
-        streaming_config.num_unique_prompts_rollout * streaming_config.num_samples_per_prompt_rollout
+        streaming_config.num_unique_prompts * streaming_config.num_samples_per_prompt
     )
     args.try_launch_beaker_eval_jobs_on_weka = args.try_launch_beaker_eval_jobs_on_weka and is_beaker_job()
     if args.push_to_hub:
@@ -1292,7 +1292,7 @@ def create_model_and_optimizer(
         num_training_steps=args.num_training_steps,
         seed=args.seed,
         per_device_train_batch_size=args.per_device_train_batch_size,
-        global_batch_size=streaming_config.num_unique_prompts_rollout,
+        global_batch_size=streaming_config.num_unique_prompts,
         dp_world_size=args.world_size // args.sequence_parallel_size,
         max_possible_score=streaming_config.max_possible_score,
         actor_manager=actor_manager,
@@ -1362,19 +1362,19 @@ def create_model_and_optimizer(
         kv_cache_max_concurrency = ray.get(vllm_engines[0].get_kv_cache_info.remote())
         ray.get(actor_manager.set_kv_cache_max_concurrency.remote(kv_cache_max_concurrency))
         expected_batch_size = (
-            streaming_config.num_unique_prompts_rollout
-            * streaming_config.num_samples_per_prompt_rollout
+            streaming_config.num_unique_prompts
+            * streaming_config.num_samples_per_prompt
             // vllm_config.vllm_num_engines
         )
         if kv_cache_max_concurrency < expected_batch_size:
             nodes_needed = math.ceil(
-                streaming_config.num_unique_prompts_rollout
-                * streaming_config.num_samples_per_prompt_rollout
+                streaming_config.num_unique_prompts
+                * streaming_config.num_samples_per_prompt
                 / kv_cache_max_concurrency
             )
             logger.warning(
                 f"kv_cache_max_concurrency ({kv_cache_max_concurrency}) is lower than "
-                f"num_unique_prompts_rollout * num_samples_per_prompt_rollout // vllm_num_engines ({expected_batch_size}). "
+                f"num_unique_prompts * num_samples_per_prompt // vllm_num_engines ({expected_batch_size}). "
                 f"This means actors will have to run multiple sequential batches, hurting performance. "
                 f"You might want to use more inference nodes ({nodes_needed} nodes to generate the entire batch simultaneously)."
             )
@@ -1385,9 +1385,7 @@ def create_model_and_optimizer(
     results, _ = ray_get_with_progress(inits, desc="Initializing models")
     resume_training_step = results[0] + 1
     episode = (
-        (resume_training_step - 1)
-        * streaming_config.num_unique_prompts_rollout
-        * streaming_config.num_samples_per_prompt_rollout
+        (resume_training_step - 1) * streaming_config.num_unique_prompts * streaming_config.num_samples_per_prompt
     )
     logger.info("======== ✅ all models initialized =========")
 
@@ -1408,7 +1406,7 @@ def create_generation_configs(
         temperature=streaming_config.temperature,
         top_p=vllm_config.vllm_top_p,
         max_tokens=streaming_config.response_length,
-        n=streaming_config.num_samples_per_prompt_rollout,
+        n=streaming_config.num_samples_per_prompt,
         stop=streaming_config.stop_strings,
         seed=args.seed,
         logprobs=1,
@@ -1579,7 +1577,7 @@ def one_training_step(
         prompt_lengths=prompt_lengths,
         response_lengths=response_lengths,
         total_generation_time=total_generation_time,
-        samples_per_prompt=streaming_config.num_samples_per_prompt_rollout,
+        samples_per_prompt=streaming_config.num_samples_per_prompt,
         num_engines=vllm_config.vllm_num_engines,
         num_gpus_per_engine=vllm_config.vllm_tensor_parallel_size,
         training_time=train_timer.duration,
@@ -1592,7 +1590,7 @@ def one_training_step(
         "training_step": training_step,
         "val/num_total_tokens": num_total_tokens,
         "val/num_step_tokens": num_step_tokens,
-        "epoch": episode / streaming_config.num_samples_per_prompt_rollout / len(train_dataset),
+        "epoch": episode / streaming_config.num_samples_per_prompt / len(train_dataset),
         "learner_tokens_per_second_overall": num_total_tokens / total_training_time,
         "learner_tokens_per_second_step": num_step_tokens / step_time,
         "time/total": step_time,
@@ -1972,7 +1970,7 @@ def run_training(
                 )
             eval_data_loader.reset()
 
-        episode += streaming_config.num_unique_prompts_rollout * streaming_config.num_samples_per_prompt_rollout
+        episode += streaming_config.num_unique_prompts * streaming_config.num_samples_per_prompt
 
         data_thread_metrics = {}
         try:
@@ -2231,7 +2229,7 @@ def main(
 
     pool_size = tools_config.pool_size
     if pool_size is None:
-        pool_size = streaming_config.num_unique_prompts_rollout * streaming_config.num_samples_per_prompt_rollout
+        pool_size = streaming_config.num_unique_prompts * streaming_config.num_samples_per_prompt
     logger.info(f"Pool size per tool: {pool_size}")
 
     pools, tool_definitions, tool_stop_sequences = initialize_tools_and_envs(
@@ -2255,11 +2253,9 @@ def main(
         configured_tool_call_names=tools_config.tool_call_names if tools_config.enabled else None,
     )
 
-    if len(train_dataset) < (
-        needed := max(streaming_config.async_steps, 1) * streaming_config.num_unique_prompts_rollout
-    ):
+    if len(train_dataset) < (needed := max(streaming_config.async_steps, 1) * streaming_config.num_unique_prompts):
         raise ValueError(
-            f"Train dataset is too small! Is {len(train_dataset)} prompts, but {needed} are needed to have enough prompts for bsz and prefill. Try reducing async_steps or num_unique_prompts_rollout, or increasing the dataset size."
+            f"Train dataset is too small! Is {len(train_dataset)} prompts, but {needed} are needed to have enough prompts for bsz and prefill. Try reducing async_steps or num_unique_prompts, or increasing the dataset size."
         )
 
     if args.cache_dataset_only:
@@ -2276,7 +2272,7 @@ def main(
     # - all prompts from async_steps + 1 training steps
     # - all eval prompts
     num_eval_prompts = len(eval_dataset) if eval_dataset is not None else 0
-    queue_size = (streaming_config.async_steps + 1) * streaming_config.num_unique_prompts_rollout + num_eval_prompts
+    queue_size = (streaming_config.async_steps + 1) * streaming_config.num_unique_prompts + num_eval_prompts
     inference_results_Q = ray_queue.Queue(maxsize=queue_size)
     prompt_Q = ray_queue.Queue(maxsize=queue_size)
     # We don't care if we ever hit the max, so we let the queue be unbounded.

--- a/open_instruct/rubrics/rubric_utils.py
+++ b/open_instruct/rubrics/rubric_utils.py
@@ -59,7 +59,7 @@ async def generate_instance_wise_evolving_rubrics(
 async def _generate_instance_wise_evolving_rubrics(
     responses: list[str],
     ground_truths: list,
-    num_samples_per_prompt_rollout: int,
+    num_samples_per_prompt: int,
     rubric_buffer: dict[str, Any] | None = None,
     use_full_responses: bool = True,
     answer_length_limit_in_words: int | None = None,
@@ -69,7 +69,7 @@ async def _generate_instance_wise_evolving_rubrics(
     Args:
         responses: List of all responses (flattened across prompts)
         ground_truths: List of ground truth data for each response
-        num_samples_per_prompt_rollout: Number of responses per prompt
+        num_samples_per_prompt: Number of responses per prompt
         rubric_buffer: Optional buffer of existing rubrics per query
         use_full_responses: Whether to use full responses vs extracted answers
         answer_length_limit_in_words: Optional word limit for answer subsampling
@@ -79,7 +79,7 @@ async def _generate_instance_wise_evolving_rubrics(
     """
     ground_truths = [json.loads(ground_truth[0]) for ground_truth in ground_truths]
 
-    num_prompts = len(responses) // num_samples_per_prompt_rollout
+    num_prompts = len(responses) // num_samples_per_prompt
 
     query_key = "query" if "query" in ground_truths[0] else "Question"
     assert query_key in ground_truths[0], f"Query key {query_key} not found in ground truth"
@@ -88,8 +88,8 @@ async def _generate_instance_wise_evolving_rubrics(
     tasks = []
     num_subsampled_answers_list = []
     for i in range(num_prompts):
-        start_idx = i * num_samples_per_prompt_rollout
-        end_idx = start_idx + num_samples_per_prompt_rollout
+        start_idx = i * num_samples_per_prompt
+        end_idx = start_idx + num_samples_per_prompt
 
         # Get the question from the first ground truth in this group
         question = ground_truths[start_idx][query_key]
@@ -147,7 +147,7 @@ async def _generate_instance_wise_evolving_rubrics(
 def update_ground_truths_with_evolving_rubrics(
     ground_truths: list,
     all_evolving_rubrics: list[dict[str, Any] | None],
-    num_samples_per_prompt_rollout: int,
+    num_samples_per_prompt: int,
     rubric_buffer: dict[str, Any] | None = None,
 ) -> tuple[list, float, float, float, float, dict[str, Any] | None, int]:
     """Update ground truths with newly generated evolving rubrics.
@@ -155,7 +155,7 @@ def update_ground_truths_with_evolving_rubrics(
     Args:
         ground_truths: List of ground truth data (may be wrapped in lists)
         all_evolving_rubrics: List of evolving rubrics per prompt
-        num_samples_per_prompt_rollout: Number of responses per prompt
+        num_samples_per_prompt: Number of responses per prompt
         rubric_buffer: Optional buffer to update with new rubrics
 
     Returns:
@@ -174,10 +174,10 @@ def update_ground_truths_with_evolving_rubrics(
     num_active_buffer_rubrics = []
 
     # Expand evolving_rubrics to match ground_truths structure
-    # Each evolving rubric applies to num_samples_per_prompt_rollout ground truths
+    # Each evolving rubric applies to num_samples_per_prompt ground truths
     expanded_evolving_rubrics = []
     for rubric in all_evolving_rubrics:
-        for _ in range(num_samples_per_prompt_rollout):
+        for _ in range(num_samples_per_prompt):
             expanded_evolving_rubrics.append(rubric)
 
     # Track processed queries to avoid duplicate buffer updates
@@ -298,7 +298,7 @@ def save_evolving_rubric_cache_safe(
     ground_truths: list,
     all_evolving_rubrics: list,
     num_subsampled_answers_list: list[int],
-    num_samples_per_prompt_rollout: int,
+    num_samples_per_prompt: int,
     use_full_responses: bool,
     answer_length_limit_in_words: int | None,
 ) -> str:
@@ -313,7 +313,7 @@ def save_evolving_rubric_cache_safe(
         ground_truths: List of ground truth data (inputs)
         all_evolving_rubrics: List of generated evolving rubrics (outputs)
         num_subsampled_answers_list: List of subsampled answer counts (outputs)
-        num_samples_per_prompt_rollout: Number of samples per prompt (config)
+        num_samples_per_prompt: Number of samples per prompt (config)
         use_full_responses: Whether full responses were used (config)
         answer_length_limit_in_words: Word limit for answers (config)
 
@@ -339,7 +339,7 @@ def save_evolving_rubric_cache_safe(
         "inputs": {
             "decoded_responses": decoded_responses,
             "ground_truths": ground_truths,
-            "num_samples_per_prompt_rollout": num_samples_per_prompt_rollout,
+            "num_samples_per_prompt": num_samples_per_prompt,
             "use_full_responses": use_full_responses,
             "answer_length_limit_in_words": answer_length_limit_in_words,
         },

--- a/open_instruct/rubrics/test_rubrics.py
+++ b/open_instruct/rubrics/test_rubrics.py
@@ -200,11 +200,11 @@ class TestUpdateGroundTruthsWithEvolvingRubrics(unittest.TestCase):
             },
         ]
 
-        num_samples_per_prompt_rollout = 2
+        num_samples_per_prompt = 2
 
         updated_gts, rate, avg_gt, avg_ar, avg_active_buf, buffer, skipped = (
             update_ground_truths_with_evolving_rubrics(
-                ground_truths.copy(), all_evolving_rubrics, num_samples_per_prompt_rollout, rubric_buffer=None
+                ground_truths.copy(), all_evolving_rubrics, num_samples_per_prompt, rubric_buffer=None
             )
         )
 
@@ -286,7 +286,7 @@ class TestSaveEvolvingRubricCacheSafe(unittest.TestCase):
                 {"positive_rubrics": [], "negative_rubrics": []},
             ],
             "num_subsampled_answers_list": [2, 2],
-            "num_samples_per_prompt_rollout": 2,
+            "num_samples_per_prompt": 2,
             "use_full_responses": True,
             "answer_length_limit_in_words": None,
         }

--- a/open_instruct/test_grpo_fast.py
+++ b/open_instruct/test_grpo_fast.py
@@ -249,11 +249,11 @@ class TestGrpoFastBase(unittest.TestCase):
 
 class TestGrpoFastVLLM(TestGrpoFastBase):
     @parameterized.expand([(1, 16), (2, 32), (4, 64), (8, 128)])
-    def test_batch_splitting_and_engine_configurations(self, vllm_num_engines: int, num_unique_prompts_rollout: int):
+    def test_batch_splitting_and_engine_configurations(self, vllm_num_engines: int, num_unique_prompts: int):
         """Test batch splitting and accumulation with various engine configurations."""
         # Create test data
         queries_next, ground_truths_next, datasets_next, raw_queries_next, dataset_indices = self.create_test_data(
-            num_unique_prompts_rollout
+            num_unique_prompts
         )
 
         # Setup and split batch
@@ -262,7 +262,7 @@ class TestGrpoFastVLLM(TestGrpoFastBase):
         )
 
         # Verify that we have the expected number of items in the queue (one per prompt)
-        self.assertEqual(prompt_Q.qsize(), num_unique_prompts_rollout)
+        self.assertEqual(prompt_Q.qsize(), num_unique_prompts)
 
         # Simulate vLLM processing
         batch_idx = 0
@@ -283,7 +283,7 @@ class TestGrpoFastVLLM(TestGrpoFastBase):
         combined_ground_truths = []
         combined_datasets = []
 
-        for _ in range(num_unique_prompts_rollout):
+        for _ in range(num_unique_prompts):
             result = inference_results_Q.get()
             dataset_index = result.index
 
@@ -333,11 +333,11 @@ class TestGrpoFastVLLM(TestGrpoFastBase):
     def test_dataset_index_preservation_through_pipeline(self):
         """Test that dataset indices are correctly preserved through the pipeline."""
         vllm_num_engines = 4
-        num_unique_prompts_rollout = 32
+        num_unique_prompts = 32
 
         # Create test data
         queries_next, ground_truths_next, datasets_next, raw_queries_next, dataset_indices = self.create_test_data(
-            num_unique_prompts_rollout
+            num_unique_prompts
         )
 
         # Setup and split batch
@@ -359,7 +359,7 @@ class TestGrpoFastVLLM(TestGrpoFastBase):
         combined_ground_truths = []
         combined_datasets = []
 
-        for _ in range(num_unique_prompts_rollout):
+        for _ in range(num_unique_prompts):
             result = inference_results_Q.get()
             dataset_index = result.index
 
@@ -381,11 +381,11 @@ class TestGrpoFastVLLM(TestGrpoFastBase):
     @parameterized.expand([(1, 16), (2, 8), (4, 4)])
     def test_multiple_samples_per_prompt(self, vllm_num_engines: int, num_samples_per_prompt: int):
         """Test handling of multiple samples per prompt."""
-        num_unique_prompts_rollout = 16
+        num_unique_prompts = 16
 
         # Create test data
         queries_next, ground_truths_next, datasets_next, raw_queries_next, dataset_indices = self.create_test_data(
-            num_unique_prompts_rollout
+            num_unique_prompts
         )
 
         # Setup and split batch
@@ -408,7 +408,7 @@ class TestGrpoFastVLLM(TestGrpoFastBase):
         combined_ground_truths = []
         combined_datasets = []
 
-        for _ in range(num_unique_prompts_rollout):
+        for _ in range(num_unique_prompts):
             result = inference_results_Q.get()
             dataset_index = result.index
 
@@ -447,7 +447,7 @@ class TestGrpoFastVLLM(TestGrpoFastBase):
         self.assertEqual(sorted(combined_datasets), sorted(datasets_next))
 
         # Verify correct number of responses
-        expected_responses = num_unique_prompts_rollout * num_samples_per_prompt
+        expected_responses = num_unique_prompts * num_samples_per_prompt
         self.assertEqual(len(combined_result.responses), expected_responses)
 
 

--- a/open_instruct/test_streaming_data_loader_gpu.py
+++ b/open_instruct/test_streaming_data_loader_gpu.py
@@ -115,7 +115,7 @@ class TestStreamingDataLoaderGPU(TestGrpoFastBase):
             max_prompt_token_length=64,
             response_length=32,
             async_steps=1,
-            num_samples_per_prompt_rollout=2,
+            num_samples_per_prompt=2,
             filter_zero_std_samples=False,
             pack_length=128,
         )
@@ -227,7 +227,7 @@ class TestStreamingDataLoaderGPU(TestGrpoFastBase):
             max_prompt_token_length=128,
             response_length=128,
             async_steps=1,
-            num_samples_per_prompt_rollout=2,
+            num_samples_per_prompt=2,
             filter_zero_std_samples=False,
             pack_length=512,
             mask_tool_use=True,

--- a/scripts/benchmarking/launch_benchmark_single_gpu.sh
+++ b/scripts/benchmarking/launch_benchmark_single_gpu.sh
@@ -73,8 +73,8 @@ for model_name_or_path in "$@"; do
 	          --verbose False \
             --response_length "$response_length" \
             --vllm_top_p 0.9 \
-            --num_unique_prompts_rollout 2 \
-            --num_samples_per_prompt_rollout 4 \
+            --num_unique_prompts 2 \
+            --num_samples_per_prompt 4 \
             --vllm_num_engines 1 \
 	    --inflight_updates True \
             --vllm_tensor_parallel_size 1 \

--- a/scripts/benchmarking/launch_benchmark_single_node.sh
+++ b/scripts/benchmarking/launch_benchmark_single_node.sh
@@ -68,8 +68,8 @@ for model_name_or_path in "$@"; do
 	          --verbose True \
             --response_length "$response_length" \
             --vllm_top_p 0.9 \
-            --num_unique_prompts_rollout 16 \
-            --num_samples_per_prompt_rollout 4 \
+            --num_unique_prompts 16 \
+            --num_samples_per_prompt 4 \
 	    --inflight_updates True \
             --vllm_num_engines 2 \
             --vllm_tensor_parallel_size 4 \

--- a/scripts/benchmarking/olmo3_infra.sh
+++ b/scripts/benchmarking/olmo3_infra.sh
@@ -36,8 +36,8 @@ for split_var in mixin_it_up; do
         --exp_name ${exp_name} \
         --beta 0.0 \
 	--async_steps=4 \
-        --num_samples_per_prompt_rollout 2 \
-        --num_unique_prompts_rollout 64 \
+        --num_samples_per_prompt 2 \
+        --num_unique_prompts 64 \
         --num_mini_batches 1 \
         --num_epochs 1 \
         --learning_rate 1e-6 \

--- a/scripts/train/debug/code.sh
+++ b/scripts/train/debug/code.sh
@@ -2,8 +2,8 @@
 python open_instruct/grpo_fast.py \
     --exp_name "test" \
     --beta 0.01 \
-    --num_unique_prompts_rollout 48 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 48 \
+    --num_samples_per_prompt 16 \
     --try_launch_beaker_eval_jobs_on_weka \
     --kl_estimator 2 \
     --learning_rate 5e-7 \

--- a/scripts/train/debug/envs/counter_1gpu.sh
+++ b/scripts/train/debug/envs/counter_1gpu.sh
@@ -19,8 +19,8 @@ uv run python open_instruct/grpo_fast.py \
     --response_length 1024 \
     --pack_length 1536 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 4 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 4 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen3-0.6B \
     --temperature 1.0 \
     --learning_rate 3e-7 \

--- a/scripts/train/debug/envs/guess_number_1gpu.sh
+++ b/scripts/train/debug/envs/guess_number_1gpu.sh
@@ -19,8 +19,8 @@ uv run python open_instruct/grpo_fast.py \
     --response_length 1024 \
     --pack_length 1536 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 4 \
-    --num_samples_per_prompt_rollout 2 \
+    --num_unique_prompts 4 \
+    --num_samples_per_prompt 2 \
     --model_name_or_path Qwen/Qwen3-0.6B \
     --temperature 0.7 \
     --learning_rate 3e-7 \

--- a/scripts/train/debug/envs/guess_number_beaker.sh
+++ b/scripts/train/debug/envs/guess_number_beaker.sh
@@ -30,8 +30,8 @@ uv run python mason.py \
     --response_length 1024 \
     --pack_length 1536 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 4 \
-    --num_samples_per_prompt_rollout 2 \
+    --num_unique_prompts 4 \
+    --num_samples_per_prompt 2 \
     --model_name_or_path Qwen/Qwen3-0.6B \
     --temperature 0.7 \
     --learning_rate 3e-7 \

--- a/scripts/train/debug/envs/sandbox_lm_1gpu.sh
+++ b/scripts/train/debug/envs/sandbox_lm_1gpu.sh
@@ -26,8 +26,8 @@ uv run python open_instruct/grpo_fast.py \
     --response_length 8192 \
     --pack_length 16384 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 4 \
-    --num_samples_per_prompt_rollout 2 \
+    --num_unique_prompts 4 \
+    --num_samples_per_prompt 2 \
     --model_name_or_path Qwen/Qwen3-0.6B \
     --temperature 1.0 \
     --learning_rate 1e-6 \

--- a/scripts/train/debug/envs/sandbox_lm_8gpu.sh
+++ b/scripts/train/debug/envs/sandbox_lm_8gpu.sh
@@ -37,8 +37,8 @@ uv run python mason.py \
     --response_length 30720 \
     --pack_length 32768 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 16 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 16 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen3-4B-Instruct-2507 \
     --temperature 1.0 \
     --learning_rate 5e-7 \

--- a/scripts/train/debug/envs/wordle_8gpu.sh
+++ b/scripts/train/debug/envs/wordle_8gpu.sh
@@ -31,8 +31,8 @@ uv run python mason.py \
     --response_length 8192 \
     --pack_length 16384 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 64 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 64 \
+    --num_samples_per_prompt 16 \
     --model_name_or_path PrimeIntellect/Qwen3-1.7B-Wordle-SFT \
     --temperature 1.0 \
     --learning_rate 1e-6 \

--- a/scripts/train/debug/envs/wordle_sandbox_lm_8gpu.sh
+++ b/scripts/train/debug/envs/wordle_sandbox_lm_8gpu.sh
@@ -33,8 +33,8 @@ uv run python mason.py \
     --response_length 4096 \
     --pack_length 16384 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 16 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 16 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path PrimeIntellect/Qwen3-1.7B-Wordle-SFT \
     --temperature 1.0 \
     --learning_rate 1e-6 \

--- a/scripts/train/debug/evolving_rubric_mini_test.sh
+++ b/scripts/train/debug/evolving_rubric_mini_test.sh
@@ -64,8 +64,8 @@ uv run python open_instruct/grpo_fast.py \
     --exp_name ${exp_name} \
     --wandb_project_name rl-rag \
     --beta 0.001 \
-    --num_samples_per_prompt_rollout 4 \
-    --num_unique_prompts_rollout 4 \
+    --num_samples_per_prompt 4 \
+    --num_unique_prompts 4 \
     --num_mini_batches 1 \
     --num_epochs 1 \
     --learning_rate 5e-7 \
@@ -111,4 +111,3 @@ uv run python open_instruct/grpo_fast.py \
 echo "=============================================="
 echo "Test completed! Log saved to /tmp/evolving_rubric_test.log"
 echo "=============================================="
-

--- a/scripts/train/debug/full_integration_test.sh
+++ b/scripts/train/debug/full_integration_test.sh
@@ -31,8 +31,8 @@ for split_var in split_int_mix_3; do
         --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name ${exp_name} \
         --beta 0.0 \
-        --num_samples_per_prompt_rollout 8 \
-        --num_unique_prompts_rollout 32 \
+        --num_samples_per_prompt 8 \
+        --num_unique_prompts 32 \
         --num_mini_batches 4 \
         --num_epochs 1 \
         --learning_rate 1e-6 \

--- a/scripts/train/debug/grpo_fast.sh
+++ b/scripts/train/debug/grpo_fast.sh
@@ -11,8 +11,8 @@ uv run python open_instruct/grpo_fast.py \
     --response_length 512 \
     --pack_length 1024 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 8 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 8 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen3-0.6B \
     --stop_strings "</answer>" \
     --apply_verifiable_reward true \

--- a/scripts/train/debug/grpo_fast_3_gpu.sh
+++ b/scripts/train/debug/grpo_fast_3_gpu.sh
@@ -14,8 +14,8 @@ uv run python open_instruct/grpo_fast.py \
     --response_length 512 \
     --pack_length 1024 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 8 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 8 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen3-0.6B \
     --stop_strings "</answer>" \
     --apply_verifiable_reward true \

--- a/scripts/train/debug/grpo_fast_llm_judge.sh
+++ b/scripts/train/debug/grpo_fast_llm_judge.sh
@@ -11,8 +11,8 @@ uv run python open_instruct/grpo_fast.py \
     --response_length 512 \
     --pack_length 1024 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 8 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 8 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen3-0.6B \
     --stop_strings "</answer>" \
     --apply_r1_style_format_reward \

--- a/scripts/train/debug/grpo_integration_test.sh
+++ b/scripts/train/debug/grpo_integration_test.sh
@@ -30,8 +30,8 @@ uv run python mason.py \
     --response_length 1024 \
     --pack_length 2048 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 8 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 8 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen2.5-1.5B \
     --stop_strings "</answer>" \
     --apply_r1_style_format_reward \

--- a/scripts/train/debug/judge.sh
+++ b/scripts/train/debug/judge.sh
@@ -12,8 +12,8 @@ python open_instruct/grpo_fast.py \
     --response_length 512 \
     --pack_length 4096 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 32 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 32 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen2.5-0.5B \
     --stop_strings "</answer>" \
     --kl_estimator 2 \
@@ -57,8 +57,8 @@ python open_instruct/grpo_fast.py \
 #     --response_length 512 \
 #     --pack_length 4096 \
 #     --per_device_train_batch_size 1 \
-#     --num_unique_prompts_rollout 64 \
-#     --num_samples_per_prompt_rollout 16 \
+#     --num_unique_prompts 64 \
+#     --num_samples_per_prompt 16 \
 #     --model_name_or_path Qwen/Qwen2.5-0.5B \
 #     --stop_strings "</answer>" \
 #     --apply_verifiable_reward true \

--- a/scripts/train/debug/large_test_script.sh
+++ b/scripts/train/debug/large_test_script.sh
@@ -22,8 +22,8 @@ uv run python mason.py \
         --exp_name ${exp_name} \
         --beta 0.0 \
         --load_ref_policy false \
-        --num_samples_per_prompt_rollout 16 \
-        --num_unique_prompts_rollout 32 \
+        --num_samples_per_prompt 16 \
+        --num_unique_prompts 32 \
         --num_mini_batches 1 \
         --num_epochs 1 \
         --learning_rate 5e-7 \

--- a/scripts/train/debug/single_gpu_on_beaker.sh
+++ b/scripts/train/debug/single_gpu_on_beaker.sh
@@ -32,8 +32,8 @@ uv run python mason.py \
     --response_length 512 \
     --pack_length 1024 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 8 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 8 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path /weka/oe-adapt-default/allennlp/deletable_checkpoint/finbarrt/dpo_utils__123__1769051928/hf_model \
     --add_bos \
     --stop_strings "</answer>" \

--- a/scripts/train/debug/tools/dr_tulu_parser_debug.sh
+++ b/scripts/train/debug/tools/dr_tulu_parser_debug.sh
@@ -40,8 +40,8 @@ VLLM_ALLOW_INSECURE_SERIALIZATION=1 uv run --extra dr-tulu open_instruct/grpo_fa
     --response_length 2048 \
     --pack_length 4096 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 16 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 16 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen3-1.7B \
     --apply_verifiable_reward true \
     --temperature 0.7 \

--- a/scripts/train/debug/tools/legacy_parser_debug.sh
+++ b/scripts/train/debug/tools/legacy_parser_debug.sh
@@ -16,8 +16,8 @@ VLLM_ALLOW_INSECURE_SERIALIZATION=1 uv run open_instruct/grpo_fast.py \
     --response_length 512 \
     --pack_length 1024 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 16 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 16 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen3-1.7B \
     --apply_verifiable_reward true \
     --temperature 0.7 \

--- a/scripts/train/debug/tools/mcp_weather_debug.sh
+++ b/scripts/train/debug/tools/mcp_weather_debug.sh
@@ -67,8 +67,8 @@ VLLM_ALLOW_INSECURE_SERIALIZATION=1 uv run open_instruct/grpo_fast.py \
     --response_length 1024 \
     --pack_length 1536 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 8 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 8 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen2.5-0.5B-Instruct \
     --apply_verifiable_reward true \
     --temperature 0.7 \

--- a/scripts/train/debug/tools/olmo_3_parser_multigpu.sh
+++ b/scripts/train/debug/tools/olmo_3_parser_multigpu.sh
@@ -40,8 +40,8 @@ uv run python mason.py \
     --pack_length 16384 \
     --inflight_updates True \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 32 \
-    --num_samples_per_prompt_rollout 8 \
+    --num_unique_prompts 32 \
+    --num_samples_per_prompt 8 \
     --model_name_or_path allenai/Olmo-3-7B-Instruct-SFT \
     --apply_verifiable_reward true \
     --temperature 1.0 \

--- a/scripts/train/debug/tools/qwen3_vllm_hermes_parser_debug.sh
+++ b/scripts/train/debug/tools/qwen3_vllm_hermes_parser_debug.sh
@@ -16,8 +16,8 @@ VLLM_ALLOW_INSECURE_SERIALIZATION=1 uv run open_instruct/grpo_fast.py \
     --response_length 2048 \
     --pack_length 4096 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 16 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 16 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen3-1.7B \
     --apply_verifiable_reward true \
     --temperature 0.7 \

--- a/scripts/train/debug/tools/tool_regression_beaker.sh
+++ b/scripts/train/debug/tools/tool_regression_beaker.sh
@@ -34,8 +34,8 @@ uv run python mason.py \
     --response_length 2048 \
     --pack_length 4096 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 16 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 16 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path Qwen/Qwen3-1.7B \
     --apply_verifiable_reward true \
     --temperature 0.7 \

--- a/scripts/train/olmo2/grpo_fast_13b_zero.sh
+++ b/scripts/train/olmo2/grpo_fast_13b_zero.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name olmo2_13b_grpo_fast_zero \
     --beta 0.0 \
-    --num_unique_prompts_rollout 48 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 48 \
+    --num_samples_per_prompt 16 \
     --kl_estimator 2 \
     --learning_rate 5e-7 \
     --dataset_mixer_list ai2-adapt-dev/math_ground_truth_zs 1.0 \

--- a/scripts/train/olmo2/grpo_fast_32b.sh
+++ b/scripts/train/olmo2/grpo_fast_32b.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name olmo2_32b_grpo_fast_zero \
     --beta 0.0 \
-    --num_unique_prompts_rollout 256 \
-    --num_samples_per_prompt_rollout 64 \
+    --num_unique_prompts 256 \
+    --num_samples_per_prompt 64 \
     --kl_estimator 2 \
     --learning_rate 5e-7 \
     --dataset_mixer_list ai2-adapt-dev/math_ground_truth_zs 1.0 \

--- a/scripts/train/olmo2/grpo_fast_32b_tulu.sh
+++ b/scripts/train/olmo2/grpo_fast_32b_tulu.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name olmo2_32b_grpo_fast_zero \
     --beta 0.0 \
-    --num_unique_prompts_rollout 256 \
-    --num_samples_per_prompt_rollout 64 \
+    --num_unique_prompts 256 \
+    --num_samples_per_prompt 64 \
     --kl_estimator 2 \
     --learning_rate 5e-7 \
     --dataset_mixer_list ai2-adapt-dev/math_ground_truth_zs 1.0 \

--- a/scripts/train/olmo2/grpo_fast_7b_zero.sh
+++ b/scripts/train/olmo2/grpo_fast_7b_zero.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name olmo2_7b_grpo_fast_zero \
     --beta 0.0 \
-    --num_unique_prompts_rollout 48 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 48 \
+    --num_samples_per_prompt 16 \
     --kl_estimator 2 \
     --learning_rate 5e-7 \
     --dataset_mixer_list ai2-adapt-dev/math_ground_truth_zs 1.0 \

--- a/scripts/train/olmo3/32b_instruct_rl.sh
+++ b/scripts/train/olmo3/32b_instruct_rl.sh
@@ -23,8 +23,8 @@ uv run python mason.py \
     -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name ${exp_name} \
         --beta 0.0 \
-        --num_samples_per_prompt_rollout 8 \
-        --num_unique_prompts_rollout 64 \
+        --num_samples_per_prompt 8 \
+        --num_unique_prompts 64 \
         --num_mini_batches 1 \
         --num_epochs 1 \
         --learning_rate 2e-6 \

--- a/scripts/train/olmo3/32b_think_rl.sh
+++ b/scripts/train/olmo3/32b_think_rl.sh
@@ -26,8 +26,8 @@ uv run python mason.py \
     -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name ${exp_name} \
         --beta 0.0 \
-        --num_samples_per_prompt_rollout 8 \
-        --num_unique_prompts_rollout 64 \
+        --num_samples_per_prompt 8 \
+        --num_unique_prompts 64 \
         --num_mini_batches 1 \
         --num_epochs 1 \
         --learning_rate 2e-6 \

--- a/scripts/train/olmo3/7b_instruct_rl.sh
+++ b/scripts/train/olmo3/7b_instruct_rl.sh
@@ -40,8 +40,8 @@ uv run python mason.py \
         --budget ai2/oe-adapt -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name ${EXP_NAME} \
         --beta 0.0 \
-        --num_samples_per_prompt_rollout 8 \
-        --num_unique_prompts_rollout 64 \
+        --num_samples_per_prompt 8 \
+        --num_unique_prompts 64 \
         --num_mini_batches 4 \
         --num_epochs 1 \
         --learning_rate 1e-6 \

--- a/scripts/train/olmo3/7b_rlzero_code.sh
+++ b/scripts/train/olmo3/7b_rlzero_code.sh
@@ -35,8 +35,8 @@ python mason.py \
     --async_steps 4 \
     --inflight_updates \
     --truncated_importance_sampling_ratio_cap 2.0 \
-    --num_samples_per_prompt_rollout 8 \
-    --num_unique_prompts_rollout 32 \
+    --num_samples_per_prompt 8 \
+    --num_unique_prompts 32 \
     --num_mini_batches 1 \
     --num_epochs 1 \
     --learning_rate 1e-6 \

--- a/scripts/train/olmo3/7b_rlzero_general.sh
+++ b/scripts/train/olmo3/7b_rlzero_general.sh
@@ -38,8 +38,8 @@ python open_instruct/grpo_fast.py \
     --async_steps 4 \
     --inflight_updates \
     --truncated_importance_sampling_ratio_cap 2.0 \
-    --num_samples_per_prompt_rollout 8 \
-    --num_unique_prompts_rollout 32 \
+    --num_samples_per_prompt 8 \
+    --num_unique_prompts 32 \
     --num_mini_batches 1 \
     --num_epochs 1 \
     --learning_rate 1e-6 \

--- a/scripts/train/olmo3/7b_rlzero_instruction_following.sh
+++ b/scripts/train/olmo3/7b_rlzero_instruction_following.sh
@@ -35,8 +35,8 @@ python mason.py \
     --async_steps 4 \
     --inflight_updates \
     --truncated_importance_sampling_ratio_cap 2.0 \
-    --num_samples_per_prompt_rollout 8 \
-    --num_unique_prompts_rollout 32 \
+    --num_samples_per_prompt 8 \
+    --num_unique_prompts 32 \
     --num_mini_batches 1 \
     --num_epochs 1 \
     --learning_rate 1e-6 \

--- a/scripts/train/olmo3/7b_rlzero_math.sh
+++ b/scripts/train/olmo3/7b_rlzero_math.sh
@@ -42,8 +42,8 @@ uv run mason.py \
     --truncated_importance_sampling_ratio_cap 2.0 \
     --advantage_normalization_type centered \
     --active_sampling \
-    --num_samples_per_prompt_rollout 8 \
-    --num_unique_prompts_rollout 32 \
+    --num_samples_per_prompt 8 \
+    --num_unique_prompts 32 \
     --num_mini_batches 1 \
     --learning_rate 1e-6 \
     --per_device_train_batch_size 1 \

--- a/scripts/train/olmo3/7b_rlzero_mix.sh
+++ b/scripts/train/olmo3/7b_rlzero_mix.sh
@@ -35,8 +35,8 @@ python mason.py \
     --async_steps 4 \
     --inflight_updates \
     --truncated_importance_sampling_ratio_cap 2.0 \
-    --num_samples_per_prompt_rollout 8 \
-    --num_unique_prompts_rollout 32 \
+    --num_samples_per_prompt 8 \
+    --num_unique_prompts 32 \
     --num_mini_batches 1 \
     --num_epochs 1 \
     --learning_rate 1e-6 \

--- a/scripts/train/olmo3/7b_think_rl.sh
+++ b/scripts/train/olmo3/7b_think_rl.sh
@@ -18,8 +18,8 @@ python mason.py \
     -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name pipelinerl_7b_olmo3_thinker \
         --beta 0.0 \
-        --num_samples_per_prompt_rollout 8 \
-        --num_unique_prompts_rollout 64 \
+        --num_samples_per_prompt 8 \
+        --num_unique_prompts 64 \
         --num_mini_batches 1 \
         --num_epochs 1 \
         --learning_rate 1e-6 \

--- a/scripts/train/olmo3/7b_think_rl_no_pipeline.sh
+++ b/scripts/train/olmo3/7b_think_rl_no_pipeline.sh
@@ -19,8 +19,8 @@ python mason.py \
     -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name 7b_olmo3_thinker_no_pipeline \
         --beta 0.0 \
-        --num_samples_per_prompt_rollout 8 \
-        --num_unique_prompts_rollout 64 \
+        --num_samples_per_prompt 8 \
+        --num_unique_prompts 64 \
         --num_mini_batches 1 \
         --num_epochs 1 \
         --learning_rate 1e-6 \

--- a/scripts/train/qwen/grpo_fast_32b.sh
+++ b/scripts/train/qwen/grpo_fast_32b.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_32b_grpo_fast_zero \
     --beta 0.0 \
-    --num_unique_prompts_rollout 256 \
-    --num_samples_per_prompt_rollout 64 \
+    --num_unique_prompts 256 \
+    --num_samples_per_prompt 64 \
     --kl_estimator 2 \
     --learning_rate 5e-7 \
     --dataset_mixer_list ai2-adapt-dev/rlvr_open_reasoner_math 1.0 \

--- a/scripts/train/qwen/grpo_fast_3b_single_node.sh
+++ b/scripts/train/qwen/grpo_fast_3b_single_node.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_3b_grpo_fast_zero \
     --beta 0.0 \
-    --num_unique_prompts_rollout 48 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 48 \
+    --num_samples_per_prompt 16 \
     --kl_estimator 2 \
     --learning_rate 5e-7 \
     --dataset_mixer_list ai2-adapt-dev/math_ground_truth_zs 1.0 \

--- a/scripts/train/qwen/grpo_fast_7b.sh
+++ b/scripts/train/qwen/grpo_fast_7b.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_7b_grpo_fast_zero \
     --beta 0.0 \
-    --num_unique_prompts_rollout 48 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 48 \
+    --num_samples_per_prompt 16 \
     --kl_estimator 2 \
     --learning_rate 5e-7 \
     --dataset_mixer_list ai2-adapt-dev/math_ground_truth_zs 1.0 \

--- a/scripts/train/qwen/grpo_fast_7b_code.sh
+++ b/scripts/train/qwen/grpo_fast_7b_code.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_7b_grpo_fast_zero_orz \
     --beta 0.0 \
-    --num_unique_prompts_rollout 128 \
-    --num_samples_per_prompt_rollout 64 \
+    --num_unique_prompts 128 \
+    --num_samples_per_prompt 64 \
     --kl_estimator 2 \
     --learning_rate 5e-7 \
     --dataset_mixer_list vwxyzjn/rlvr_acecoder 1.0 \

--- a/scripts/train/qwen/grpo_fast_7b_orz.sh
+++ b/scripts/train/qwen/grpo_fast_7b_orz.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_7b_grpo_fast_zero_orz \
     --beta 0.0 \
-    --num_unique_prompts_rollout 128 \
-    --num_samples_per_prompt_rollout 64 \
+    --num_unique_prompts 128 \
+    --num_samples_per_prompt 64 \
     --kl_estimator 2 \
     --learning_rate 5e-7 \
     --dataset_mixer_list ai2-adapt-dev/rlvr_open_reasoner_math 1.0 \

--- a/scripts/train/rlvr/grpo_fast_mini copy.sh
+++ b/scripts/train/rlvr/grpo_fast_mini copy.sh
@@ -12,8 +12,8 @@ python open_instruct/grpo_fast.py \
     --response_length 256 \
     --pack_length 512 \
     --per_device_train_batch_size 1 \
-    --num_unique_prompts_rollout 16 \
-    --num_samples_per_prompt_rollout 4 \
+    --num_unique_prompts 16 \
+    --num_samples_per_prompt 4 \
     --model_name_or_path HuggingFaceTB/SmolLM2-135M \
     --stop_strings "</answer>" \
     --apply_r1_style_format_reward \

--- a/scripts/train/rlvr/judge_general_verifier.sh
+++ b/scripts/train/rlvr/judge_general_verifier.sh
@@ -32,8 +32,8 @@ python mason.py \
             --response_length 8192 \
             --pack_length 16384 \
             --per_device_train_batch_size 1 \
-            --num_unique_prompts_rollout 64 \
-            --num_samples_per_prompt_rollout 16 \
+            --num_unique_prompts 64 \
+            --num_samples_per_prompt 16 \
             --model_name_or_path Qwen/Qwen2.5-7B \
             --stop_strings "</answer>" \
             --apply_verifiable_reward true \

--- a/scripts/train/rlvr/valpy_if_grpo_fast.sh
+++ b/scripts/train/rlvr/valpy_if_grpo_fast.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name valpy_if_multi_tulu3.1_8b_grpo \
     --beta 0.01 \
-    --num_unique_prompts_rollout 48 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 48 \
+    --num_samples_per_prompt 16 \
     --try_launch_beaker_eval_jobs_on_weka \
     --kl_estimator 2 \
     --learning_rate 5e-7 \

--- a/scripts/train/tulu3/grpo_fast_8b.sh
+++ b/scripts/train/tulu3/grpo_fast_8b.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name tulu3.1_8b_grpo_fast \
     --beta 0.01 \
-    --num_unique_prompts_rollout 48 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 48 \
+    --num_samples_per_prompt 16 \
     --try_launch_beaker_eval_jobs_on_weka \
     --kl_estimator 2 \
     --learning_rate 5e-7 \

--- a/scripts/train/tulu3/grpo_fast_8b_code_dpo.sh
+++ b/scripts/train/tulu3/grpo_fast_8b_code_dpo.sh
@@ -15,8 +15,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name $exp_name \
     --beta 0.01 \
-    --num_unique_prompts_rollout 48 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 48 \
+    --num_samples_per_prompt 16 \
     --try_launch_beaker_eval_jobs_on_weka \
     --kl_estimator 2 \
     --learning_rate 5e-7 \

--- a/scripts/train/tulu3/grpo_fast_8b_code_sft.sh
+++ b/scripts/train/tulu3/grpo_fast_8b_code_sft.sh
@@ -15,8 +15,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name $exp_name \
     --beta 0.01 \
-    --num_unique_prompts_rollout 48 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 48 \
+    --num_samples_per_prompt 16 \
     --try_launch_beaker_eval_jobs_on_weka \
     --kl_estimator 2 \
     --learning_rate 5e-7 \

--- a/scripts/train/tulu3/grpo_fast_8b_single_node.sh
+++ b/scripts/train/tulu3/grpo_fast_8b_single_node.sh
@@ -10,8 +10,8 @@ python mason.py \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name tulu3.1_8b_grpo_fast \
     --beta 0.01 \
-    --num_unique_prompts_rollout 64 \
-    --num_samples_per_prompt_rollout 16 \
+    --num_unique_prompts 64 \
+    --num_samples_per_prompt 16 \
     --try_launch_beaker_eval_jobs_on_weka \
     --kl_estimator 2 \
     --learning_rate 5e-7 \

--- a/test_rl_utils_gpu.py
+++ b/test_rl_utils_gpu.py
@@ -91,7 +91,7 @@ class TestRlUtilsGPU(TestGrpoFastBase):
                 max_prompt_token_length=64,
                 response_length=32,
                 async_steps=1,
-                num_samples_per_prompt_rollout=2,
+                num_samples_per_prompt=2,
                 filter_zero_std_samples=False,
                 pack_length=128,
                 save_traces=True,


### PR DESCRIPTION
Renames `num_unique_prompts_rollout` → `num_unique_prompts` and `num_samples_per_prompt_rollout` → `num_samples_per_prompt` across the codebase. The `_rollout` suffix was unnecessary and made the names longer without adding clarity. Pure mechanical rename across 62 files (Python source, tests, and shell scripts).

GPU_TESTS=bypass