### PR TITLE
Fix save_completion_lengths writing CSV header on every batch call

### DIFF
--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -54,10 +54,12 @@ def save_completion_lengths(batch_results: list[dict], timestamp: int, batch_idx
     """
     csv_path = DATA_DIR / f"completion_lengths_{timestamp}.csv"
 
+    write_header = not csv_path.exists()
     with open(csv_path, "a", newline="") as csvfile:
         fieldnames = ["batch_num", "prompt_num", "completion_length"]
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-        writer.writeheader()
+        if write_header:
+            writer.writeheader()
 
         for batch_result in batch_results:
             response_lengths = batch_result["response_lengths"]


### PR DESCRIPTION
## Bug

`save_completion_lengths` is called once per batch in the main benchmark loop (`benchmark_generators.py:525`, inside `for batch_idx in range(1, num_batches)`). The function opens `completion_lengths_<timestamp>.csv` in append mode and unconditionally calls `writer.writeheader()`, so every batch after the first writes another header row interleaved with the data.

The resulting CSV looks like:

```
batch_num,prompt_num,completion_length
1,0,42
1,1,37
batch_num,prompt_num,completion_length
2,0,55
...
```

## Root cause

`writer.writeheader()` runs unconditionally even when the file already contains rows from a previous call.

## Why the fix is correct

Check whether the file exists before opening it in append mode, and only write the header when it does not yet exist. `open(path, "a")` creates the file if missing, so the check must happen *before* the `open()` call — hence the `write_header = not csv_path.exists()` line captured up front. This matches the intent of the existing `if not csv_path.exists(): writer.writeheader()` pattern used in `save_benchmark_results_to_csv` (see PR #1619), ensuring the header is written exactly once.