### PR TITLE
Fix PreferenceDatasetProcessor.filter not checking rejected sequence length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `PreferenceDatasetProcessor.filter` dropping the rejected-sequence length check, so over-long rejected completions were no longer filtered (https://github.com/allenai/open-instruct/pull/1597).
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -251,13 +251,10 @@ class PreferenceDatasetProcessor(DatasetProcessor):
                 len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
                 if self.config.max_prompt_token_length is not None
                 else (
-                    True and len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
+                    len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
+                    and len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length
                     if self.config.max_token_length is not None
-                    else (
-                        True and len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length
-                        if self.config.max_token_length is not None
-                        else True
-                    )
+                    else True
                 )
             )
 


### PR DESCRIPTION
## Bug

`PreferenceDatasetProcessor.filter` uses a nested ternary to check sequence lengths:

```python
len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
if self.config.max_token_length is not None
else (
    len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length
    if self.config.max_token_length is not None  # ← duplicate condition
    else True
)
```

The inner `if self.config.max_token_length is not None` re-tests the exact condition already evaluated as `False` by the outer `else` branch. This makes the rejected-length check dead code — rejected sequences exceeding `max_token_length` are never filtered out.

## Fix

Check both chosen **and** rejected lengths in a single branch when `max_token_length` is set, matching the pattern used by `SFTDatasetProcessor.filter` (line 301-314).

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>