### PR TITLE
Miscellaneous small fixes for training scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix empty optimizer group error with torch 2.10 and DeepSpeed in `finetune.py`, `dpo_tune_cache.py`, and `utils.py`.
+- Fix `DatasetTransformationCache.load_or_transform_dataset` return type to match expected tuple unpacking.
+- Fix DeepSpeed gradient clipping in `grpo_fast.py` by passing `max_norm` to the DS config.
+- Fix `dpo_tune_cache.py` logging on every rank by switching to `accelerate.logging.get_logger`.
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
-- Fix empty optimizer group error with torch 2.10 and DeepSpeed in `finetune.py`, `dpo_tune_cache.py`, and `utils.py`.
-- Fix `DatasetTransformationCache.load_or_transform_dataset` return type to match expected tuple unpacking.
-- Fix DeepSpeed gradient clipping in `grpo_fast.py` by passing `max_norm` to the DS config.
-- Fix `dpo_tune_cache.py` logging on every rank by switching to `accelerate.logging.get_logger`.
+- Fix empty optimizer group error with torch 2.10 and DeepSpeed in `finetune.py`, `dpo_tune_cache.py`, and `utils.py`. (https://github.com/allenai/open-instruct/pull/1598)
+- Fix `DatasetTransformationCache.load_or_transform_dataset` return type to match expected tuple unpacking. (https://github.com/allenai/open-instruct/pull/1598)
+- Fix DeepSpeed gradient clipping in `grpo_fast.py` by passing `max_norm` to the DS config. (https://github.com/allenai/open-instruct/pull/1598)
+- Fix `dpo_tune_cache.py` logging on every rank. (https://github.com/allenai/open-instruct/pull/1598)
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1814,7 +1814,7 @@ class DatasetTransformationCache:
 
     def load_or_transform_dataset(
         self, dcs: list[DatasetConfig], tc: TokenizerConfig, dataset_skip_cache: bool = False
-    ) -> Dataset:
+    ) -> tuple[Dataset, dict[str, Any]]:
         """Load dataset from cache if it exists, otherwise transform and cache it."""
         repo_name = f"{self.hf_entity}/dataset-mix-cached"
 
@@ -1837,7 +1837,7 @@ class DatasetTransformationCache:
                 assert isinstance(loaded_dataset, Dataset)
                 if "index" not in loaded_dataset.column_names:
                     loaded_dataset = loaded_dataset.add_column("index", range(len(loaded_dataset)))
-                return loaded_dataset
+                return loaded_dataset, {"per_dataset_stats": [], "dataset_order": []}
 
         print("Cache not found, transforming datasets...")
 
@@ -1853,7 +1853,7 @@ class DatasetTransformationCache:
             combined_dataset = combined_dataset.remove_columns("index")
         combined_dataset = combined_dataset.add_column("index", range(len(combined_dataset)))
         if dataset_skip_cache:
-            return combined_dataset
+            return combined_dataset, {"per_dataset_stats": [], "dataset_order": []}
 
         # Push to hub with config hash as revision
         combined_dataset.push_to_hub(
@@ -1897,7 +1897,7 @@ This is a cached dataset produced by https://github.com/allenai/open-instruct
             repo_name, split=DEFAULT_SPLIT_FOR_CACHED_DATASET, revision=self.config_hash, num_proc=max_num_processes()
         )
         assert isinstance(final_dataset, Dataset)
-        return final_dataset
+        return final_dataset, {"per_dataset_stats": [], "dataset_order": []}
 
 
 class LocalDatasetTransformationCache:

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -948,6 +948,7 @@ def remove_dataset_source_field(dataset: Dataset) -> Dataset:
 
 TOOLS_COLUMN_KEY = "tools"
 ENV_CONFIG_KEY = "env_config"
+EMPTY_DATASET_STATISTICS = {"per_dataset_stats": [], "dataset_order": []}
 
 # Cache version: increment this when transformation logic changes significantly
 # to invalidate old caches. v6: Added return_dict=False to apply_chat_template calls for transformers 5.x.
@@ -1837,7 +1838,7 @@ class DatasetTransformationCache:
                 assert isinstance(loaded_dataset, Dataset)
                 if "index" not in loaded_dataset.column_names:
                     loaded_dataset = loaded_dataset.add_column("index", range(len(loaded_dataset)))
-                return loaded_dataset, {"per_dataset_stats": [], "dataset_order": []}
+                return loaded_dataset, EMPTY_DATASET_STATISTICS.copy()
 
         print("Cache not found, transforming datasets...")
 
@@ -1853,7 +1854,7 @@ class DatasetTransformationCache:
             combined_dataset = combined_dataset.remove_columns("index")
         combined_dataset = combined_dataset.add_column("index", range(len(combined_dataset)))
         if dataset_skip_cache:
-            return combined_dataset, {"per_dataset_stats": [], "dataset_order": []}
+            return combined_dataset, EMPTY_DATASET_STATISTICS.copy()
 
         # Push to hub with config hash as revision
         combined_dataset.push_to_hub(
@@ -1897,7 +1898,7 @@ This is a cached dataset produced by https://github.com/allenai/open-instruct
             repo_name, split=DEFAULT_SPLIT_FOR_CACHED_DATASET, revision=self.config_hash, num_proc=max_num_processes()
         )
         assert isinstance(final_dataset, Dataset)
-        return final_dataset, {"per_dataset_stats": [], "dataset_order": []}
+        return final_dataset, EMPTY_DATASET_STATISTICS.copy()
 
 
 class LocalDatasetTransformationCache:
@@ -1945,7 +1946,7 @@ class LocalDatasetTransformationCache:
                 return dataset, statistics
             else:
                 # Return empty statistics if not cached
-                return dataset, {"per_dataset_stats": [], "dataset_order": []}
+                return dataset, EMPTY_DATASET_STATISTICS.copy()
 
         print("Cache not found or invalid, transforming datasets...")
 

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -39,7 +39,6 @@ import torch.utils.data
 import transformers
 from accelerate import Accelerator, DataLoaderConfiguration
 from accelerate.accelerator import GradientAccumulationPlugin
-from accelerate.logging import get_logger
 from accelerate.utils import DeepSpeedPlugin, InitProcessGroupKwargs, set_seed
 from huggingface_hub import HfApi
 from peft import LoraConfig, TaskType, get_peft_model, prepare_model_for_kbit_training

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -39,6 +39,7 @@ import torch.utils.data
 import transformers
 from accelerate import Accelerator, DataLoaderConfiguration
 from accelerate.accelerator import GradientAccumulationPlugin
+from accelerate.logging import get_logger
 from accelerate.utils import DeepSpeedPlugin, InitProcessGroupKwargs, set_seed
 from huggingface_hub import HfApi
 from peft import LoraConfig, TaskType, get_peft_model, prepare_model_for_kbit_training
@@ -69,7 +70,7 @@ from open_instruct.utils import (
     maybe_use_ai2_wandb_entity,
 )
 
-logger = logger_utils.setup_logger(__name__)
+logger = get_logger(__name__)
 
 
 def build_deepspeed_config(

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -423,6 +423,10 @@ def main(args: dpo_utils.DPOExperimentConfig, tc: TokenizerConfig):
         },
         {"params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)], "weight_decay": 0.0},
     ]
+
+    # Filter empty groups to avoid issues with torch 2.10 and deepspeed
+    optimizer_grouped_parameters = [group for group in optimizer_grouped_parameters if group["params"]]
+
     if args.use_qlora or args.dpo_use_paged_optimizer:
         from bitsandbytes.optim import AdamW  # noqa: PLC0415
 

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -71,7 +71,7 @@ from open_instruct.utils import (
     maybe_use_ai2_wandb_entity,
 )
 
-logger = get_logger(__name__)
+logger = logger_utils.setup_logger(__name__)
 
 
 def build_deepspeed_config(
@@ -674,7 +674,8 @@ def main(args: dpo_utils.DPOExperimentConfig, tc: TokenizerConfig):
                     metrics_to_log["perf/tokens_per_second_step"] = step_tokens_per_second
                     metrics_to_log["perf/tokens_per_second_total"] = total_tokens_per_second
 
-                    logger.info(logger_str)
+                    if accelerator.is_main_process:
+                        logger.info(logger_str)
                     if args.with_tracking:
                         accelerator.log(metrics_to_log, step=completed_steps)
                     if accelerator.is_main_process:

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -61,6 +61,7 @@ from open_instruct.utils import (
     ModelDims,
     clean_last_n_checkpoints,
     get_last_checkpoint_path,
+    get_optimizer_grouped_parameters,
     get_wandb_tags,
     is_beaker_job,
     launch_ai2_evals_on_weka,
@@ -414,18 +415,7 @@ def main(args: dpo_utils.DPOExperimentConfig, tc: TokenizerConfig):
     )
 
     # Optimizer
-    # Split weights in two groups, one with weight decay and the other not.
-    no_decay = ["bias", "layer_norm.weight"]
-    optimizer_grouped_parameters = [
-        {
-            "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
-            "weight_decay": args.weight_decay,
-        },
-        {"params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)], "weight_decay": 0.0},
-    ]
-
-    # Filter empty groups to avoid issues with torch 2.10 and deepspeed
-    optimizer_grouped_parameters = [group for group in optimizer_grouped_parameters if group["params"]]
+    optimizer_grouped_parameters = get_optimizer_grouped_parameters(model, args.weight_decay)
 
     if args.use_qlora or args.dpo_use_paged_optimizer:
         from bitsandbytes.optim import AdamW  # noqa: PLC0415

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -60,6 +60,7 @@ from open_instruct.utils import (
     ArgumentParserPlus,
     clean_last_n_checkpoints,
     get_last_checkpoint_path,
+    get_optimizer_grouped_parameters,
     get_wandb_tags,
     is_beaker_job,
     launch_ai2_evals_on_weka,
@@ -666,18 +667,7 @@ def main(args: FlatArguments, tc: TokenizerConfig):
     )
 
     # Optimizer
-    # Split weights in two groups, one with weight decay and the other not.
-    no_decay = ["bias", "layer_norm.weight"]
-    optimizer_grouped_parameters = [
-        {
-            "params": [p for n, p in model.named_parameters() if not any(nd in n for nd in no_decay)],
-            "weight_decay": args.weight_decay,
-        },
-        {"params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)], "weight_decay": 0.0},
-    ]
-
-    # Filter empty groups to avoid issues with torch 2.10 and deepspeed
-    optimizer_grouped_parameters = [group for group in optimizer_grouped_parameters if group["params"]]
+    optimizer_grouped_parameters = get_optimizer_grouped_parameters(model, args.weight_decay)
 
     if args.use_qlora:
         from bitsandbytes.optim import AdamW  # noqa: PLC0415

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -675,6 +675,10 @@ def main(args: FlatArguments, tc: TokenizerConfig):
         },
         {"params": [p for n, p in model.named_parameters() if any(nd in n for nd in no_decay)], "weight_decay": 0.0},
     ]
+
+    # Filter empty groups to avoid issues with torch 2.10 and deepspeed
+    optimizer_grouped_parameters = [group for group in optimizer_grouped_parameters if group["params"]]
+
     if args.use_qlora:
         from bitsandbytes.optim import AdamW  # noqa: PLC0415
 

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -252,6 +252,7 @@ class PolicyTrainerRayProcess(RayProcess):
             adam_offload=args.deepspeed_offload_optimizer,
             stage=args.deepspeed_stage,
             bf16=True,
+            max_norm=args.max_grad_norm if args.max_grad_norm is not None else 0.0,
             zpg=args.deepspeed_zpg,
             sequence_parallel_size=args.sequence_parallel_size,
         )

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -1527,6 +1527,10 @@ def get_optimizer_grouped_parameters(
             "weight_decay": 0.0,
         },
     ]
+
+    # Filter empty groups to avoid issues with torch 2.10 and deepspeed
+    optimizer_grouped_parameters = [group for group in optimizer_grouped_parameters if group["params"]]
+
     return optimizer_grouped_parameters
 
 


### PR DESCRIPTION
Small self-explanatory fixes to the training scripts `finetune.py (deprecated), dpo_tune_cache.py, grpo_fast.py` (see changelog/commits for descriptions).

Regarding the optimizer param group fix in 9ddc55da6464ca7a2d0a10a6a11967a53796a4ac, the error we get is
```
[rank0]:   File "/workspace/open-instruct/.venv/lib/python3.12/site-packages/torch/optim/lr_scheduler.py", line 296, in _update_lr                                                                                                                   
[rank0]:     for param_group, lr in zip(self.optimizer.param_groups, values, strict=True): 
 ValueError: zip() argument 2 is longer than argument 1 
```
which seems to be due the addition of `strict=True` in the scheduler for torch 2.10. eg. https://github.com/huggingface/transformers/pull/43711