### PR TITLE
Fix truncate_messages_to_fit_context double-counting system tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `truncate_messages_to_fit_context` double-counting system tokens, which under-filled the judge context window by `system_tokens` worth of space (https://github.com/allenai/open-instruct/pull/1601).
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).

--- a/open_instruct/context_window_checker.py
+++ b/open_instruct/context_window_checker.py
@@ -210,7 +210,7 @@ def truncate_messages_to_fit_context(
 
         # Truncate other messages to fit
         truncated_messages = system_messages.copy()
-        current_tokens = system_tokens
+        current_tokens = 0  # tracks non-system tokens; compared against remaining_tokens
 
         for msg in other_messages:
             content = msg.get("content", "")
@@ -279,7 +279,7 @@ def truncate_messages_to_fit_context(
 
             # Truncate other messages to fit
             truncated_messages = system_messages.copy()
-            current_tokens = system_tokens
+            current_tokens = 0  # tracks non-system tokens; compared against remaining_tokens
 
             for msg in other_messages:
                 content = msg.get("content", "")


### PR DESCRIPTION
## Bug

`truncate_messages_to_fit_context` in `open_instruct/context_window_checker.py` under-fills the judge context window by `system_tokens` worth of space, dropping or truncating later messages even when there is still room in the budget. The same bug exists in both the HuggingFace and tiktoken branches.

## Root cause

The function partitions messages into system and non-system, counts `system_tokens`, and then sets a non-system budget:

\`\`\`python
remaining_tokens = available_tokens - system_tokens
\`\`\`

It then walks `other_messages` with:

\`\`\`python
current_tokens = system_tokens
for msg in other_messages:
    ...
    if current_tokens + message_tokens <= remaining_tokens:  # <-- compares against non-system budget
        ...
    else:
        available_for_content = remaining_tokens - current_tokens - role_tokens
\`\`\`

Because `current_tokens` is seeded with `system_tokens`, the fit check is effectively \`system_tokens + message_tokens <= available_tokens - system_tokens\`, so system tokens are subtracted twice from the budget that other messages can use. `available_for_content` in the per-message truncation path has the same double-subtraction.

### Worked example

\`available_tokens = 1000\`, \`system_tokens = 200\` (so \`remaining_tokens = 800\`).

- **Current**: first other message must satisfy \`200 + msg <= 800\`, i.e. up to **600** tokens.
- **Expected**: first other message can take the whole **800**-token non-system budget.

So up to `system_tokens` worth of headroom is wasted on every call, causing unnecessary message drops / content truncation for long judge prompts.

## Fix

Initialize `current_tokens = 0` in both the HF and tiktoken branches so it tracks *non-system* tokens only, matching the `remaining_tokens` semantics. 2-line change.

\`\`\`diff
-        current_tokens = system_tokens
+        current_tokens = 0  # tracks non-system tokens; compared against remaining_tokens
\`\`\`

Nothing else in the loop needs to change: `current_tokens + message_tokens <= remaining_tokens` and `available_for_content = remaining_tokens - current_tokens - role_tokens` are now both consistent ("non-system tokens used so far" vs "non-system budget").

`check_context_window_limit` is unaffected — it does not split system vs non-system and was already computing the right total.

GPU_TESTS=bypass