### PR TITLE
Stabilize GRPO LLM judge calls by routing them through the guarded LiteLLM helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ All notable changes to this project will be documented in this file.
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).
+- Route GRPO LLM judge requests through the shared semaphore-guarded LiteLLM helper, preserving judge-specific retries and cost accounting while removing stale per-verifier client cleanup code (https://github.com/allenai/open-instruct/pull/1587).
 - Fix shellcheck `$@` quoting in GRPO debug scripts (https://github.com/allenai/open-instruct/pull/1572).
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 

--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -22,7 +22,6 @@ from typing import Any, Literal
 
 import numpy as np
 import requests
-from litellm import acompletion
 
 from open_instruct import context_window_checker, logger_utils
 from open_instruct.if_functions import IF_FUNCTIONS_MAP
@@ -37,7 +36,7 @@ from open_instruct.math_utils import (
     remove_boxed,
 )
 from open_instruct.rubrics.prompts import RUBRIC_SCORING_PROMPT
-from open_instruct.rubrics.run_utils import extract_json_from_response, run_litellm_async
+from open_instruct.rubrics.run_utils import extract_json_from_response, run_litellm_async, run_litellm_async_raw
 from open_instruct.utils import extract_final_answer
 
 logger = logger_utils.setup_logger(__name__)
@@ -700,9 +699,6 @@ class LMJudgeVerifier(VerifierFunction):
     Verifier that uses a language model's judgement to score a response.
     """
 
-    # Use WeakKeyDictionary to automatically clean up clients when event loops are garbage collected
-    _client_cache = weakref.WeakKeyDictionary()
-
     def __init__(self, judge_type: str, verifier_config: LMJudgeVerifierConfig) -> None:
         super().__init__(f"general-{judge_type}", verifier_config=verifier_config, weight=1.0)
         self.prompt_template = JUDGE_PROMPT_MAP[judge_type]
@@ -762,7 +758,6 @@ class LMJudgeVerifier(VerifierFunction):
         """
         Asynchronous version of __call__ that properly handles the async OpenAI client.
         """
-        # client = self._get_client()
         final_answer = extract_final_answer(prediction)
         prompt = self.prompt_template.format(input=query, output=final_answer, label=label)
 
@@ -802,8 +797,8 @@ class LMJudgeVerifier(VerifierFunction):
                         logger.error("Cannot fit request within context window even after truncation.")
                         return VerificationResult(score=0.0, cost=0.0, reasoning="Error: Context window exceeded")
                 # end of Faeze's context window check
-                response = await acompletion(
-                    model=self.verifier_config.llm_judge_model,
+                response = await run_litellm_async_raw(
+                    model_name=self.verifier_config.llm_judge_model,
                     messages=messages,
                     temperature=self.verifier_config.llm_judge_temperature,
                     max_completion_tokens=self.verifier_config.llm_judge_max_tokens,
@@ -856,17 +851,9 @@ class LMJudgeVerifier(VerifierFunction):
     @classmethod
     async def cleanup_all_clients(cls):
         """
-        Manually close all cached clients. Call this before shutting down to avoid cleanup warnings.
+        Judge requests use the shared LiteLLM helper and do not own per-verifier clients.
         """
-        clients_to_close = list(cls._client_cache.values())
-        cls._client_cache.clear()
-
-        for client in clients_to_close:
-            try:
-                await client.close()
-            except Exception as e:
-                logger.warning(f"Error closing OpenAI client: {e}")
-                # Suppress the error to avoid breaking shutdown
+        return None
 
     @classmethod
     def get_config_class(cls) -> type:

--- a/open_instruct/rubrics/run_utils.py
+++ b/open_instruct/rubrics/run_utils.py
@@ -119,6 +119,51 @@ def run_litellm(model_name: str, user_prompt: str, system_prompt: str | None = N
     return response.choices[0].message.content
 
 
+def _build_messages(
+    user_prompt: str | None = None, system_prompt: str | None = None, messages: list[dict[str, str]] | None = None
+) -> list[dict[str, str]]:
+    """Build chat messages for LiteLLM requests."""
+    if messages is not None:
+        return messages
+
+    return (
+        [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
+        if system_prompt is not None
+        else [{"role": "user", "content": user_prompt}]
+    )
+
+
+def _apply_async_chat_defaults(chat_kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Apply the existing `run_litellm_async` defaults for rubric-style callers."""
+    request_kwargs = dict(chat_kwargs)
+    request_kwargs["temperature"] = request_kwargs.get("temperature", 0)
+    if "max_tokens" not in request_kwargs and "max_completion_tokens" not in request_kwargs:
+        request_kwargs["max_tokens"] = 16384
+    request_kwargs["top_p"] = request_kwargs.get("top_p", 1.0)
+    request_kwargs["frequency_penalty"] = request_kwargs.get("frequency_penalty", 0.0)
+    request_kwargs["presence_penalty"] = request_kwargs.get("presence_penalty", 0.0)
+    request_kwargs["num_retries"] = request_kwargs.get("num_retries", 5)
+    request_kwargs["fallbacks"] = request_kwargs.get("fallbacks", [])
+    request_kwargs["timeout"] = request_kwargs.get("timeout", float(os.environ.get("LITELLM_DEFAULT_TIMEOUT", "600")))
+    return request_kwargs
+
+
+async def run_litellm_async_raw(
+    model_name: str,
+    user_prompt: str | None = None,
+    system_prompt: str | None = None,
+    messages: list[dict[str, str]] | None = None,
+    **chat_kwargs,
+) -> Any:
+    """Async LiteLLM helper that returns the raw response and preserves exceptions."""
+    litellm = _get_litellm()
+    msgs = _build_messages(user_prompt=user_prompt, system_prompt=system_prompt, messages=messages)
+
+    semaphore = _get_litellm_semaphore()
+    async with semaphore:
+        return await litellm.acompletion(messages=msgs, model=model_name, **chat_kwargs)
+
+
 async def run_litellm_async(
     model_name: str,
     user_prompt: str | None = None,
@@ -140,36 +185,15 @@ async def run_litellm_async(
     Returns:
         The response content from the model
     """
-    litellm = _get_litellm()
-
-    # Set default parameters
-    chat_kwargs["temperature"] = chat_kwargs.get("temperature", 0)
-    chat_kwargs["max_tokens"] = chat_kwargs.get("max_tokens", 16384)
-    chat_kwargs["top_p"] = chat_kwargs.get("top_p", 1.0)
-    chat_kwargs["frequency_penalty"] = chat_kwargs.get("frequency_penalty", 0.0)
-    chat_kwargs["presence_penalty"] = chat_kwargs.get("presence_penalty", 0.0)
-    chat_kwargs["num_retries"] = chat_kwargs.get("num_retries", 5)
-    chat_kwargs["fallbacks"] = chat_kwargs.get("fallbacks", [])
-
-    # Prepare messages
-    if messages is not None:
-        msgs = messages
-    else:
-        msgs = (
-            [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]
-            if system_prompt is not None
-            else [{"role": "user", "content": user_prompt}]
-        )
-
-    # Apply default timeout if not provided
-    chat_kwargs["timeout"] = chat_kwargs.get("timeout", float(os.environ.get("LITELLM_DEFAULT_TIMEOUT", "600")))
-
-    # Guard concurrent calls with a global semaphore
+    request_kwargs = _apply_async_chat_defaults(chat_kwargs)
     try:
-        semaphore = _get_litellm_semaphore()
-        async with semaphore:
-            # Create chat completion
-            response = await litellm.acompletion(messages=msgs, model=model_name, **chat_kwargs)
+        response = await run_litellm_async_raw(
+            model_name=model_name,
+            user_prompt=user_prompt,
+            system_prompt=system_prompt,
+            messages=messages,
+            **request_kwargs,
+        )
     except Exception as e:
         # if we get an error, return an empty string
         logger.warning(f"Error in run_litellm_async: {e}")

--- a/open_instruct/rubrics/run_utils.py
+++ b/open_instruct/rubrics/run_utils.py
@@ -124,7 +124,12 @@ def _build_messages(
 ) -> list[dict[str, str]]:
     """Build chat messages for LiteLLM requests."""
     if messages is not None:
+        if not messages:
+            raise ValueError("messages must not be empty.")
         return messages
+
+    if user_prompt is None:
+        raise ValueError("Either messages or user_prompt must be provided.")
 
     return (
         [{"role": "system", "content": system_prompt}, {"role": "user", "content": user_prompt}]

--- a/open_instruct/rubrics/test_rubrics.py
+++ b/open_instruct/rubrics/test_rubrics.py
@@ -137,6 +137,28 @@ class TestRunLitellmAsyncHelpers(unittest.TestCase):
         ):
             asyncio.run(run_litellm_async_raw(model_name="test-model", user_prompt="hello"))
 
+    def test_raw_helper_requires_user_prompt_or_messages(self):
+        class FakeLiteLLM:
+            async def acompletion(self, **kwargs):
+                raise AssertionError("Should not reach LiteLLM when inputs are invalid")
+
+        with (
+            patch("open_instruct.rubrics.run_utils._get_litellm", return_value=FakeLiteLLM()),
+            self.assertRaisesRegex(ValueError, "Either messages or user_prompt must be provided"),
+        ):
+            asyncio.run(run_litellm_async_raw(model_name="test-model"))
+
+    def test_raw_helper_rejects_empty_messages(self):
+        class FakeLiteLLM:
+            async def acompletion(self, **kwargs):
+                raise AssertionError("Should not reach LiteLLM when inputs are invalid")
+
+        with (
+            patch("open_instruct.rubrics.run_utils._get_litellm", return_value=FakeLiteLLM()),
+            self.assertRaisesRegex(ValueError, "messages must not be empty"),
+        ):
+            asyncio.run(run_litellm_async_raw(model_name="test-model", messages=[]))
+
     def test_wrapper_preserves_existing_failure_behavior(self):
         with patch("open_instruct.rubrics.run_utils.run_litellm_async_raw", side_effect=RuntimeError("boom")):
             response = asyncio.run(run_litellm_async(model_name="test-model", user_prompt="hello"))

--- a/open_instruct/rubrics/test_rubrics.py
+++ b/open_instruct/rubrics/test_rubrics.py
@@ -19,11 +19,12 @@ import os
 import shutil
 import tempfile
 import unittest
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from open_instruct.ground_truth_utils import RubricVerifier, RubricVerifierConfig
 from open_instruct.model_utils import Batch
-from open_instruct.rubrics import RubricManager
+from open_instruct.rubrics import RubricManager, run_utils
 from open_instruct.rubrics.evolving_rubric_step import _build_ground_truth_overrides
 from open_instruct.rubrics.metrics import (
     compute_rubric_count_metrics,
@@ -35,7 +36,7 @@ from open_instruct.rubrics.rubric_utils import (
     save_evolving_rubric_cache_safe,
     update_ground_truths_with_evolving_rubrics,
 )
-from open_instruct.rubrics.run_utils import extract_json_from_response
+from open_instruct.rubrics.run_utils import extract_json_from_response, run_litellm_async, run_litellm_async_raw
 
 
 def _check_litellm_available():
@@ -91,6 +92,96 @@ class TestExtractJsonFromResponse(unittest.TestCase):
     def test_multiple_json_objects(self):
         """Test multiple JSON objects (should get last valid one)."""
         self.assertEqual(extract_json_from_response('{"a": 1} more text {"score": 2}'), {"score": 2})
+
+
+def _make_fake_response(content: str):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+
+class TestRunLitellmAsyncHelpers(unittest.TestCase):
+    def setUp(self):
+        run_utils._LITELLM_SEMAPHORES.clear()
+
+    def tearDown(self):
+        run_utils._LITELLM_SEMAPHORES.clear()
+
+    def test_raw_helper_returns_raw_response(self):
+        response = _make_fake_response("raw-content")
+
+        class FakeLiteLLM:
+            def __init__(self):
+                self.calls = []
+
+            async def acompletion(self, **kwargs):
+                self.calls.append(kwargs)
+                return response
+
+        fake_litellm = FakeLiteLLM()
+        with patch("open_instruct.rubrics.run_utils._get_litellm", return_value=fake_litellm):
+            result = asyncio.run(run_litellm_async_raw(model_name="test-model", user_prompt="hello"))
+
+        self.assertIs(result, response)
+        self.assertEqual(fake_litellm.calls[0]["model"], "test-model")
+        self.assertEqual(fake_litellm.calls[0]["messages"], [{"role": "user", "content": "hello"}])
+        self.assertNotIn("num_retries", fake_litellm.calls[0])
+        self.assertNotIn("fallbacks", fake_litellm.calls[0])
+
+    def test_raw_helper_preserves_exceptions(self):
+        class FakeLiteLLM:
+            async def acompletion(self, **kwargs):
+                raise RuntimeError("boom")
+
+        with (
+            patch("open_instruct.rubrics.run_utils._get_litellm", return_value=FakeLiteLLM()),
+            self.assertRaisesRegex(RuntimeError, "boom"),
+        ):
+            asyncio.run(run_litellm_async_raw(model_name="test-model", user_prompt="hello"))
+
+    def test_wrapper_preserves_existing_failure_behavior(self):
+        with patch("open_instruct.rubrics.run_utils.run_litellm_async_raw", side_effect=RuntimeError("boom")):
+            response = asyncio.run(run_litellm_async(model_name="test-model", user_prompt="hello"))
+
+        self.assertEqual(response, "")
+
+    def test_wrapper_applies_existing_defaults(self):
+        response = _make_fake_response("wrapped-content")
+
+        with patch(
+            "open_instruct.rubrics.run_utils.run_litellm_async_raw", AsyncMock(return_value=response)
+        ) as helper:
+            result = asyncio.run(run_litellm_async(model_name="test-model", user_prompt="hello"))
+
+        self.assertEqual(result, "wrapped-content")
+        self.assertEqual(helper.await_args.kwargs["temperature"], 0)
+        self.assertEqual(helper.await_args.kwargs["max_tokens"], 16384)
+        self.assertEqual(helper.await_args.kwargs["num_retries"], 5)
+        self.assertEqual(helper.await_args.kwargs["fallbacks"], [])
+        self.assertIn("timeout", helper.await_args.kwargs)
+
+    def test_raw_helper_respects_semaphore_limit(self):
+        state = {"active": 0, "max_active": 0}
+        response = _make_fake_response("ok")
+
+        class FakeLiteLLM:
+            async def acompletion(self, **kwargs):
+                state["active"] += 1
+                state["max_active"] = max(state["max_active"], state["active"])
+                await asyncio.sleep(0.01)
+                state["active"] -= 1
+                return response
+
+        async def run_many_calls():
+            tasks = [run_litellm_async_raw(model_name="test-model", user_prompt=f"hello-{i}") for i in range(6)]
+            return await asyncio.gather(*tasks)
+
+        with (
+            patch.dict(os.environ, {"LITELLM_MAX_CONCURRENT_CALLS": "2"}, clear=False),
+            patch("open_instruct.rubrics.run_utils._get_litellm", return_value=FakeLiteLLM()),
+        ):
+            results = asyncio.run(run_many_calls())
+
+        self.assertEqual(len(results), 6)
+        self.assertLessEqual(state["max_active"], 2)
 
 
 @unittest.skipIf(not _check_litellm_available(), "litellm not installed")

--- a/open_instruct/test_ground_truth_utils.py
+++ b/open_instruct/test_ground_truth_utils.py
@@ -3,11 +3,21 @@
 Test script for verifier functionality in Python
 """
 
+import asyncio
 import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 from parameterized import parameterized
 
-from open_instruct.ground_truth_utils import F1Verifier, GSM8KVerifier, PuzzleMatcherVerifier
+from open_instruct.ground_truth_utils import (
+    F1Verifier,
+    GSM8KVerifier,
+    LMJudgeVerifier,
+    LMJudgeVerifierConfig,
+    PuzzleMatcherVerifier,
+    cleanup_all_llm_judge_clients,
+)
 
 
 class TestPuzzleMatcherVerifier(unittest.TestCase):
@@ -160,6 +170,63 @@ class TestGSM8KVerifier(unittest.TestCase):
     def test_signed_number_extraction(self, _name, prediction, label, expected_score):
         result = self.verifier([], prediction, label)
         self.assertEqual(result.score, expected_score)
+
+
+def _make_litellm_response(content: str, prompt_tokens: int = 10, completion_tokens: int = 5):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))],
+        usage=SimpleNamespace(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens),
+    )
+
+
+class TestLMJudgeVerifier(unittest.TestCase):
+    def setUp(self):
+        self.verifier = LMJudgeVerifier(
+            "quality",
+            LMJudgeVerifierConfig(
+                llm_judge_model="azure/gpt-4o-mini-standard",
+                llm_judge_max_tokens=256,
+                llm_judge_max_context_length=4096,
+                llm_judge_temperature=0.0,
+                llm_judge_timeout=30,
+                seed=17,
+            ),
+        )
+
+    def test_async_call_uses_shared_helper_and_preserves_retry_and_cost(self):
+        response = _make_litellm_response('{"REASONING":"clear","SCORE":7}', prompt_tokens=10, completion_tokens=5)
+        raw_helper = AsyncMock(side_effect=[RuntimeError("temporary"), response])
+        sleep_mock = AsyncMock()
+
+        with (
+            patch("open_instruct.ground_truth_utils.run_litellm_async_raw", raw_helper),
+            patch(
+                "open_instruct.ground_truth_utils.context_window_checker.check_context_window_limit", return_value=True
+            ),
+            patch("open_instruct.ground_truth_utils.asyncio.sleep", sleep_mock),
+        ):
+            result = asyncio.run(
+                self.verifier.async_call(
+                    tokenized_prediction=[],
+                    prediction="<answer>final answer</answer>",
+                    label="reference",
+                    query="What is the answer?",
+                )
+            )
+
+        self.assertAlmostEqual(result.score, 0.7)
+        self.assertEqual(result.reasoning, "clear")
+        self.assertAlmostEqual(result.cost, 0.0000045)
+        self.assertEqual(raw_helper.await_count, 2)
+        self.assertEqual(sleep_mock.await_count, 1)
+        self.assertEqual(raw_helper.await_args_list[-1].kwargs["model_name"], "azure/gpt-4o-mini-standard")
+        self.assertEqual(raw_helper.await_args_list[-1].kwargs["max_completion_tokens"], 256)
+        self.assertNotIn("num_retries", raw_helper.await_args_list[-1].kwargs)
+        self.assertNotIn("fallbacks", raw_helper.await_args_list[-1].kwargs)
+
+    def test_cleanup_helpers_are_safe_noops(self):
+        self.assertIsNone(asyncio.run(LMJudgeVerifier.cleanup_all_clients()))
+        self.assertIsNone(asyncio.run(cleanup_all_llm_judge_clients()))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- route `LMJudgeVerifier` through the shared semaphore-guarded LiteLLM async path instead of calling `litellm.acompletion(...)` directly
- add a raw-response LiteLLM helper so the judge path can preserve exception-driven retries and usage-based cost accounting
- remove the stale per-verifier client-cache cleanup path and replace it with an honest no-op
- add focused tests for raw helper behavior, semaphore limiting, wrapper defaults, and judge retry/cost preservation

