### PR TITLE
Drop unused ty ignore in VllmToolParser._make_request

### DIFF
--- a/open_instruct/environments/tools/parsers.py
+++ b/open_instruct/environments/tools/parsers.py
@@ -154,7 +154,7 @@ class VllmToolParser(ToolParser):
 
         Usually these only need the list of tools.
         """
-        return ChatCompletionRequest(model="dummy", messages=[], tools=self._tool_definitions)  # ty: ignore[invalid-argument-type]
+        return ChatCompletionRequest(model="dummy", messages=[], tools=self._tool_definitions)
 
     def get_tool_calls(self, text: str) -> list[EnvCall]:
         """Extract tool calls from model output.


### PR DESCRIPTION
## Summary

- Removes a `# ty: ignore[invalid-argument-type]` on the `ChatCompletionRequest(...)` call in `VllmToolParser._make_request` that ty no longer flags.
- Split out of #1620 (match-sft) to keep that PR focused on the SFT parity work.

## Test plan

- [x] `uv run ty check open_instruct/environments/tools/parsers.py` — all checks pass without the ignore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)