### PR TITLE
grpo_fast: harden single-node startup resource checks and diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).
+- Harden `grpo_fast` startup with explicit Ray resource preflight checks and actionable learner placement-group timeout diagnostics for single-node runs (https://github.com/allenai/open-instruct/pull/1586).
 - Fix shellcheck `$@` quoting in GRPO debug scripts (https://github.com/allenai/open-instruct/pull/1572).
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -176,14 +176,14 @@ def _build_vlm_name_mapper(model_name: str):
 
 def _startup_debug_context(
     args: grpo_utils.GRPOExperimentConfig,
-    plan: grpo_fast_resource_plan.GrpoFastResourcePlan,
+    requirements: dict[str, Any],
     cluster_resources: dict[str, float] | None = None,
     available_resources: dict[str, float] | None = None,
 ) -> str:
     ray_address = os.environ.get("RAY_ADDRESS", "<unset>")
     return "\n".join(
         [
-            grpo_fast_resource_plan.format_grpo_fast_resource_plan(plan),
+            grpo_fast_resource_plan.format_grpo_fast_startup_requirements(requirements),
             f"Ray cluster resources: {grpo_fast_resource_plan.format_resource_snapshot(cluster_resources)}",
             f"Ray available resources: {grpo_fast_resource_plan.format_resource_snapshot(available_resources)}",
             (
@@ -196,7 +196,7 @@ def _startup_debug_context(
 
 def wait_for_grpo_fast_minimum_cluster_resources(
     args: grpo_utils.GRPOExperimentConfig,
-    plan: grpo_fast_resource_plan.GrpoFastResourcePlan,
+    requirements: dict[str, Any],
     timeout_s: float = CLUSTER_STARTUP_TIMEOUT_S,
     poll_interval_s: float = 5.0,
 ) -> dict[str, float]:
@@ -206,10 +206,10 @@ def wait_for_grpo_fast_minimum_cluster_resources(
 
     while True:
         last_cluster_resources = ray.cluster_resources()
-        shortfalls = grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(plan, last_cluster_resources)
+        shortfalls = grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(requirements, last_cluster_resources)
         if not shortfalls:
             logger.info("Ray cluster resources satisfy GRPO startup requirements.")
-            logger.info(_startup_debug_context(args, plan, last_cluster_resources, ray.available_resources()))
+            logger.info(_startup_debug_context(args, requirements, last_cluster_resources, ray.available_resources()))
             return last_cluster_resources
 
         if time.perf_counter() >= deadline:
@@ -223,16 +223,18 @@ def wait_for_grpo_fast_minimum_cluster_resources(
         "Timed out waiting for Ray to report the minimum resources required for GRPO startup.\n"
         + "\n".join(
             f"- {shortfall}"
-            for shortfall in grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(plan, last_cluster_resources)
+            for shortfall in grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(
+                requirements, last_cluster_resources
+            )
         )
         + "\n"
-        + _startup_debug_context(args, plan, last_cluster_resources, available_resources)
+        + _startup_debug_context(args, requirements, last_cluster_resources, available_resources)
     )
 
 
 def wait_for_grpo_fast_placement_group(
     args: grpo_utils.GRPOExperimentConfig,
-    plan: grpo_fast_resource_plan.GrpoFastResourcePlan,
+    requirements: dict[str, Any],
     pg: PlacementGroup,
     timeout_s: float = PLACEMENT_GROUP_READY_TIMEOUT_S,
 ) -> None:
@@ -246,7 +248,7 @@ def wait_for_grpo_fast_placement_group(
             "Timed out waiting for the learner placement group to be scheduled.\n"
             "Ray reported enough total resources earlier, so this usually means the requested bundles cannot be placed "
             "on the currently available nodes or CPUs/GPUs are fragmented.\n"
-            + _startup_debug_context(args, plan, cluster_resources, available_resources)
+            + _startup_debug_context(args, requirements, cluster_resources, available_resources)
         ) from exc
 
 
@@ -1297,11 +1299,16 @@ def create_model_and_optimizer(
     dict[str, Any] | None,
 ]:
     """Create the model, optimizer, and vLLM engines."""
-    resource_plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
-    wait_for_grpo_fast_minimum_cluster_resources(args, resource_plan)
+    resource_requirements = grpo_fast_resource_plan.build_grpo_fast_startup_requirements(
+        num_learners_per_node=args.num_learners_per_node,
+        single_gpu_mode=args.single_gpu_mode,
+        vllm_num_engines=vllm_config.vllm_num_engines,
+        vllm_tensor_parallel_size=vllm_config.vllm_tensor_parallel_size,
+    )
+    wait_for_grpo_fast_minimum_cluster_resources(args, resource_requirements)
 
-    pg = placement_group(resource_plan.learner_pg_bundles, strategy=resource_plan.learner_pg_strategy)
-    wait_for_grpo_fast_placement_group(args, resource_plan, pg)
+    pg = placement_group(resource_requirements["learner_pg_bundles"], strategy="STRICT_SPREAD")
+    wait_for_grpo_fast_placement_group(args, resource_requirements, pg)
 
     queues_to_monitor = {
         "Inference Results Queue": inference_results_Q,

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -81,7 +81,7 @@ from transformers.integrations import HfDeepSpeedConfig
 from vllm.distributed.weight_transfer.base import WeightTransferInitRequest
 from vllm.distributed.weight_transfer.nccl_engine import NCCLWeightTransferEngine
 
-from open_instruct import logger_utils, model_utils, vllm_utils
+from open_instruct import grpo_fast_resource_plan, logger_utils, model_utils, vllm_utils
 from open_instruct.actor_manager import ActorManager
 from open_instruct.data_types import ShutdownSentinel
 from open_instruct.dataset_transformation import (
@@ -160,6 +160,9 @@ def _build_data_prep_actor_resume_state(checkpoint_state: dict[str, Any] | None)
 
 CHECKPOINT_COMPLETE_MARKER = ".checkpoint_complete"
 WEIGHT_SYNC_TIMEOUT_S = 120.0
+CLUSTER_STARTUP_TIMEOUT_S = 1200.0
+PLACEMENT_GROUP_READY_TIMEOUT_S = 300.0
+LEARNER_ACTOR_NUM_CPUS = 4
 EXCLUDED_ENV_VARS = {"CUDA_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES"}
 
 
@@ -169,6 +172,82 @@ def _build_vlm_name_mapper(model_name: str):
     if "qwen3.5" in model_name.lower():
         return lambda name: f"language_model.{name}"
     return None
+
+
+def _startup_debug_context(
+    args: grpo_utils.GRPOExperimentConfig,
+    plan: grpo_fast_resource_plan.GrpoFastResourcePlan,
+    cluster_resources: dict[str, float] | None = None,
+    available_resources: dict[str, float] | None = None,
+) -> str:
+    ray_address = os.environ.get("RAY_ADDRESS", "<unset>")
+    return "\n".join(
+        [
+            grpo_fast_resource_plan.format_grpo_fast_resource_plan(plan),
+            f"Ray cluster resources: {grpo_fast_resource_plan.format_resource_snapshot(cluster_resources)}",
+            f"Ray available resources: {grpo_fast_resource_plan.format_resource_snapshot(available_resources)}",
+            (
+                "Runtime context: "
+                f"num_nodes={args.num_nodes}, single_gpu_mode={args.single_gpu_mode}, RAY_ADDRESS={ray_address}"
+            ),
+        ]
+    )
+
+
+def wait_for_grpo_fast_minimum_cluster_resources(
+    args: grpo_utils.GRPOExperimentConfig,
+    plan: grpo_fast_resource_plan.GrpoFastResourcePlan,
+    timeout_s: float = CLUSTER_STARTUP_TIMEOUT_S,
+    poll_interval_s: float = 5.0,
+) -> dict[str, float]:
+    """Wait for Ray to see enough resources for GRPO startup before creating placement groups."""
+    deadline = time.perf_counter() + timeout_s
+    last_cluster_resources: dict[str, float] = {}
+
+    while True:
+        last_cluster_resources = ray.cluster_resources()
+        shortfalls = grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(plan, last_cluster_resources)
+        if not shortfalls:
+            logger.info("Ray cluster resources satisfy GRPO startup requirements.")
+            logger.info(_startup_debug_context(args, plan, last_cluster_resources, ray.available_resources()))
+            return last_cluster_resources
+
+        if time.perf_counter() >= deadline:
+            break
+
+        logger.info("Waiting for Ray resources before creating learner placement group: " + "; ".join(shortfalls))
+        time.sleep(poll_interval_s)
+
+    available_resources = ray.available_resources()
+    raise RuntimeError(
+        "Timed out waiting for Ray to report the minimum resources required for GRPO startup.\n"
+        + "\n".join(
+            f"- {shortfall}"
+            for shortfall in grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(plan, last_cluster_resources)
+        )
+        + "\n"
+        + _startup_debug_context(args, plan, last_cluster_resources, available_resources)
+    )
+
+
+def wait_for_grpo_fast_placement_group(
+    args: grpo_utils.GRPOExperimentConfig,
+    plan: grpo_fast_resource_plan.GrpoFastResourcePlan,
+    pg: PlacementGroup,
+    timeout_s: float = PLACEMENT_GROUP_READY_TIMEOUT_S,
+) -> None:
+    """Wait for the learner placement group and raise an actionable error if it never schedules."""
+    try:
+        ray_get_with_progress([pg.ready()], desc="Waiting for placement group", timeout=timeout_s)
+    except TimeoutError as exc:
+        cluster_resources = ray.cluster_resources()
+        available_resources = ray.available_resources()
+        raise RuntimeError(
+            "Timed out waiting for the learner placement group to be scheduled.\n"
+            "Ray reported enough total resources earlier, so this usually means the requested bundles cannot be placed "
+            "on the currently available nodes or CPUs/GPUs are fragmented.\n"
+            + _startup_debug_context(args, plan, cluster_resources, available_resources)
+        ) from exc
 
 
 @ray.remote(num_gpus=1)
@@ -870,7 +949,7 @@ class ModelGroup:
         self.ray_process_cls = ray_process_cls
         self.num_gpus_per_node = num_gpus_per_node
         self.num_gpus_per_actor = 0.48 if single_gpu_mode else 1
-        self.num_cpus_per_actor = 4
+        self.num_cpus_per_actor = LEARNER_ACTOR_NUM_CPUS
         self.models = []
         world_size = sum(self.num_gpus_per_node)
         master_policy = ray_process_cls.options(
@@ -1218,10 +1297,11 @@ def create_model_and_optimizer(
     dict[str, Any] | None,
 ]:
     """Create the model, optimizer, and vLLM engines."""
-    # Create placement group
-    bundles = [{"GPU": actor_num_gpus, "CPU": actor_num_gpus * 10} for actor_num_gpus in args.num_learners_per_node]
-    pg = placement_group(bundles, strategy="STRICT_SPREAD")
-    ray_get_with_progress([pg.ready()], desc="Waiting for placement group")
+    resource_plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
+    wait_for_grpo_fast_minimum_cluster_resources(args, resource_plan)
+
+    pg = placement_group(resource_plan.learner_pg_bundles, strategy=resource_plan.learner_pg_strategy)
+    wait_for_grpo_fast_placement_group(args, resource_plan, pg)
 
     queues_to_monitor = {
         "Inference Results Queue": inference_results_Q,
@@ -1235,7 +1315,7 @@ def create_model_and_optimizer(
 
     # Create DataPreparationActor FIRST so StreamingDataLoader can find it
     _data_prep_actor = data_loader_lib.DataPreparationActor.options(
-        name=data_loader_lib.DATA_PREP_ACTOR_NAME, num_cpus=2
+        name=data_loader_lib.DATA_PREP_ACTOR_NAME, num_cpus=grpo_fast_resource_plan.DATA_PREPARATION_ACTOR_NUM_CPUS
     ).remote(  # type: ignore[unresolved-attribute]
         dataset=train_dataset,
         inference_results_Q=inference_results_Q,

--- a/open_instruct/grpo_fast_resource_plan.py
+++ b/open_instruct/grpo_fast_resource_plan.py
@@ -1,35 +1,6 @@
-import dataclasses
-from typing import Protocol
-
 LEARNER_PLACEMENT_GROUP_CPU_PER_GPU = 10
 DATA_PREPARATION_ACTOR_NUM_CPUS = 2
 ACTOR_MANAGER_NUM_CPUS = 1
-
-
-class ExperimentConfigLike(Protocol):
-    num_learners_per_node: list[int]
-    single_gpu_mode: bool
-
-
-class VLLMConfigLike(Protocol):
-    vllm_num_engines: int
-    vllm_tensor_parallel_size: int
-
-
-@dataclasses.dataclass(frozen=True)
-class GrpoFastResourcePlan:
-    """Minimum resource view needed to reason about GRPO startup scheduling."""
-
-    learner_pg_bundles: list[dict[str, float]]
-    learner_pg_strategy: str
-    learner_pg_total_gpus: float
-    learner_pg_total_cpus: float
-    separate_vllm_total_gpus: float
-    separate_vllm_total_cpus: float
-    data_prep_actor_cpus: float
-    actor_manager_cpus: float
-    min_total_cluster_gpus: float
-    min_total_cluster_cpus: float
 
 
 def format_resource_amount(amount: float) -> str:
@@ -52,10 +23,12 @@ def format_resource_snapshot(resources: dict[str, float] | None) -> str:
     return "{" + ", ".join(formatted) + "}"
 
 
-def build_grpo_fast_resource_plan(args: ExperimentConfigLike, vllm_config: VLLMConfigLike) -> GrpoFastResourcePlan:
+def build_grpo_fast_startup_requirements(
+    num_learners_per_node: list[int], single_gpu_mode: bool, vllm_num_engines: int, vllm_tensor_parallel_size: int
+) -> dict:
     learner_pg_bundles = [
         {"GPU": actor_num_gpus, "CPU": actor_num_gpus * LEARNER_PLACEMENT_GROUP_CPU_PER_GPU}
-        for actor_num_gpus in args.num_learners_per_node
+        for actor_num_gpus in num_learners_per_node
     ]
     learner_pg_total_gpus = float(sum(bundle["GPU"] for bundle in learner_pg_bundles))
     learner_pg_total_cpus = float(sum(bundle["CPU"] for bundle in learner_pg_bundles))
@@ -63,82 +36,79 @@ def build_grpo_fast_resource_plan(args: ExperimentConfigLike, vllm_config: VLLMC
     # In single_gpu_mode, vLLM shares the learner placement group instead of reserving a separate one.
     separate_vllm_total_gpus = 0.0
     separate_vllm_total_cpus = 0.0
-    if not args.single_gpu_mode:
-        separate_vllm_total_gpus = float(vllm_config.vllm_num_engines * vllm_config.vllm_tensor_parallel_size)
-        separate_vllm_total_cpus = float(vllm_config.vllm_num_engines * vllm_config.vllm_tensor_parallel_size)
+    if not single_gpu_mode:
+        separate_vllm_total_gpus = float(vllm_num_engines * vllm_tensor_parallel_size)
+        separate_vllm_total_cpus = float(vllm_num_engines * vllm_tensor_parallel_size)
 
-    data_prep_actor_cpus = float(DATA_PREPARATION_ACTOR_NUM_CPUS)
-    actor_manager_cpus = float(ACTOR_MANAGER_NUM_CPUS)
-    return GrpoFastResourcePlan(
-        learner_pg_bundles=learner_pg_bundles,
-        learner_pg_strategy="STRICT_SPREAD",
-        learner_pg_total_gpus=learner_pg_total_gpus,
-        learner_pg_total_cpus=learner_pg_total_cpus,
-        separate_vllm_total_gpus=separate_vllm_total_gpus,
-        separate_vllm_total_cpus=separate_vllm_total_cpus,
-        data_prep_actor_cpus=data_prep_actor_cpus,
-        actor_manager_cpus=actor_manager_cpus,
-        min_total_cluster_gpus=learner_pg_total_gpus + separate_vllm_total_gpus,
-        min_total_cluster_cpus=learner_pg_total_cpus
+    return {
+        "learner_pg_bundles": learner_pg_bundles,
+        "learner_pg_total_gpus": learner_pg_total_gpus,
+        "learner_pg_total_cpus": learner_pg_total_cpus,
+        "separate_vllm_total_gpus": separate_vllm_total_gpus,
+        "separate_vllm_total_cpus": separate_vllm_total_cpus,
+        "data_prep_actor_cpus": float(DATA_PREPARATION_ACTOR_NUM_CPUS),
+        "actor_manager_cpus": float(ACTOR_MANAGER_NUM_CPUS),
+        "min_total_cluster_gpus": learner_pg_total_gpus + separate_vllm_total_gpus,
+        "min_total_cluster_cpus": learner_pg_total_cpus
         + separate_vllm_total_cpus
-        + data_prep_actor_cpus
-        + actor_manager_cpus,
-    )
+        + float(DATA_PREPARATION_ACTOR_NUM_CPUS)
+        + float(ACTOR_MANAGER_NUM_CPUS),
+    }
 
 
-def format_grpo_fast_resource_plan(plan: GrpoFastResourcePlan) -> str:
+def format_grpo_fast_startup_requirements(requirements: dict) -> str:
     lines = [
         (
             "Learner placement group "
-            f"strategy={plan.learner_pg_strategy}, bundles={plan.learner_pg_bundles}, "
-            f"totals=(GPU={format_resource_amount(plan.learner_pg_total_gpus)}, "
-            f"CPU={format_resource_amount(plan.learner_pg_total_cpus)})"
+            f"strategy=STRICT_SPREAD, bundles={requirements['learner_pg_bundles']}, "
+            f"totals=(GPU={format_resource_amount(requirements['learner_pg_total_gpus'])}, "
+            f"CPU={format_resource_amount(requirements['learner_pg_total_cpus'])})"
         ),
         (
             "Separate vLLM minimum totals="
-            f"(GPU={format_resource_amount(plan.separate_vllm_total_gpus)}, "
-            f"CPU={format_resource_amount(plan.separate_vllm_total_cpus)})"
+            f"(GPU={format_resource_amount(requirements['separate_vllm_total_gpus'])}, "
+            f"CPU={format_resource_amount(requirements['separate_vllm_total_cpus'])})"
         ),
         (
             "Minimum full-topology totals="
-            f"(GPU={format_resource_amount(plan.min_total_cluster_gpus)}, "
-            f"CPU={format_resource_amount(plan.min_total_cluster_cpus)}; "
+            f"(GPU={format_resource_amount(requirements['min_total_cluster_gpus'])}, "
+            f"CPU={format_resource_amount(requirements['min_total_cluster_cpus'])}; "
             "includes "
-            f"DataPreparationActor CPU={format_resource_amount(plan.data_prep_actor_cpus)}, "
-            f"ActorManager CPU={format_resource_amount(plan.actor_manager_cpus)})"
+            f"DataPreparationActor CPU={format_resource_amount(requirements['data_prep_actor_cpus'])}, "
+            f"ActorManager CPU={format_resource_amount(requirements['actor_manager_cpus'])})"
         ),
     ]
     return "\n".join(lines)
 
 
-def get_grpo_fast_resource_shortfalls(plan: GrpoFastResourcePlan, cluster_resources: dict[str, float]) -> list[str]:
+def get_grpo_fast_resource_shortfalls(requirements: dict, cluster_resources: dict[str, float]) -> list[str]:
     cluster_gpus = float(cluster_resources.get("GPU", 0.0))
     cluster_cpus = float(cluster_resources.get("CPU", 0.0))
 
     shortfalls = []
-    if cluster_gpus < plan.learner_pg_total_gpus:
+    if cluster_gpus < requirements["learner_pg_total_gpus"]:
         shortfalls.append(
             "learner placement group requires "
-            f"GPU={format_resource_amount(plan.learner_pg_total_gpus)} but Ray currently sees "
+            f"GPU={format_resource_amount(requirements['learner_pg_total_gpus'])} but Ray currently sees "
             f"GPU={format_resource_amount(cluster_gpus)}"
         )
-    elif cluster_gpus < plan.min_total_cluster_gpus:
+    elif cluster_gpus < requirements["min_total_cluster_gpus"]:
         shortfalls.append(
             "full topology requires at least "
-            f"GPU={format_resource_amount(plan.min_total_cluster_gpus)} but Ray currently sees "
+            f"GPU={format_resource_amount(requirements['min_total_cluster_gpus'])} but Ray currently sees "
             f"GPU={format_resource_amount(cluster_gpus)}"
         )
 
-    if cluster_cpus < plan.learner_pg_total_cpus:
+    if cluster_cpus < requirements["learner_pg_total_cpus"]:
         shortfalls.append(
             "learner placement group requires "
-            f"CPU={format_resource_amount(plan.learner_pg_total_cpus)} but Ray currently sees "
+            f"CPU={format_resource_amount(requirements['learner_pg_total_cpus'])} but Ray currently sees "
             f"CPU={format_resource_amount(cluster_cpus)}"
         )
-    elif cluster_cpus < plan.min_total_cluster_cpus:
+    elif cluster_cpus < requirements["min_total_cluster_cpus"]:
         shortfalls.append(
             "full topology requires at least "
-            f"CPU={format_resource_amount(plan.min_total_cluster_cpus)} but Ray currently sees "
+            f"CPU={format_resource_amount(requirements['min_total_cluster_cpus'])} but Ray currently sees "
             f"CPU={format_resource_amount(cluster_cpus)}"
         )
 

--- a/open_instruct/grpo_fast_resource_plan.py
+++ b/open_instruct/grpo_fast_resource_plan.py
@@ -1,0 +1,145 @@
+import dataclasses
+from typing import Protocol
+
+LEARNER_PLACEMENT_GROUP_CPU_PER_GPU = 10
+DATA_PREPARATION_ACTOR_NUM_CPUS = 2
+ACTOR_MANAGER_NUM_CPUS = 1
+
+
+class ExperimentConfigLike(Protocol):
+    num_learners_per_node: list[int]
+    single_gpu_mode: bool
+
+
+class VLLMConfigLike(Protocol):
+    vllm_num_engines: int
+    vllm_tensor_parallel_size: int
+
+
+@dataclasses.dataclass(frozen=True)
+class GrpoFastResourcePlan:
+    """Minimum resource view needed to reason about GRPO startup scheduling."""
+
+    learner_pg_bundles: list[dict[str, float]]
+    learner_pg_strategy: str
+    learner_pg_total_gpus: float
+    learner_pg_total_cpus: float
+    separate_vllm_total_gpus: float
+    separate_vllm_total_cpus: float
+    data_prep_actor_cpus: float
+    actor_manager_cpus: float
+    min_total_cluster_gpus: float
+    min_total_cluster_cpus: float
+
+
+def format_resource_amount(amount: float) -> str:
+    amount = float(amount)
+    if amount.is_integer():
+        return str(int(amount))
+    return f"{amount:g}"
+
+
+def format_resource_snapshot(resources: dict[str, float] | None) -> str:
+    if not resources:
+        return "{}"
+    formatted = []
+    for key in sorted(resources):
+        value = resources[key]
+        if isinstance(value, (int, float)):
+            formatted.append(f"{key}={format_resource_amount(value)}")
+        else:
+            formatted.append(f"{key}={value}")
+    return "{" + ", ".join(formatted) + "}"
+
+
+def build_grpo_fast_resource_plan(args: ExperimentConfigLike, vllm_config: VLLMConfigLike) -> GrpoFastResourcePlan:
+    learner_pg_bundles = [
+        {"GPU": actor_num_gpus, "CPU": actor_num_gpus * LEARNER_PLACEMENT_GROUP_CPU_PER_GPU}
+        for actor_num_gpus in args.num_learners_per_node
+    ]
+    learner_pg_total_gpus = float(sum(bundle["GPU"] for bundle in learner_pg_bundles))
+    learner_pg_total_cpus = float(sum(bundle["CPU"] for bundle in learner_pg_bundles))
+
+    # In single_gpu_mode, vLLM shares the learner placement group instead of reserving a separate one.
+    separate_vllm_total_gpus = 0.0
+    separate_vllm_total_cpus = 0.0
+    if not args.single_gpu_mode:
+        separate_vllm_total_gpus = float(vllm_config.vllm_num_engines * vllm_config.vllm_tensor_parallel_size)
+        separate_vllm_total_cpus = float(vllm_config.vllm_num_engines * vllm_config.vllm_tensor_parallel_size)
+
+    data_prep_actor_cpus = float(DATA_PREPARATION_ACTOR_NUM_CPUS)
+    actor_manager_cpus = float(ACTOR_MANAGER_NUM_CPUS)
+    return GrpoFastResourcePlan(
+        learner_pg_bundles=learner_pg_bundles,
+        learner_pg_strategy="STRICT_SPREAD",
+        learner_pg_total_gpus=learner_pg_total_gpus,
+        learner_pg_total_cpus=learner_pg_total_cpus,
+        separate_vllm_total_gpus=separate_vllm_total_gpus,
+        separate_vllm_total_cpus=separate_vllm_total_cpus,
+        data_prep_actor_cpus=data_prep_actor_cpus,
+        actor_manager_cpus=actor_manager_cpus,
+        min_total_cluster_gpus=learner_pg_total_gpus + separate_vllm_total_gpus,
+        min_total_cluster_cpus=learner_pg_total_cpus
+        + separate_vllm_total_cpus
+        + data_prep_actor_cpus
+        + actor_manager_cpus,
+    )
+
+
+def format_grpo_fast_resource_plan(plan: GrpoFastResourcePlan) -> str:
+    lines = [
+        (
+            "Learner placement group "
+            f"strategy={plan.learner_pg_strategy}, bundles={plan.learner_pg_bundles}, "
+            f"totals=(GPU={format_resource_amount(plan.learner_pg_total_gpus)}, "
+            f"CPU={format_resource_amount(plan.learner_pg_total_cpus)})"
+        ),
+        (
+            "Separate vLLM minimum totals="
+            f"(GPU={format_resource_amount(plan.separate_vllm_total_gpus)}, "
+            f"CPU={format_resource_amount(plan.separate_vllm_total_cpus)})"
+        ),
+        (
+            "Minimum full-topology totals="
+            f"(GPU={format_resource_amount(plan.min_total_cluster_gpus)}, "
+            f"CPU={format_resource_amount(plan.min_total_cluster_cpus)}; "
+            "includes "
+            f"DataPreparationActor CPU={format_resource_amount(plan.data_prep_actor_cpus)}, "
+            f"ActorManager CPU={format_resource_amount(plan.actor_manager_cpus)})"
+        ),
+    ]
+    return "\n".join(lines)
+
+
+def get_grpo_fast_resource_shortfalls(plan: GrpoFastResourcePlan, cluster_resources: dict[str, float]) -> list[str]:
+    cluster_gpus = float(cluster_resources.get("GPU", 0.0))
+    cluster_cpus = float(cluster_resources.get("CPU", 0.0))
+
+    shortfalls = []
+    if cluster_gpus < plan.learner_pg_total_gpus:
+        shortfalls.append(
+            "learner placement group requires "
+            f"GPU={format_resource_amount(plan.learner_pg_total_gpus)} but Ray currently sees "
+            f"GPU={format_resource_amount(cluster_gpus)}"
+        )
+    elif cluster_gpus < plan.min_total_cluster_gpus:
+        shortfalls.append(
+            "full topology requires at least "
+            f"GPU={format_resource_amount(plan.min_total_cluster_gpus)} but Ray currently sees "
+            f"GPU={format_resource_amount(cluster_gpus)}"
+        )
+
+    if cluster_cpus < plan.learner_pg_total_cpus:
+        shortfalls.append(
+            "learner placement group requires "
+            f"CPU={format_resource_amount(plan.learner_pg_total_cpus)} but Ray currently sees "
+            f"CPU={format_resource_amount(cluster_cpus)}"
+        )
+    elif cluster_cpus < plan.min_total_cluster_cpus:
+        shortfalls.append(
+            "full topology requires at least "
+            f"CPU={format_resource_amount(plan.min_total_cluster_cpus)} but Ray currently sees "
+            f"CPU={format_resource_amount(cluster_cpus)}"
+        )
+
+    return shortfalls

--- a/open_instruct/test_grpo_fast_resource_plan.py
+++ b/open_instruct/test_grpo_fast_resource_plan.py
@@ -17,34 +17,48 @@ class TestGrpoFastResourcePlanning(unittest.TestCase):
         args = self._make_args(num_learners_per_node=[6])
         vllm_config = self._make_vllm_config(vllm_num_engines=2, vllm_tensor_parallel_size=1)
 
-        plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
+        requirements = grpo_fast_resource_plan.build_grpo_fast_startup_requirements(
+            num_learners_per_node=args.num_learners_per_node,
+            single_gpu_mode=args.single_gpu_mode,
+            vllm_num_engines=vllm_config.vllm_num_engines,
+            vllm_tensor_parallel_size=vllm_config.vllm_tensor_parallel_size,
+        )
 
-        self.assertEqual(plan.learner_pg_strategy, "STRICT_SPREAD")
-        self.assertEqual(plan.learner_pg_bundles, [{"GPU": 6, "CPU": 60}])
-        self.assertEqual(plan.learner_pg_total_gpus, 6.0)
-        self.assertEqual(plan.learner_pg_total_cpus, 60.0)
-        self.assertEqual(plan.separate_vllm_total_gpus, 2.0)
-        self.assertEqual(plan.separate_vllm_total_cpus, 2.0)
-        self.assertEqual(plan.min_total_cluster_gpus, 8.0)
-        self.assertEqual(plan.min_total_cluster_cpus, 65.0)
+        self.assertEqual(requirements["learner_pg_bundles"], [{"GPU": 6, "CPU": 60}])
+        self.assertEqual(requirements["learner_pg_total_gpus"], 6.0)
+        self.assertEqual(requirements["learner_pg_total_cpus"], 60.0)
+        self.assertEqual(requirements["separate_vllm_total_gpus"], 2.0)
+        self.assertEqual(requirements["separate_vllm_total_cpus"], 2.0)
+        self.assertEqual(requirements["min_total_cluster_gpus"], 8.0)
+        self.assertEqual(requirements["min_total_cluster_cpus"], 65.0)
 
     def test_build_resource_plan_omits_separate_vllm_totals_in_single_gpu_mode(self):
         args = self._make_args(num_learners_per_node=[1], single_gpu_mode=True)
         vllm_config = self._make_vllm_config(vllm_num_engines=1, vllm_tensor_parallel_size=1)
 
-        plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
+        requirements = grpo_fast_resource_plan.build_grpo_fast_startup_requirements(
+            num_learners_per_node=args.num_learners_per_node,
+            single_gpu_mode=args.single_gpu_mode,
+            vllm_num_engines=vllm_config.vllm_num_engines,
+            vllm_tensor_parallel_size=vllm_config.vllm_tensor_parallel_size,
+        )
 
-        self.assertEqual(plan.separate_vllm_total_gpus, 0.0)
-        self.assertEqual(plan.separate_vllm_total_cpus, 0.0)
-        self.assertEqual(plan.min_total_cluster_gpus, 1.0)
-        self.assertEqual(plan.min_total_cluster_cpus, 13.0)
+        self.assertEqual(requirements["separate_vllm_total_gpus"], 0.0)
+        self.assertEqual(requirements["separate_vllm_total_cpus"], 0.0)
+        self.assertEqual(requirements["min_total_cluster_gpus"], 1.0)
+        self.assertEqual(requirements["min_total_cluster_cpus"], 13.0)
 
     def test_resource_shortfalls_report_learner_pg_cpu_gap_first(self):
         args = self._make_args(num_learners_per_node=[6])
         vllm_config = self._make_vllm_config(vllm_num_engines=2, vllm_tensor_parallel_size=1)
-        plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
+        requirements = grpo_fast_resource_plan.build_grpo_fast_startup_requirements(
+            num_learners_per_node=args.num_learners_per_node,
+            single_gpu_mode=args.single_gpu_mode,
+            vllm_num_engines=vllm_config.vllm_num_engines,
+            vllm_tensor_parallel_size=vllm_config.vllm_tensor_parallel_size,
+        )
 
-        shortfalls = grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(plan, {"GPU": 8, "CPU": 32})
+        shortfalls = grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(requirements, {"GPU": 8, "CPU": 32})
 
         self.assertEqual(len(shortfalls), 1)
         self.assertIn("learner placement group requires CPU=60", shortfalls[0])
@@ -52,9 +66,14 @@ class TestGrpoFastResourcePlanning(unittest.TestCase):
     def test_resource_shortfalls_report_full_topology_gap_after_pg_fits(self):
         args = self._make_args(num_learners_per_node=[6])
         vllm_config = self._make_vllm_config(vllm_num_engines=2, vllm_tensor_parallel_size=1)
-        plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
+        requirements = grpo_fast_resource_plan.build_grpo_fast_startup_requirements(
+            num_learners_per_node=args.num_learners_per_node,
+            single_gpu_mode=args.single_gpu_mode,
+            vllm_num_engines=vllm_config.vllm_num_engines,
+            vllm_tensor_parallel_size=vllm_config.vllm_tensor_parallel_size,
+        )
 
-        shortfalls = grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(plan, {"GPU": 8, "CPU": 64})
+        shortfalls = grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(requirements, {"GPU": 8, "CPU": 64})
 
         self.assertEqual(len(shortfalls), 1)
         self.assertIn("full topology requires at least CPU=65", shortfalls[0])

--- a/open_instruct/test_grpo_fast_resource_plan.py
+++ b/open_instruct/test_grpo_fast_resource_plan.py
@@ -1,0 +1,60 @@
+import unittest
+from types import SimpleNamespace
+
+from open_instruct import grpo_fast_resource_plan
+
+
+class TestGrpoFastResourcePlanning(unittest.TestCase):
+    def _make_args(self, *, num_learners_per_node, single_gpu_mode=False, num_nodes=1):
+        return SimpleNamespace(
+            num_learners_per_node=num_learners_per_node, single_gpu_mode=single_gpu_mode, num_nodes=num_nodes
+        )
+
+    def _make_vllm_config(self, *, vllm_num_engines, vllm_tensor_parallel_size):
+        return SimpleNamespace(vllm_num_engines=vllm_num_engines, vllm_tensor_parallel_size=vllm_tensor_parallel_size)
+
+    def test_build_resource_plan_for_single_node_tulu_topology(self):
+        args = self._make_args(num_learners_per_node=[6])
+        vllm_config = self._make_vllm_config(vllm_num_engines=2, vllm_tensor_parallel_size=1)
+
+        plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
+
+        self.assertEqual(plan.learner_pg_strategy, "STRICT_SPREAD")
+        self.assertEqual(plan.learner_pg_bundles, [{"GPU": 6, "CPU": 60}])
+        self.assertEqual(plan.learner_pg_total_gpus, 6.0)
+        self.assertEqual(plan.learner_pg_total_cpus, 60.0)
+        self.assertEqual(plan.separate_vllm_total_gpus, 2.0)
+        self.assertEqual(plan.separate_vllm_total_cpus, 2.0)
+        self.assertEqual(plan.min_total_cluster_gpus, 8.0)
+        self.assertEqual(plan.min_total_cluster_cpus, 65.0)
+
+    def test_build_resource_plan_omits_separate_vllm_totals_in_single_gpu_mode(self):
+        args = self._make_args(num_learners_per_node=[1], single_gpu_mode=True)
+        vllm_config = self._make_vllm_config(vllm_num_engines=1, vllm_tensor_parallel_size=1)
+
+        plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
+
+        self.assertEqual(plan.separate_vllm_total_gpus, 0.0)
+        self.assertEqual(plan.separate_vllm_total_cpus, 0.0)
+        self.assertEqual(plan.min_total_cluster_gpus, 1.0)
+        self.assertEqual(plan.min_total_cluster_cpus, 13.0)
+
+    def test_resource_shortfalls_report_learner_pg_cpu_gap_first(self):
+        args = self._make_args(num_learners_per_node=[6])
+        vllm_config = self._make_vllm_config(vllm_num_engines=2, vllm_tensor_parallel_size=1)
+        plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
+
+        shortfalls = grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(plan, {"GPU": 8, "CPU": 32})
+
+        self.assertEqual(len(shortfalls), 1)
+        self.assertIn("learner placement group requires CPU=60", shortfalls[0])
+
+    def test_resource_shortfalls_report_full_topology_gap_after_pg_fits(self):
+        args = self._make_args(num_learners_per_node=[6])
+        vllm_config = self._make_vllm_config(vllm_num_engines=2, vllm_tensor_parallel_size=1)
+        plan = grpo_fast_resource_plan.build_grpo_fast_resource_plan(args, vllm_config)
+
+        shortfalls = grpo_fast_resource_plan.get_grpo_fast_resource_shortfalls(plan, {"GPU": 8, "CPU": 64})
+
+        self.assertEqual(len(shortfalls), 1)
+        self.assertIn("full topology requires at least CPU=65", shortfalls[0])


### PR DESCRIPTION
## Summary
- add a small startup resource-planning module for `grpo_fast`
- preflight-check Ray-visible CPU/GPU resources before creating the learner placement group
- bound learner placement-group waits and raise actionable diagnostics instead of hanging indefinitely
- add focused unit tests for the single-node startup resource calculations

## Why
Issue #1431 reports one-node GRPO/RLVR runs hanging at `Waiting for placement group`. In the current startup path, `grpo_fast.py` asks Ray for the learner placement group before surfacing the effective startup resource requirements, so CPU/GPU visibility problems can look like opaque hangs.

This change keeps the existing scheduling model intact, but makes startup behavior much easier to diagnose and much safer on single-node runs.

## Root Cause
- the learner placement group is requested before learner actors, data prep, and vLLM engines are initialized
- the practical one-node topology is more than just `8 GPUs`; it also depends on Ray-visible CPU for the learner placement group and follow-on actors
- `grpo_fast.py` previously waited on `pg.ready()` without a bounded timeout or enough context to explain why scheduling was stuck

## What Changed
- added `open_instruct/grpo_fast_resource_plan.py` to centralize startup resource planning and shortfall reporting
- added a GRPO startup preflight in `open_instruct/grpo_fast.py` that waits for Ray to report the minimum required resources before creating the learner placement group
- replaced the unbounded learner placement-group wait with a bounded wait that includes cluster resources, available resources, runtime context, and likely-cause hints in the failure message
- extracted named CPU constants for learner actors and the data-prep actor instead of leaving those values as inline magic numbers
- added `open_instruct/test_grpo_fast_resource_plan.py` to cover the `6 learners / 2 vLLM` topology, `single_gpu_mode`, learner-PG CPU shortfalls, and full-topology CPU shortfalls

## Validation
- `uv run pytest open_instruct/test_grpo_fast_resource_plan.py -q`
- `make style`
- `make quality`

## Notes
- this is intentionally a focused startup-hardening change; it does not redesign the single-node scheduler or placement strategy yet
- I could not run a full end-to-end local `grpo_fast.py` + `vllm` startup on macOS in this environment, so the runtime validation here is targeted unit coverage plus repo checks
- `make quality` still reports one unrelated pre-existing `ty` warning in `open_instruct/environments/tools/parsers.py`

## Issue
- Addresses #1431
