### PR TITLE
Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).
 - Fix shellcheck `$@` quoting in GRPO debug scripts (https://github.com/allenai/open-instruct/pull/1572).
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2228,8 +2228,22 @@ def main(
     checkpoint_state = None
     data_prep_actor_state = None
     if args.checkpoint_state_dir and os.path.exists(args.checkpoint_state_dir):
-        checkpoint_path = os.path.join(args.checkpoint_state_dir, "global_0", "state.pt")
-        if os.path.exists(checkpoint_path):
+        # Find the latest checkpoint tag from the 'latest' file written by DeepSpeed/calibrate_checkpoint_state_dir
+        latest_file = os.path.join(args.checkpoint_state_dir, "latest")
+        checkpoint_path = None
+        if os.path.exists(latest_file):
+            with open(latest_file) as f:
+                tag = f.read().strip()
+            # DeepSpeed saves rank-0 model states (including client_state) in this file
+            candidate = os.path.join(args.checkpoint_state_dir, tag, "mp_rank_00_model_states.pt")
+            if os.path.exists(candidate):
+                checkpoint_path = candidate
+        if checkpoint_path is None:
+            # Fallback: search for any model states file in the checkpoint directory
+            matches = sorted(pathlib.Path(args.checkpoint_state_dir).rglob("mp_rank_00_model_states.pt"))
+            if matches:
+                checkpoint_path = str(matches[-1])
+        if checkpoint_path is not None and os.path.exists(checkpoint_path):
             checkpoint_state = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
             logger.info(f"Loaded checkpoint state from {checkpoint_path}")
             data_prep_actor_state = checkpoint_state.get("data_prep_actor_state")


### PR DESCRIPTION
## Summary
- Fixes the checkpoint reload in `main()` which used a hardcoded path `global_0/state.pt` that does not match DeepSpeed's actual checkpoint directory structure (`global_step{N}/mp_rank_00_model_states.pt`)
- Reads the `latest` file (maintained by DeepSpeed and `calibrate_checkpoint_state_dir`) to find the correct checkpoint tag, then loads the rank-0 model states file
- Includes a fallback glob search for robustness when the `latest` file is missing

Fixes #1262

## Test plan
- [ ] Verify checkpoint reload works correctly on single-GPU training runs
- [ ] Verify checkpoint reload works correctly on multi-GPU DeepSpeed training runs
- [ ] Verify the fallback glob path works when the `latest` file is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>