### PR TITLE
Extend pre-commit hook to ban nonlocal keyword

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,9 +29,9 @@ repos:
 
   - repo: local
     hooks:
-      - id: ban-type-checking
-        name: Ban TYPE_CHECKING blocks
-        entry: bash -c '! grep -rn "if TYPE_CHECKING" open_instruct/'
+      - id: ban-keywords
+        name: Ban prohibited keywords
+        entry: bash -c '! grep -rn -E "if TYPE_CHECKING|nonlocal " open_instruct/'
         language: system
         pass_filenames: false
         types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Extend pre-commit hook to also ban `nonlocal` keyword (https://github.com/allenai/open-instruct/pull/PLACEHOLDER).
 - Set checkpoint_state_freq default in data_loader.py, not mason.py (https://github.com/allenai/open-instruct/pull/1600).
 - Inline data prep actor naming in `StreamingDataLoader` and GRPO, removing redundant helpers and parameter plumbing (https://github.com/allenai/open-instruct/pull/1326).
 - Use local fixture for AceCode test instead of downloading from HuggingFace (https://github.com/allenai/open-instruct/pull/1593).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Extend pre-commit hook to also ban `nonlocal` keyword (https://github.com/allenai/open-instruct/pull/PLACEHOLDER).
+- Extend pre-commit hook to also ban `nonlocal` keyword (https://github.com/allenai/open-instruct/pull/1613).
 - Set checkpoint_state_freq default in data_loader.py, not mason.py (https://github.com/allenai/open-instruct/pull/1600).
 - Inline data prep actor naming in `StreamingDataLoader` and GRPO, removing redundant helpers and parameter plumbing (https://github.com/allenai/open-instruct/pull/1326).
 - Use local fixture for AceCode test instead of downloading from HuggingFace (https://github.com/allenai/open-instruct/pull/1593).


### PR DESCRIPTION
## Summary
- Renames the `ban-type-checking` pre-commit hook to `ban-keywords` and extends it to also ban the `nonlocal` keyword in `open_instruct/`.

## Test plan
- [x] Verified `pre-commit run ban-keywords --all-files` passes
- [x] No existing `nonlocal` usages in `open_instruct/`

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)