### PR TITLE
Fix dataset_name validation always raising ValueError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
-- Fix dataset validation logic that rejected `--dataset_name` as the sole dataset mechanism in DPO and finetuning configs (https://github.com/allenai/open-instruct/pull/1594).
+- Fix dataset validation logic that rejected `--dataset_name` as the sole dataset mechanism in DPO and finetuning configs (https://github.com/allenai/open-instruct/pull/1595).
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix dataset validation logic that rejected `--dataset_name` as the sole dataset mechanism in DPO and finetuning configs (https://github.com/allenai/open-instruct/pull/1594).
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).

--- a/open_instruct/dpo_utils.py
+++ b/open_instruct/dpo_utils.py
@@ -338,10 +338,8 @@ class DPOExperimentConfig(
 
         if self.dataset_name is None and self.dataset_mixer is None and self.mixer_list is None:
             raise ValueError("Need either a dataset name, dataset mixer, or a training file.")
-        if (
-            (self.dataset_name is not None and (self.dataset_mixer is not None or self.mixer_list is not None))
-            or (self.dataset_name is not None)
-            or (self.dataset_mixer is not None and self.mixer_list is not None)
+        if (self.dataset_name is not None and (self.dataset_mixer is not None or self.mixer_list is not None)) or (
+            self.dataset_mixer is not None and self.mixer_list is not None
         ):
             raise ValueError("Cannot provide two dataset selection mechanisms.")
         if self.try_launch_beaker_eval_jobs and not self.push_to_hub:

--- a/open_instruct/dpo_utils.py
+++ b/open_instruct/dpo_utils.py
@@ -338,8 +338,9 @@ class DPOExperimentConfig(
 
         if self.dataset_name is None and self.dataset_mixer is None and self.mixer_list is None:
             raise ValueError("Need either a dataset name, dataset mixer, or a training file.")
-        if (self.dataset_name is not None and (self.dataset_mixer is not None or self.mixer_list is not None)) or (
-            self.dataset_mixer is not None and self.mixer_list is not None
+        if (
+            (self.dataset_name is not None and (self.dataset_mixer is not None or self.mixer_list is not None))
+            or (self.dataset_mixer is not None and self.mixer_list is not None)
         ):
             raise ValueError("Cannot provide two dataset selection mechanisms.")
         if self.try_launch_beaker_eval_jobs and not self.push_to_hub:

--- a/open_instruct/dpo_utils.py
+++ b/open_instruct/dpo_utils.py
@@ -338,9 +338,8 @@ class DPOExperimentConfig(
 
         if self.dataset_name is None and self.dataset_mixer is None and self.mixer_list is None:
             raise ValueError("Need either a dataset name, dataset mixer, or a training file.")
-        if (
-            (self.dataset_name is not None and (self.dataset_mixer is not None or self.mixer_list is not None))
-            or (self.dataset_mixer is not None and self.mixer_list is not None)
+        if (self.dataset_name is not None and (self.dataset_mixer is not None or self.mixer_list is not None)) or (
+            self.dataset_mixer is not None and self.mixer_list is not None
         ):
             raise ValueError("Cannot provide two dataset selection mechanisms.")
         if self.try_launch_beaker_eval_jobs and not self.push_to_hub:

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -327,8 +327,9 @@ class FlatArguments:
         if self.dataset_name is None and self.dataset_mixer is None and self.dataset_mixer_list is None:
             raise ValueError("Need either a dataset name, dataset mixer, or dataset mixer list.")
         if (
-            self.dataset_name is not None and (self.dataset_mixer is not None or self.dataset_mixer_list is not None)
-        ) or (self.dataset_mixer is not None and self.dataset_mixer_list is not None):
+            (self.dataset_name is not None and (self.dataset_mixer is not None or self.dataset_mixer_list is not None))
+            or (self.dataset_mixer is not None and self.dataset_mixer_list is not None)
+        ):
             raise ValueError("Cannot provide two dataset selection mechanisms.")
         if self.try_launch_beaker_eval_jobs and not self.push_to_hub:
             raise ValueError("Cannot launch Beaker evaluation jobs without pushing to the Hub.")

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -327,10 +327,8 @@ class FlatArguments:
         if self.dataset_name is None and self.dataset_mixer is None and self.dataset_mixer_list is None:
             raise ValueError("Need either a dataset name, dataset mixer, or dataset mixer list.")
         if (
-            (self.dataset_name is not None and (self.dataset_mixer is not None or self.dataset_mixer_list is not None))
-            or (self.dataset_name is not None)
-            or (self.dataset_mixer is not None and self.dataset_mixer_list is not None)
-        ):
+            self.dataset_name is not None and (self.dataset_mixer is not None or self.dataset_mixer_list is not None)
+        ) or (self.dataset_mixer is not None and self.dataset_mixer_list is not None):
             raise ValueError("Cannot provide two dataset selection mechanisms.")
         if self.try_launch_beaker_eval_jobs and not self.push_to_hub:
             raise ValueError("Cannot launch Beaker evaluation jobs without pushing to the Hub.")

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -327,9 +327,8 @@ class FlatArguments:
         if self.dataset_name is None and self.dataset_mixer is None and self.dataset_mixer_list is None:
             raise ValueError("Need either a dataset name, dataset mixer, or dataset mixer list.")
         if (
-            (self.dataset_name is not None and (self.dataset_mixer is not None or self.dataset_mixer_list is not None))
-            or (self.dataset_mixer is not None and self.dataset_mixer_list is not None)
-        ):
+            self.dataset_name is not None and (self.dataset_mixer is not None or self.dataset_mixer_list is not None)
+        ) or (self.dataset_mixer is not None and self.dataset_mixer_list is not None):
             raise ValueError("Cannot provide two dataset selection mechanisms.")
         if self.try_launch_beaker_eval_jobs and not self.push_to_hub:
             raise ValueError("Cannot launch Beaker evaluation jobs without pushing to the Hub.")


### PR DESCRIPTION
## Summary

The dataset selection validation in both `DPOExperimentConfig.__post_init__` (`dpo_utils.py`) and `FlatArguments.__post_init__` (`finetune.py`) has a logic error that makes `--dataset_name` unusable as the sole dataset mechanism.

**Bug:** The condition meant to reject *multiple* dataset mechanisms includes a standalone clause `or (self.dataset_name is not None)` that fires whenever `dataset_name` is set — even when no mixer is provided.

```python
# Before (always rejects dataset_name alone):
if (
    (self.dataset_name is not None and (self.dataset_mixer is not None or ...))
    or (self.dataset_name is not None)      # <-- always True when dataset_name is set
    or (self.dataset_mixer is not None and ...)
):
    raise ValueError("Cannot provide two dataset selection mechanisms.")
```

**Impact:** Scripts like `dpo_train_with_accelerate.sh` and `dpo_train_with_qlora.sh` that pass `--dataset_name` alone crash immediately.

**Fix:** Remove the erroneous middle clause. The remaining two clauses correctly detect when multiple mechanisms are provided simultaneously.

## Test plan
- [x] Verified `dpo_train_with_accelerate.sh` and `dpo_train_with_qlora.sh` use `--dataset_name` as sole mechanism
- [x] Confirmed the first clause catches `dataset_name` + mixer/mixer_list combos
- [x] Confirmed the third clause catches `dataset_mixer` + `mixer_list` combos
- [x] Ran `make style && make quality` — passes (pre-existing diagnostic in unrelated file)