### PR TITLE
Fix validate_choice substring check with swapped operands

### DIFF
--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -360,7 +360,7 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
-    return any(text in option for option in options)
+    return any(option in text for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted


### PR DESCRIPTION
## Bug

\`validate_choice\` enforces the IFEval constraint _\"Answer with one of the following options: {options}\"_ (comment on the line above). The implementation:

\`\`\`python
def validate_choice(text: str, options: list) -> bool:
    return any(text in option for option in options)
\`\`\`

## Root cause

\`text in option\` tests whether the full model response is a substring of an option. Options are short phrases (e.g. \`\"yes\"\`, \`\"red\"\`) while responses are typically longer sentences, so the common case \`validate_choice(\"I choose red\", [\"red\", \"blue\"])\` returns \`False\` — only responses that are themselves contained in an option pass, the inverse of the constraint's intent.

Other \`validate_*\` checks in the same module (e.g. \`verify_keywords\`) consistently look for the constraint tokens inside the response, not vice versa.

## Fix

Swap the operands to \`option in text\`, matching both the constraint semantics and the rest of the module.

(The legacy copy in \`scripts/eval_constraints/if_functions.py\` has the same bug; I've left it alone to keep this change minimal since that file is not imported by the training code paths.)