### PR TITLE
Remove configure_hf_hub_retry (HF Hub handles retries internally)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - OLMo-core GRPO actor with Ray-distributed FSDP2 training (https://github.com/allenai/open-instruct/pull/1398).
 
 ### Fixed
+- Remove `configure_hf_hub_retry`; HF Hub handles retries internally (https://github.com/allenai/open-instruct/pull/1565).
 - Remove the runtime `temperature` field from GRPO `ExperimentConfig` and pass streaming temperature explicitly, avoiding W&B config collisions with `StreamingDataLoaderConfig.temperature` (https://github.com/allenai/open-instruct/pull/1561).
 - Log `val/tis_ratio` and `val/tis_clipfrac` in `grpo_fast` so truncated importance sampling diagnostics are visible during GRPO training (https://github.com/allenai/open-instruct/pull/1558).
 - Fix SP double-shift bug: keep both `labels` and `shift_labels` in batch so `ForCausalLMLoss` uses pre-shifted labels (https://github.com/allenai/open-instruct/pull/1549).

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2227,7 +2227,6 @@ def main(
     vllm_config: data_loader_lib.VLLMConfig,
     tools_config: EnvsConfig,
 ):
-    utils.configure_hf_hub_retry()
     tokenizer = make_tokenizer(tc, model_config)
     args = setup_runtime_variables(args, streaming_config, tools_config)
     validate_configs(streaming_config, vllm_config, tuple(args.num_learners_per_node), args.sequence_parallel_size)

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -67,12 +67,10 @@ from datasets.builder import DatasetGenerationError
 from dateutil import parser
 from huggingface_hub import HfApi
 from ray.util import state as ray_state
-from requests.adapters import HTTPAdapter
 from rich.pretty import pprint
 from tqdm import tqdm
 from transformers import MODEL_FOR_CAUSAL_LM_MAPPING, AutoConfig, HfArgumentParser
 from transformers.integrations import HfDeepSpeedConfig
-from urllib3.util.retry import Retry
 
 from open_instruct import data_types, logger_utils
 from open_instruct.launch_utils import gs_folder_exists, live_subprocess_output
@@ -937,20 +935,6 @@ class BeakerRuntimeConfig:
 
 def is_beaker_job() -> bool:
     return "BEAKER_JOB_ID" in os.environ
-
-
-def configure_hf_hub_retry(total: int = 5, backoff_factor: float = 1) -> None:
-    """Configure HF Hub HTTP retries with exponential backoff on 429/5xx."""
-
-    def backend_factory() -> requests.Session:
-        session = requests.Session()
-        retries = Retry(total=total, backoff_factor=backoff_factor, status_forcelist=[429, 500, 502, 503, 504])
-        adapter = HTTPAdapter(max_retries=retries)
-        session.mount("http://", adapter)
-        session.mount("https://", adapter)
-        return session
-
-    huggingface_hub.configure_http_backend(backend_factory=backend_factory)
 
 
 def ensure_hf_repo_cached(repo_id: str, revision: str | None = None) -> None:

--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -579,7 +579,6 @@ class LLMRayActor:
         eval_dataset=None,
         **kwargs,
     ):
-        utils.configure_hf_hub_retry()
         assert_threaded_actor(self)
         self._tool_definitions = tool_definitions
         self._tool_stop_sequences = tool_stop_sequences


### PR DESCRIPTION
## Summary
- Remove `configure_hf_hub_retry()` function from `utils.py` and all its callers in `grpo_fast.py` and `vllm_utils.py`
- Remove unused imports (`HTTPAdapter`, `Retry`)

## Context
`configure_hf_hub_retry()` was added in PR #1528 to prevent HF rate-limit crashes during Ray actor spawning. It called `huggingface_hub.configure_http_backend()` to inject a custom `requests.Session` with urllib3 `Retry`.

However, `configure_http_backend()` was **removed in huggingface_hub v1.0.0** (Oct 2024) when the library migrated from `requests` to `httpx`. Our pinned version (v1.7.2) no longer has this function, so **`configure_hf_hub_retry()` would crash at runtime if called**.

This is safe to remove because:
1. huggingface_hub v1.0+ has built-in retry logic via `http_backoff()` — same behavior (429/5xx, exponential backoff)
2. The real fix from PR #1528 (pre-downloading the model before Ray actors spawn) is still in place

GPU_TESTS=bypass

## Test plan
- [ ] Verify GRPO and vLLM inference work without explicit retry configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)