### PR TITLE
Refactor DPO to use shared OLMo-core configs

### DIFF
--- a/open_instruct/dpo.py
+++ b/open_instruct/dpo.py
@@ -8,7 +8,7 @@ OLMo-core's native training infrastructure.
 import os
 import pathlib
 import shutil
-from typing import Any
+from typing import Any, cast
 
 import torch
 import torch.distributed as dist
@@ -18,9 +18,10 @@ from olmo_core import train
 from olmo_core.config import DType
 from olmo_core.distributed import utils as distributed_utils
 from olmo_core.distributed.parallel import DataParallelType
+from olmo_core.nn.attention import AttentionBackendName
 from olmo_core.nn.hf.checkpoint import load_hf_model
 from olmo_core.train import callbacks
-from olmo_core.train.callbacks import CheckpointerCallback, ProfilerCallback
+from olmo_core.train.callbacks import ProfilerCallback
 from olmo_core.train.train_module.transformer import config as transformer_config
 
 from open_instruct import data_loader as data_loader_lib
@@ -52,7 +53,7 @@ def export_to_hf(
 
 
 def _load_dataset_distributed(
-    args: dpo_utils.ExperimentConfig,
+    args: dpo_utils.DPOExperimentConfig,
     tc: dataset_transformation.TokenizerConfig,
     transform_fn_args: list[dict],
     is_main_process: bool,
@@ -83,7 +84,7 @@ def _load_dataset_distributed(
     return dataset
 
 
-def _setup_model(args: dpo_utils.ExperimentConfig, device: torch.device):
+def _setup_model(args: dpo_utils.DPOExperimentConfig, device: torch.device):
     """Build OLMo-core model architecture (weights loaded after parallelization)."""
     hf_config = transformers.AutoConfig.from_pretrained(args.model_name_or_path)
     vocab_size = hf_config.vocab_size
@@ -98,7 +99,7 @@ def _setup_model(args: dpo_utils.ExperimentConfig, device: torch.device):
     return model, model_config
 
 
-def _setup_scheduler(args: dpo_utils.ExperimentConfig, num_training_steps: int):
+def _setup_scheduler(args: dpo_utils.DPOExperimentConfig, num_training_steps: int):
     """Return scheduler."""
     warmup_steps = int(num_training_steps * args.warmup_ratio)
     if args.lr_scheduler_type == "cosine":
@@ -110,7 +111,7 @@ def _setup_scheduler(args: dpo_utils.ExperimentConfig, num_training_steps: int):
     return scheduler
 
 
-def _setup_callbacks(args: dpo_utils.ExperimentConfig, dp_world_size: int):
+def _setup_callbacks(args: dpo_utils.DPOExperimentConfig, dp_world_size: int):
     """Return callbacks dict."""
     json_config = dpo_utils.config_to_json_serializable(vars(args))
     trainer_callbacks: dict[str, callbacks.Callback] = {"beaker": BeakerCallbackV2(config=json_config)}
@@ -127,8 +128,9 @@ def _setup_callbacks(args: dpo_utils.ExperimentConfig, dp_world_size: int):
             entity=args.wandb_entity,
             config=json_config,
         )
-    checkpointing_steps = int(args.checkpointing_steps)
-    trainer_callbacks["checkpointer"] = CheckpointerCallback(save_interval=checkpointing_steps, save_async=False)
+    trainer_callbacks["checkpointer"] = olmo_core_utils.build_checkpointer_callback(
+        args.checkpointing_steps, args.ephemeral_save_interval
+    )
     model_dims = utils.ModelDims.from_hf_config(args.model_name_or_path)
     trainer_callbacks["perf"] = PerfCallback(
         model_dims=model_dims,
@@ -145,7 +147,7 @@ def _setup_callbacks(args: dpo_utils.ExperimentConfig, dp_world_size: int):
 
 
 def _handle_post_training(
-    args: dpo_utils.ExperimentConfig,
+    args: dpo_utils.DPOExperimentConfig,
     model,
     model_config,
     tokenizer,
@@ -197,7 +199,7 @@ def _handle_post_training(
         model_utils.push_folder_to_hub(hf_model_path, args.hf_repo_id, args.hf_repo_revision)
 
 
-def main(args: dpo_utils.ExperimentConfig, tc: dataset_transformation.TokenizerConfig) -> None:
+def main(args: dpo_utils.DPOExperimentConfig, tc: dataset_transformation.TokenizerConfig) -> None:
     """Main entry point for DPO training with OLMo-core."""
     if args.model_name_or_path is None:
         raise ValueError("--model_name_or_path is required. Specify a HuggingFace model name or path.")
@@ -216,14 +218,9 @@ def main(args: dpo_utils.ExperimentConfig, tc: dataset_transformation.TokenizerC
     if args.use_8bit_optimizer:
         raise ValueError("use_8bit_optimizer is not supported with OLMo-core DPO training.")
 
-    tc.tokenizer_name_or_path = (
-        args.model_name_or_path if tc.tokenizer_name_or_path is None else tc.tokenizer_name_or_path
-    )
-    tokenizer = tc.tokenizer
-
-    args.local_cache_dir = os.path.abspath(args.local_cache_dir)
-    if utils.is_beaker_job():
-        args.local_cache_dir = "/weka/oe-adapt-default/allennlp/deletable_open_instruct_dataset_cache"
+    # DPO's DPOExperimentConfig uses inheritance, not composition, so args satisfies both
+    # ModelConfig and DatasetConfig. TODO(finbarrtimbers): refactor to use composition.
+    tokenizer = olmo_core_utils.setup_tokenizer_and_cache(args, args, tc)
 
     transform_fn_args = [{"max_seq_length": args.max_seq_length}, {}]
     ref_cache_hash = dpo_utils.compute_reference_cache_hash(args, tc)
@@ -231,19 +228,7 @@ def main(args: dpo_utils.ExperimentConfig, tc: dataset_transformation.TokenizerC
     logger.info(f"Reference logprobs cache path: {reference_cache_path}")
 
     if args.cache_dataset_only:
-        dataset_transformation.get_cached_dataset_tulu(
-            dataset_mixer_list=args.mixer_list,
-            dataset_mixer_list_splits=args.mixer_list_splits,
-            tc=tc,
-            dataset_transform_fn=args.transform_fn,
-            transform_fn_args=transform_fn_args,
-            target_columns=args.target_columns,
-            dataset_cache_mode=args.cache_mode,
-            dataset_config_hash=args.config_hash,
-            hf_entity=args.hf_entity,
-            dataset_local_cache_dir=args.local_cache_dir,
-            dataset_skip_cache=args.skip_cache,
-        )
+        olmo_core_utils.load_dataset_distributed(args, tc, transform_fn_args, is_main_process=True)
         logger.info("Dataset cached successfully. Exiting because --cache_dataset_only was set.")
         return
 
@@ -254,7 +239,7 @@ def main(args: dpo_utils.ExperimentConfig, tc: dataset_transformation.TokenizerC
     dp_rank = global_rank // tp_degree
     is_main_process = global_rank == 0
 
-    dataset = _load_dataset_distributed(args, tc, transform_fn_args, is_main_process)
+    dataset = olmo_core_utils.load_dataset_distributed(args, tc, transform_fn_args, is_main_process)
     dataset = dataset.shuffle(seed=args.seed)
     dataset.set_format(type="pt")
 
@@ -272,7 +257,9 @@ def main(args: dpo_utils.ExperimentConfig, tc: dataset_transformation.TokenizerC
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-    model, model_config = _setup_model(args, device)
+    model, model_config = olmo_core_utils.setup_model(
+        args.model_name_or_path, args.config_name, cast(AttentionBackendName, args.attn_implementation)
+    )
 
     if args.packing:
         logger.info("Using packing/padding-free collation")
@@ -438,6 +425,6 @@ def main(args: dpo_utils.ExperimentConfig, tc: dataset_transformation.TokenizerC
 if __name__ == "__main__":
     from open_instruct.utils import ArgumentParserPlus
 
-    parser = ArgumentParserPlus((dpo_utils.ExperimentConfig, dataset_transformation.TokenizerConfig))
+    parser = ArgumentParserPlus((dpo_utils.DPOExperimentConfig, dataset_transformation.TokenizerConfig))
     args, tc = parser.parse()
     main(args, tc)

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -113,7 +113,7 @@ def build_deepspeed_config(
     return config
 
 
-def main(args: dpo_utils.ExperimentConfig, tc: TokenizerConfig):
+def main(args: dpo_utils.DPOExperimentConfig, tc: TokenizerConfig):
     # ------------------------------------------------------------
     # Initialize the accelerator. We will let the accelerator handle device placement for us in this example.
     # If we're using tracking, we also need to initialize it here and it will by default pick up all supported trackers
@@ -763,6 +763,6 @@ def print_gpu_stats(init_gpu_memory: int | None):
 
 
 if __name__ == "__main__":
-    parser = ArgumentParserPlus((dpo_utils.ExperimentConfig, TokenizerConfig))
+    parser = ArgumentParserPlus((dpo_utils.DPOExperimentConfig, TokenizerConfig))
     args, tc = parser.parse_args_into_dataclasses()
     main(args, tc)

--- a/open_instruct/dpo_utils.py
+++ b/open_instruct/dpo_utils.py
@@ -45,6 +45,14 @@ from open_instruct.dataset_transformation import (
     compute_config_hash,
     load_dataset_configs,
 )
+from open_instruct.olmo_core_utils import (
+    CheckpointConfig,
+    DatasetConfig,
+    ExperimentConfig,
+    LoggingConfig,
+    ModelConfig,
+    TrainingConfig,
+)
 from open_instruct.padding_free_collator import calculate_per_token_logps
 from open_instruct.padding_free_collator import concatenated_inputs as pf_concatenated_inputs
 from open_instruct.padding_free_collator import get_batch_logps as pf_get_batch_logps
@@ -85,18 +93,6 @@ class DPOLossType(enum.StrEnum):
 
 
 @dataclass
-class TrackingConfig:
-    """Base configuration for experiment tracking."""
-
-    exp_name: str = "dpo_experiment"
-    """The name of this experiment"""
-    run_name: str | None = None
-    """A unique name of this run"""
-    seed: int = 42
-    """Random seed for initialization and dataset shuffling."""
-
-
-@dataclass
 class DPOConfig:
     """Configuration for DPO-specific hyperparameters."""
 
@@ -119,37 +115,9 @@ class DPOConfig:
 
 
 @dataclass
-class TrainingConfig:
-    """Configuration for training hyperparameters."""
+class DPOTrainingConfig(TrainingConfig):
+    """DPO-specific training configuration extending TrainingConfig."""
 
-    num_epochs: int = 1
-    """Total number of training epochs to perform."""
-    per_device_train_batch_size: int = 8
-    """Batch size per GPU/TPU core/CPU for training."""
-    gradient_accumulation_steps: int = 1
-    """Number of updates steps to accumulate before performing a backward/update pass."""
-    learning_rate: float = 2e-5
-    """The initial learning rate for the optimizer."""
-    warmup_ratio: float = 0.1
-    """Linear warmup over warmup_ratio fraction of total steps."""
-    weight_decay: float = 0.0
-    """Weight decay for AdamW if we apply some."""
-    max_grad_norm: float = -1
-    """Maximum gradient norm for clipping. -1 means no clipping."""
-    max_seq_length: int = 2048
-    """The maximum total input sequence length after tokenization."""
-    lr_scheduler_type: str = "linear"
-    """The scheduler type to use for learning rate adjustment."""
-    max_train_steps: int | None = None
-    """If set, overrides the number of training steps. Otherwise, num_epochs is used."""
-    activation_memory_budget: float = 1.0
-    """Memory budget for activation checkpointing (0.0-1.0).
-
-    A practical "just turn it on" default is `0.5` (somewhat arbitrary, but works well in practice):
-    any value < 1.0 enables budget-mode checkpointing. Higher values use more memory and are
-    typically faster; lower values use less memory and are typically slower, so use the highest
-    value your hardware can support. See: https://pytorch.org/blog/activation-checkpointing-techniques/.
-    """
     use_8bit_optimizer: bool = False
     """Use 8bit optimizer from bitsandbytes."""
     dpo_use_paged_optimizer: bool = False
@@ -166,38 +134,10 @@ class TrainingConfig:
     """Context parallelism degree. Default 1 (disabled)."""
     cache_logprobs_only: bool = False
     """Exit after building the reference logprobs cache (for benchmarking)."""
-    compile_model: bool = True
-    """Whether to apply torch.compile to model blocks."""
     fsdp_shard_degree: int | None = None
     """FSDP shard degree. None means auto-detect."""
     fsdp_num_replicas: int | None = None
     """Number of FSDP replicas. None means auto-detect."""
-
-
-@dataclass
-class DatasetConfig:
-    """Configuration for dataset loading and processing."""
-
-    mixer_list: list[str] = field(default_factory=lambda: ["allenai/tulu-3-wildchat-reused-on-policy-8b", "1.0"])
-    """A list of datasets (local or HF) to sample from."""
-    mixer_list_splits: list[str] = field(default_factory=lambda: ["train"])
-    """The dataset splits to use for training"""
-    transform_fn: list[str] = field(
-        default_factory=lambda: ["preference_tulu_tokenize_and_truncate_v1", "preference_tulu_filter_v1"]
-    )
-    """The list of transform functions to apply to the dataset."""
-    target_columns: list[str] = field(default_factory=lambda: TOKENIZED_PREFERENCE_DATASET_KEYS)
-    """The columns to use for the dataset."""
-    cache_mode: Literal["hf", "local"] = "local"
-    """The mode to use for caching the dataset."""
-    local_cache_dir: str = "local_dataset_cache"
-    """The directory to save the local dataset cache to."""
-    skip_cache: bool = False
-    """Whether to skip the cache."""
-    cache_dataset_only: bool = False
-    """Immediately exit after caching the dataset"""
-    config_hash: str | None = None
-    """The hash of the dataset configuration."""
 
 
 @dataclass
@@ -215,49 +155,17 @@ class LoRAConfig:
 
 
 @dataclass
-class LoggingConfig:
-    """Configuration for logging and experiment tracking."""
-
-    logging_steps: int | None = None
-    """Log the training loss and learning rate every logging_steps steps."""
-    with_tracking: bool = False
-    """If toggled, this experiment will be tracked with Weights and Biases"""
-    wandb_project: str = "open_instruct_internal"
-    """The wandb project name"""
-    wandb_entity: str | None = None
-    """The entity (team) of wandb's project"""
-    report_to: str | list[str] = "all"
-    """The integration(s) to report results and logs to."""
-
-
-@dataclass
 class HubConfig:
     """Configuration for Hugging Face Hub integration."""
 
     push_to_hub: bool = True
     """Whether to upload the saved model to huggingface"""
-    hf_entity: str | None = None
-    """The user or org name of the model repository from the Hugging Face Hub"""
     hf_repo_id: str | None = None
     """The id of the saved model in the Hugging Face Hub"""
     hf_repo_revision: str | None = None
     """The revision of the saved model in the Hugging Face Hub"""
     hf_repo_url: str | None = None
     """The url of the saved model in the Hugging Face Hub"""
-
-
-@dataclass
-class CheckpointConfig:
-    """Configuration for checkpointing."""
-
-    output_dir: str = "output/"
-    """The output directory where the model predictions and checkpoints will be written."""
-    checkpointing_steps: int | str = 500
-    """Whether the various states should be saved at the end of every n steps, or 'epoch' for each epoch."""
-    keep_last_n_checkpoints: int = 3
-    """How many checkpoints to keep in the output directory. -1 for all."""
-    resume_from_checkpoint: str | None = None
-    """If the training should continue from a checkpoint folder."""
 
 
 @dataclass
@@ -282,25 +190,6 @@ class EvalConfig:
     """The priority of auto-launched evaluation jobs"""
 
 
-@dataclass
-class ModelConfig:
-    """Configuration for model loading."""
-
-    model_name_or_path: str | None = None
-    """The model checkpoint for weights initialization."""
-    model_revision: str | None = None
-    """The specific model version to use (can be a branch name, tag name or commit id)."""
-    low_cpu_mem_usage: bool = False
-    """Create the model as an empty shell, then materialize parameters when pretrained weights are loaded."""
-    attn_implementation: model_utils.AttentionBackendName | None = None
-    """Which attention implementation to use.
-    If None, auto-detects the best available implementation."""
-
-    def __post_init__(self):
-        if self.attn_implementation is None:
-            self.attn_implementation = model_utils.detect_attn_implementation()
-
-
 REFERENCE_LOGPROBS_CACHE_PATH = os.environ.get(
     "REFERENCE_LOGPROBS_CACHE_PATH", "/weka/oe-adapt-default/allennlp/deletable_reference_logprobs_cache"
 )
@@ -309,11 +198,11 @@ torch.backends.cuda.matmul.allow_tf32 = True
 
 
 @dataclass
-class ExperimentConfig(
-    TrackingConfig,
+class DPOExperimentConfig(
+    ExperimentConfig,
     ModelConfig,
     DPOConfig,
-    TrainingConfig,
+    DPOTrainingConfig,
     DatasetConfig,
     LoRAConfig,
     LoggingConfig,
@@ -327,14 +216,16 @@ class ExperimentConfig(
 
     _VALID_DICT_FIELDS = ["additional_model_arguments", "optimizer_kwargs"]
 
-    exp_name: str = os.path.basename(__file__)[: -len(".py")]
+    exp_name: str = "dpo"
+    mixer_list: list[str] = field(default_factory=lambda: ["allenai/tulu-3-wildchat-reused-on-policy-8b", "1.0"])
+    transform_fn: list[str] = field(
+        default_factory=lambda: ["preference_tulu_tokenize_and_truncate_v1", "preference_tulu_filter_v1"]
+    )
+    target_columns: list[str] = field(default_factory=lambda: TOKENIZED_PREFERENCE_DATASET_KEYS)
     do_not_randomize_output_dir: bool = False
     """By default the output directory will be randomized"""
     send_slack_alerts: bool = False
     """Whether to send Slack alerts on training failures"""
-    config_name: str | None = field(
-        default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
-    )
     additional_model_arguments: dict | str | None = field(
         default_factory=dict, metadata={"help": "A dictionary of additional model args used to construct the model."}
     )
@@ -440,7 +331,7 @@ class ExperimentConfig(
         return fn
 
     def __post_init__(self):
-        super().__post_init__()
+        ModelConfig.__post_init__(self)
         if self.send_slack_alerts and not os.environ.get("SLACK_WEBHOOK_URL"):
             logger.warning(
                 "--send_slack_alerts is set but SLACK_WEBHOOK_URL is not in the environment. Slack alerts will not be sent."
@@ -473,11 +364,11 @@ class ExperimentConfig(
                 raise ValueError("offload_param can only be used with zero_stage 3")
 
 
-FlatArguments = ExperimentConfig
+FlatArguments = DPOExperimentConfig
 
 
-def compute_reference_cache_hash(args: ExperimentConfig, tc: TokenizerConfig) -> str:
-    """Compute deterministic hash for reference logprobs cache from ExperimentConfig."""
+def compute_reference_cache_hash(args: DPOExperimentConfig, tc: TokenizerConfig) -> str:
+    """Compute deterministic hash for reference logprobs cache from DPOExperimentConfig."""
     transform_fn_args = [{"max_seq_length": args.max_seq_length}, {}]
     dcs = load_dataset_configs(
         args.mixer_list, args.mixer_list_splits, args.transform_fn, transform_fn_args, args.target_columns

--- a/open_instruct/mix_data_preferences.py
+++ b/open_instruct/mix_data_preferences.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from open_instruct.dpo_utils import ExperimentConfig
 
 # script for mixing and saving data
+from open_instruct.dpo_utils import DPOExperimentConfig
 from open_instruct.utils import ArgumentParserPlus, get_datasets
 
 # Run as module for local imports, e.g.:
@@ -25,9 +25,9 @@ from open_instruct.utils import ArgumentParserPlus, get_datasets
 
 
 def main() -> None:
-    parser = ArgumentParserPlus((ExperimentConfig,))  # type: ignore[arg-type]
+    parser = ArgumentParserPlus((DPOExperimentConfig,))  # type: ignore[arg-type]
     (args,) = parser.parse()  # type: ignore[misc]
-    assert isinstance(args, ExperimentConfig)
+    assert isinstance(args, DPOExperimentConfig)
 
     # assert that data_mixer is not none in config
     assert args.dataset_mixer is not None, "data_mixer is required in config"

--- a/open_instruct/olmo_core_train_modules.py
+++ b/open_instruct/olmo_core_train_modules.py
@@ -109,7 +109,7 @@ class DPOTrainModule(TransformerTrainModule):
         optim: OptimConfig,
         sample_microbatch_size: int,
         max_sequence_length: int,
-        dpo_config: dpo_utils.ExperimentConfig,
+        dpo_config: dpo_utils.DPOExperimentConfig,
         dp_config: transformer_config.TransformerDataParallelConfig | None = None,
         tp_config: transformer_config.TransformerTensorParallelConfig | None = None,
         cp_config: transformer_config.TransformerContextParallelConfig | None = None,

--- a/open_instruct/test_dpo_utils.py
+++ b/open_instruct/test_dpo_utils.py
@@ -7,20 +7,20 @@ import torch
 
 from open_instruct import dpo_utils
 from open_instruct.dataset_transformation import TokenizerConfig
-from open_instruct.dpo_utils import DPOLossType, ExperimentConfig
+from open_instruct.dpo_utils import DPOExperimentConfig, DPOLossType
 
 logging.basicConfig(level=logging.INFO)
 
 
-def make_test_args(**overrides) -> ExperimentConfig:
-    """Create an ExperimentConfig with test defaults."""
+def make_test_args(**overrides) -> DPOExperimentConfig:
+    """Create a DPOExperimentConfig with test defaults."""
     defaults = {
         "model_name_or_path": "allenai/OLMo-2-1124-7B",
         "mixer_list": ["allenai/tulu-3-wildchat-reused-on-policy-8b", "1.0"],
         "config_hash": "test_dataset_config_hash",
     }
     defaults.update(overrides)
-    return ExperimentConfig(**defaults)
+    return DPOExperimentConfig(**defaults)
 
 
 class TestDPOLoss(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Rename `ExperimentConfig` to `DPOExperimentConfig` throughout DPO code
- Use shared config classes from `olmo_core_utils.py` (from #1576) instead of local definitions
- Update `mix_data_preferences.py` and `olmo_core_train_modules.py` to use the new name
- Simplify DPO setup by using shared `setup_tokenizer_and_cache` and `load_dataset_distributed` helpers

**Depends on #1576**

## Test plan
- [ ] `make style && make quality` passes
- [ ] `uv run pytest open_instruct/test_dpo_utils.py` passes
- [ ] GPU tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)