### PR TITLE
Fix find_shared_text off-by-one and crash on empty input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix off-by-one in `find_shared_text` so the full shared prefix is returned when one string is a prefix of another, and handle empty-input cases (https://github.com/allenai/open-instruct/pull/1604).
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).

--- a/open_instruct/reward_modeling_eval.py
+++ b/open_instruct/reward_modeling_eval.py
@@ -22,11 +22,11 @@ api = HfApi()
 
 def find_shared_text(chosen_text: str, rejected_text: str):
     """return shared (prompt) text between chosen and rejected text"""
-    for i in range(min(len(chosen_text), len(rejected_text))):
+    min_len = min(len(chosen_text), len(rejected_text))
+    for i in range(min_len):
         if chosen_text[i] != rejected_text[i]:
-            break
-
-    return chosen_text[:i]
+            return chosen_text[:i]
+    return chosen_text[:min_len]
 
 
 def evaluate(


### PR DESCRIPTION
## Summary

`find_shared_text` in `reward_modeling_eval.py` has two bugs caused by the `for`/`break` pattern:

1. **Off-by-one when one string is a prefix of the other**: When the loop completes without hitting `break`, `i` is left at `min(len(a), len(b)) - 1`, so `chosen_text[:i]` drops the last shared character.

   ```python
   >>> find_shared_text("hello world", "hello world extra")
   'hello worl'   # missing final 'd'
   ```

2. **`UnboundLocalError` when either input is empty**: `range(0)` never executes, so `i` is never assigned, and `chosen_text[:i]` crashes.

   ```python
   >>> find_shared_text("", "abc")
   UnboundLocalError: cannot access local variable 'i'
   ```

**Fix**: Use early `return` on mismatch inside the loop. Fall through to `return chosen_text[:min_len]` when one string is a prefix of the other (or either is empty).

## Test plan

- [x] Verified both failure modes in Python REPL
- [x] Verified fix returns correct results for: identical strings, prefix relationship, mismatch, empty inputs

🤖 Generated with [Claude Code](https://claude.ai/claude-code)