### PR TITLE
Fix Batch.__getitem__ active_tools for int and list indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
-- Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/NEW).
+- Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix shellcheck `$@` quoting in GRPO debug scripts (https://github.com/allenai/open-instruct/pull/1572).
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/NEW).
 - Fix shellcheck `$@` quoting in GRPO debug scripts (https://github.com/allenai/open-instruct/pull/1572).
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -135,7 +135,6 @@ class Batch:
 
     def __getitem__(self, key: slice | int | list[int]) -> "Batch":
         """Enable indexing and slicing: batch[5], batch[start:end], or batch[[1,3,5]]."""
-        active_tools = self.active_tools[key] if self.active_tools is not None else None
         if isinstance(key, slice):
             # Handle slice object: batch[start:end]
             return Batch(
@@ -146,7 +145,7 @@ class Batch:
                 decoded_responses=self.decoded_responses[key] if self.decoded_responses is not None else None,
                 indices=self.indices[key] if self.indices is not None else None,
                 scores=self.scores[key] if self.scores is not None else None,
-                active_tools=active_tools,
+                active_tools=self.active_tools[key] if self.active_tools is not None else None,
             )
         elif isinstance(key, int):
             # Handle single index: batch[5]
@@ -158,7 +157,7 @@ class Batch:
                 decoded_responses=[self.decoded_responses[key]] if self.decoded_responses is not None else None,
                 indices=[self.indices[key]] if self.indices is not None else None,
                 scores=[self.scores[key]] if self.scores is not None else None,
-                active_tools=active_tools,
+                active_tools=[self.active_tools[key]] if self.active_tools is not None else None,
             )
         else:
             # Handle list of indices: batch[[1,3,5]]
@@ -172,7 +171,7 @@ class Batch:
                 else None,
                 indices=[self.indices[i] for i in key] if self.indices is not None else None,
                 scores=[self.scores[i] for i in key] if self.scores is not None else None,
-                active_tools=active_tools,
+                active_tools=[self.active_tools[i] for i in key] if self.active_tools is not None else None,
             )
 
 


### PR DESCRIPTION
## Summary
- Fix `Batch.__getitem__` handling of `active_tools` for `int` and `list[int]` indexing in `model_utils.py`
- **Int indexing** (`batch[5]`): `active_tools` was not wrapped in a list, unlike all other fields — returned a bare element instead of a single-element list
- **List indexing** (`batch[[1,3,5]]`): crashed with `TypeError` because Python lists don't support list-based indexing (`my_list[[1,3,5]]`)
- Root cause: `active_tools` was computed once before the `isinstance` type dispatch (line 138), but each branch needs different handling (slice, wrap-in-list, or list comprehension)
- Fix: moved `active_tools` computation inline into each branch, matching the pattern used by all other optional fields (`raw_queries`, `decoded_responses`, `indices`, `scores`)

## Test plan
- [x] `uv run ruff check open_instruct/model_utils.py` — all checks passed
- [x] `uv run pytest open_instruct/test_model_utils.py` — 7/7 tests passed

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)