## Why
Issue #1214 reports that heavy-load GRPO runs with an LLM judge degrade after roughly 20-25 steps into timeouts, `Unclosed client session` warnings, and `aiohttp` connector teardown failures. The strongest code-level mismatch was that the judge verifier bypassed the repo's existing guarded LiteLLM helper, while the rubric path already used a shared per-event-loop semaphore.

This change keeps the fix scoped to the most likely root cause:
- reuse the existing guarded LiteLLM path
- preserve judge-specific retry behavior instead of inheriting rubric defaults
- avoid adding new config or scheduling complexity until the minimal fix is validated

## What changed
- Added `run_litellm_async_raw(...)` in `open_instruct/rubrics/run_utils.py`
- Kept `run_litellm_async(...)` behavior compatible for existing rubric callers
- Migrated `LMJudgeVerifier` in `open_instruct/ground_truth_utils.py` to the shared raw helper
- Simplified stale judge cleanup code that no longer reflected real resource ownership
- Added targeted unit coverage in `open_instruct/rubrics/test_rubrics.py` and `open_instruct/test_ground_truth_utils.py`

## Validation
- `ruff check` on touched files
- `python -m compileall` on the worktree
- `pytest open_instruct/test_ground_truth_utils.py open_instruct/rubrics/test_rubrics.py -q`
  - result: `86 passed, 6 skipped`

## Notes
- This PR addresses issue #1214.
- GRPO collection tests were not runnable in this macOS environment because `vllm` is not installed locally.
- The local pytest run also required `DS_ACCELERATOR=cpu` to avoid a DeepSpeed macOS import crash.

GPU_TESTS=bypass
