### PR TITLE
Fix save_benchmark_results_to_csv never writing the header row

### DIFF
--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -140,9 +140,10 @@ def save_benchmark_results_to_csv(
     csv_dir = csv_path.parent
     csv_dir.mkdir(parents=True, exist_ok=True)
 
+    write_header = not csv_path.exists()
     with csv_path.open("a", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=list(row_data.keys()))
-        if not csv_path.exists():
+        if write_header:
             writer.writeheader()
         writer.writerow(row_data)
     logger.info(f"Saved benchmark results to {csv_path}")


### PR DESCRIPTION
### Bug
`save_benchmark_results_to_csv` never emits a header row for the benchmark results CSV. The first row of the very first benchmark run lands in the file without column names.

https://github.com/allenai/open-instruct/blob/3d761d0/open_instruct/benchmark_generators.py#L143-L147

```python
with csv_path.open("a", newline="") as csvfile:
    writer = csv.DictWriter(csvfile, fieldnames=list(row_data.keys()))
    if not csv_path.exists():
        writer.writeheader()
    writer.writerow(row_data)
```

### Root cause
`pathlib.Path.open('a', ...)` creates the file if it does not already exist. So by the time `if not csv_path.exists()` executes inside the `with` block, the file has just been created and `csv_path.exists()` is always `True`; the header is never written.

### Fix
Snapshot `csv_path.exists()` into a local flag before opening the file, and use that flag to decide whether to write the header. The file-opening side effect no longer hides the 'first run' state from the header check, so the header is written exactly once — on the first run.