### PR TITLE
Use Ray to validate that allocated gpus correspond to requeusted # of GPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 
 ### Added
+- Add validation that allocated number of gpus correspond to requested number of GPUs (https://github.com/allenai/open-instruct/pull/1606).
 - Add model step logging for GRPO/vLLM by propagating `model_step` through generation metadata/results, syncing vLLM engines to the latest training step after weight sync, and reporting `model_step_min/max/mean` reward metrics (https://github.com/allenai/open-instruct/pull/1508).
 - Add Qwen3.5 VLM-as-CausalLM support for GRPO, SFT, and DPO: `language_model_only` for vLLM, param name mapping for weight sync, VLM config handling, liger-kernel bump to 0.7.0, pre-download model on rank 0 to avoid HF cache race conditions, update vllm to 0.19.0, and fix Ulysses SP for VLM models by passing the model object to `register_with_transformers` (https://github.com/allenai/open-instruct/pull/1568).
 - Add OLMo-core sharding and parallelism documentation covering HSDP configuration across DPO, GRPO, and SFT (https://github.com/allenai/open-instruct/pull/1582).

--- a/open_instruct/grpo.py
+++ b/open_instruct/grpo.py
@@ -136,6 +136,12 @@ def main(
     if ray_address := utils.get_ray_address():
         ray_init_kwargs["address"] = ray_address
     ray.init(**ray_init_kwargs)
+    grpo_utils.validate_allocated_gpus(
+        tuple(args.num_learners_per_node),
+        vllm_config.vllm_num_engines,
+        vllm_config.vllm_tensor_parallel_size,
+        args.single_gpu_mode,
+    )
 
     pool_size = tools_config.pool_size
     if pool_size is None:

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -955,19 +955,6 @@ def validate_configs(
     )
 
 
-def validate_allocated_gpus(num_learners_per_node: tuple[int, ...], vllm_num_engines: int) -> None:
-    """Validate that Ray sees the expected number of GPUs for this job."""
-    expected_gpus = sum(num_learners_per_node) + vllm_num_engines
-    allocated_gpus: float = ray.cluster_resources().get("GPU", 0.0)
-    if not math.isclose(allocated_gpus, expected_gpus):
-        raise ValueError(
-            f"Ray reports {allocated_gpus} allocated GPUs for this job, but "
-            f"sum(num_learners_per_node={list(num_learners_per_node)}) + "
-            f"vllm_num_engines ({vllm_num_engines}) = {expected_gpus}. "
-            "These must match."
-        )
-
-
 def setup_runtime_variables(
     args: grpo_utils.GRPOExperimentConfig,
     streaming_config: data_loader_lib.StreamingDataLoaderConfig,
@@ -2298,7 +2285,12 @@ def main(
             "env_vars": {k: v for k, v in os.environ.items() if k not in EXCLUDED_ENV_VARS},
         }
     )
-    validate_allocated_gpus(tuple(args.num_learners_per_node), vllm_config.vllm_num_engines)
+    grpo_utils.validate_allocated_gpus(
+        tuple(args.num_learners_per_node),
+        vllm_config.vllm_num_engines,
+        vllm_config.vllm_tensor_parallel_size,
+        args.single_gpu_mode,
+    )
 
     pool_size = tools_config.pool_size
     if pool_size is None:

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -955,6 +955,19 @@ def validate_configs(
     )
 
 
+def validate_allocated_gpus(num_learners_per_node: tuple[int, ...], vllm_num_engines: int) -> None:
+    """Validate that Ray sees the expected number of GPUs for this job."""
+    expected_gpus = sum(num_learners_per_node) + vllm_num_engines
+    allocated_gpus: float = ray.cluster_resources().get("GPU", 0.0)
+    if not math.isclose(allocated_gpus, expected_gpus):
+        raise ValueError(
+            f"Ray reports {allocated_gpus} allocated GPUs for this job, but "
+            f"sum(num_learners_per_node={list(num_learners_per_node)}) + "
+            f"vllm_num_engines ({vllm_num_engines}) = {expected_gpus}. "
+            "These must match."
+        )
+
+
 def setup_runtime_variables(
     args: grpo_utils.GRPOExperimentConfig,
     streaming_config: data_loader_lib.StreamingDataLoaderConfig,
@@ -2285,6 +2298,7 @@ def main(
             "env_vars": {k: v for k, v in os.environ.items() if k not in EXCLUDED_ENV_VARS},
         }
     )
+    validate_allocated_gpus(tuple(args.num_learners_per_node), vllm_config.vllm_num_engines)
 
     pool_size = tools_config.pool_size
     if pool_size is None:

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 import numpy as np
+import ray
 import torch
 import torch.distributed as dist
 
@@ -20,6 +21,34 @@ from open_instruct.utils import (
 
 logger = logger_utils.setup_logger(__name__)
 TORCH_DTYPES: dict[str, torch.dtype] = {"bfloat16": torch.bfloat16, "float32": torch.float32}
+
+
+def validate_allocated_gpus(
+    num_learners_per_node: tuple[int, ...],
+    vllm_num_engines: int,
+    vllm_tensor_parallel_size: int,
+    single_gpu_mode: bool,
+) -> None:
+    """Validate that Ray sees the expected number of GPUs for this job."""
+    total_learners = sum(num_learners_per_node)
+    if single_gpu_mode and (total_learners != 1 or vllm_num_engines != 1):
+        raise ValueError(
+            "single_gpu_mode requires exactly one learner and one vLLM engine, but got "
+            f"sum(num_learners_per_node={list(num_learners_per_node)})={total_learners} and "
+            f"vllm_num_engines={vllm_num_engines}."
+        )
+    expected_vllm_gpus = 0 if single_gpu_mode else vllm_num_engines * vllm_tensor_parallel_size
+    expected_gpus = total_learners + expected_vllm_gpus
+    allocated_gpus: float = ray.cluster_resources().get("GPU", 0.0)
+    if not math.isclose(allocated_gpus, expected_gpus):
+        raise ValueError(
+            f"Ray reports {allocated_gpus} allocated GPUs for this job, but "
+            f"sum(num_learners_per_node={list(num_learners_per_node)}) + "
+            f"vllm_num_engines ({vllm_num_engines}) * "
+            f"vllm_tensor_parallel_size ({vllm_tensor_parallel_size}) if not "
+            f"single_gpu_mode ({single_gpu_mode}) = {expected_gpus}. "
+            "These must match."
+        )
 
 
 def compute_pass_at_k_metrics(correct_per_prompt: np.ndarray) -> dict[str, float]:

--- a/open_instruct/test_grpo_fast_eval.py
+++ b/open_instruct/test_grpo_fast_eval.py
@@ -16,7 +16,7 @@ from open_instruct.dataset_transformation import (
     RAW_PROMPT_KEY,
     VERIFIER_SOURCE_KEY,
 )
-from open_instruct.grpo_fast import create_generation_configs, maybe_evaluate
+from open_instruct.grpo_fast import create_generation_configs, maybe_evaluate, validate_allocated_gpus
 
 
 class _QueueWithSize:
@@ -54,6 +54,20 @@ class TestCreateGenerationConfigs(unittest.TestCase):
             streaming_config.response_length, streaming_config.eval_response_length
         )
         self.assertEqual(max_model_len, 1536)
+
+
+class TestValidateAllocatedGpus(unittest.TestCase):
+    def test_accepts_matching_gpu_count(self):
+        with patch("open_instruct.grpo_fast.ray.cluster_resources", return_value={"GPU": 16.0}):
+            validate_allocated_gpus((4, 4), 8)
+
+    def test_rejects_mismatched_gpu_count(self):
+        with patch("open_instruct.grpo_fast.ray.cluster_resources", return_value={"GPU": 15.0}):
+            with self.assertRaisesRegex(
+                ValueError,
+                r"Ray reports 15\.0 allocated GPUs.*num_learners_per_node=\[4, 4\].*vllm_num_engines \(8\) = 16",
+            ):
+                validate_allocated_gpus((4, 4), 8)
 
 
 class TestMaybeEvaluate(unittest.TestCase):

--- a/open_instruct/test_grpo_fast_eval.py
+++ b/open_instruct/test_grpo_fast_eval.py
@@ -16,7 +16,7 @@ from open_instruct.dataset_transformation import (
     RAW_PROMPT_KEY,
     VERIFIER_SOURCE_KEY,
 )
-from open_instruct.grpo_fast import create_generation_configs, maybe_evaluate, validate_allocated_gpus
+from open_instruct.grpo_fast import create_generation_configs, maybe_evaluate
 
 
 class _QueueWithSize:
@@ -54,20 +54,6 @@ class TestCreateGenerationConfigs(unittest.TestCase):
             streaming_config.response_length, streaming_config.eval_response_length
         )
         self.assertEqual(max_model_len, 1536)
-
-
-class TestValidateAllocatedGpus(unittest.TestCase):
-    def test_accepts_matching_gpu_count(self):
-        with patch("open_instruct.grpo_fast.ray.cluster_resources", return_value={"GPU": 16.0}):
-            validate_allocated_gpus((4, 4), 8)
-
-    def test_rejects_mismatched_gpu_count(self):
-        with patch("open_instruct.grpo_fast.ray.cluster_resources", return_value={"GPU": 15.0}):
-            with self.assertRaisesRegex(
-                ValueError,
-                r"Ray reports 15\.0 allocated GPUs.*num_learners_per_node=\[4, 4\].*vllm_num_engines \(8\) = 16",
-            ):
-                validate_allocated_gpus((4, 4), 8)
 
 
 class TestMaybeEvaluate(unittest.TestCase):

--- a/open_instruct/test_grpo_utils.py
+++ b/open_instruct/test_grpo_utils.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+
+from open_instruct.grpo_utils import validate_allocated_gpus
+
+
+class TestValidateAllocatedGpus(unittest.TestCase):
+    def test_accepts_matching_gpu_count(self):
+        with patch("open_instruct.grpo_utils.ray.cluster_resources", return_value={"GPU": 16.0}):
+            validate_allocated_gpus((4, 4), 8, 1, False)
+
+    def test_accounts_for_tensor_parallel_size(self):
+        with patch("open_instruct.grpo_utils.ray.cluster_resources", return_value={"GPU": 24.0}):
+            validate_allocated_gpus((4, 4), 8, 2, False)
+
+    def test_single_gpu_mode_does_not_require_extra_vllm_gpus(self):
+        with patch("open_instruct.grpo_utils.ray.cluster_resources", return_value={"GPU": 1.0}):
+            validate_allocated_gpus((1,), 1, 1, True)
+
+    def test_single_gpu_mode_requires_exactly_one_learner_and_one_engine(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"single_gpu_mode requires exactly one learner and one vLLM engine.*"
+            r"sum\(num_learners_per_node=\[4, 4\]\)=8.*vllm_num_engines=8",
+        ):
+            validate_allocated_gpus((4, 4), 8, 1, True)
+
+    def test_rejects_mismatched_gpu_count(self):
+        with (
+            patch("open_instruct.grpo_utils.ray.cluster_resources", return_value={"GPU": 15.0}),
+            self.assertRaisesRegex(
+                ValueError,
+                r"Ray reports 15\.0 allocated GPUs.*num_learners_per_node=\[4, 4\].*"
+                r"vllm_num_engines \(8\) \* vllm_tensor_parallel_size \(1\).*"
+                r"single_gpu_mode \(False\) = 16",
+            ),
+        ):
+            validate_allocated_gpus((4, 4), 8, 1, False)


### PR DESCRIPTION
## Summary
- validate Ray GPU allocation in both `grpo_fast.py` and `grpo.py` after `ray.init()`
- account for `vllm_tensor_parallel_size` when computing expected vLLM GPU usage
- reject invalid `single_gpu_mode` configurations unless there is exactly one learner and one vLLM engine
- move the shared validation helper into `grpo_utils.py`
- move validation coverage into a dedicated `test_grpo_utils.py` module and keep `test_grpo_fast_eval.py` focused on GRPO-fast eval behavior
- add a changelog entry for this PR in `CHANGELOG.md`

## Details
The shared helper now expects:
- standard mode: `sum(num_learners_per_node) + vllm_num_engines * vllm_tensor_parallel_size`
- `single_gpu_mode`: exactly 1 learner and 1 vLLM engine, with no extra vLLM GPUs expected

This avoids undercounting tensor-parallel vLLM allocations and prevents `single_gpu_mode` from silently accepting unsupported multi-learner or multi-engine layouts.

## Testing
- `uv run pytest open_instruct/test_grpo_utils.py open_instruct/test_grpo_fast_eval.py`
- `make style`
- `make quality`
