### PR TITLE
Fix is_equiv returning None instead of False on ValueError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `is_equiv` returning `None` instead of `False` when expression simplification raises `ValueError` (https://github.com/allenai/open-instruct/pull/1605).
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).

--- a/open_instruct/math_utils.py
+++ b/open_instruct/math_utils.py
@@ -197,6 +197,7 @@ def is_equiv(x1: str, x2: str) -> bool:
                 return sympy.simplify(diff) == 0
             except ValueError:
                 eval_logger.debug(f"Had some trouble simplifying when comparing {x1} and {x2}")
+                return False
     except TimeoutError:
         eval_logger.debug(f"Timed out comparing {x1} and {x2}")
         return False


### PR DESCRIPTION
## Bug

`is_equiv()` in `open_instruct/math_utils.py` has a `-> bool` return type but implicitly returns `None` when `sympy.simplify()` raises `ValueError`. The `except ValueError` handler (line 198-199) logs a debug message but lacks a `return False` statement, causing execution to fall through and exit the function without returning.

## Root cause

Every other error path in `is_equiv` (`LaTeXParsingError`, `SympifyError`, `TypeError`, `TimeoutError`, generic `Exception`) explicitly returns `False`. The `ValueError` handler was the only one missing its `return False`.

## Fix

Add `return False` after the debug log in the `except ValueError` handler, consistent with all other error paths in the function.