### PR TITLE
Fix DeepSpeed 0.18+ hook registration in add_hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - OLMo-core GRPO actor with Ray-distributed FSDP2 training (https://github.com/allenai/open-instruct/pull/1398).
 
 ### Fixed
+- Use `setup_zero_stage3_hooks()` for DeepSpeed 0.18+ compat in `add_hooks` (https://github.com/allenai/open-instruct/pull/1566).
 - Remove the runtime `temperature` field from GRPO `ExperimentConfig` and pass streaming temperature explicitly, avoiding W&B config collisions with `StreamingDataLoaderConfig.temperature` (https://github.com/allenai/open-instruct/pull/1561).
 - Log `val/tis_ratio` and `val/tis_clipfrac` in `grpo_fast` so truncated importance sampling diagnostics are visible during GRPO training (https://github.com/allenai/open-instruct/pull/1558).
 - Fix SP double-shift bug: keep both `labels` and `shift_labels` in batch so `ForCausalLMLoss` uses pre-shifted labels (https://github.com/allenai/open-instruct/pull/1549).

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -608,7 +608,7 @@ def add_hooks(model: "DeepSpeedEngine") -> None:
         optimizer_offload = model.optimizer.parameter_offload
     elif model.optimizer is not None:
         optimizer_offload = model.optimizer
-    optimizer_offload._register_hooks_recursively(optimizer_offload.module)
+    optimizer_offload.setup_zero_stage3_hooks()
 
 
 @contextmanager


### PR DESCRIPTION
## Summary
- Replace `optimizer_offload._register_hooks_recursively(optimizer_offload.module)` with `optimizer_offload.setup_zero_stage3_hooks()` in `model_utils.py`
- DeepSpeed 0.18+ deprecated the private `_register_hooks_recursively()` method in favor of the public `setup_zero_stage3_hooks()` API

GPU_TESTS=bypass

## Test plan
- [ ] Verify ZeRO-3 training works with the updated hook registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)