### PR TITLE
Fix IFEvalVerifier ZeroDivisionError when constraint has no instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `IFEvalVerifier` raising `ZeroDivisionError` when a ground-truth constraint has no `instruction_id` entries, by returning `score=0.0` for the empty-rewards case (https://github.com/allenai/open-instruct/pull/1624).
 - Fix `verify_sentence_constraint` not recognising `!` as a sentence terminator, causing IFEval sentence-count checks to undercount any response containing exclamations (https://github.com/allenai/open-instruct/pull/1612).
 - Fix `DataPreparationActor` hanging on shutdown by killing the actor with `ray.kill()` during cleanup (https://github.com/allenai/open-instruct/pull/1611).
 - Fix empty optimizer group error with torch 2.10 and DeepSpeed in `finetune.py`, `dpo_tune_cache.py`, and `utils.py`. (https://github.com/allenai/open-instruct/pull/1598)

--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -352,6 +352,8 @@ class IFEvalVerifier(VerifierFunction):
                 rewards.append(1.0)
             else:
                 rewards.append(0.0)
+        if not rewards:
+            return VerificationResult(score=0.0)
         return VerificationResult(score=sum(rewards) / len(rewards))
 
 


### PR DESCRIPTION
## Bug

`IFEvalVerifier.__call__` in `open_instruct/ground_truth_utils.py` builds a `rewards` list by zipping the constraint's `instruction_id` / `kwargs`, then returns the mean:

```python
rewards = []
if len(prediction) == 0 or len(answer) == 0:
    logger.warning("Empty prediction received for IFEvalVerifier.")
    return VerificationResult(score=0.0)
for instruction_key, args in zip(instruction_keys, args_list):
    ...
    rewards.append(1.0 if ... else 0.0)
return VerificationResult(score=sum(rewards) / len(rewards))
```

If `constraint_dict["instruction_id"]` is an empty list — possible for ground-truth entries that arrive with no IFEval constraints attached — the `zip` yields no iterations, `rewards` stays empty, and `sum(rewards) / len(rewards)` raises `ZeroDivisionError`, crashing the whole batch's reward computation inside the training loop.

## Root cause

The final return assumes at least one constraint was evaluated. The other early-exit in this method (empty prediction/answer) already returns `score=0.0`, but the empty-constraint case has no corresponding guard.

## Why the fix is correct

Return `VerificationResult(score=0.0)` when `rewards` is empty, matching the existing empty-prediction branch four lines above:

```python
if not rewards:
    return VerificationResult(score=0.0)
return VerificationResult(score=sum(rewards) / len(rewards))
```

No constraints means no evidence that any instruction was satisfied, so 0.0 is the consistent "all-or-nothing" score. Non-empty cases are unchanged. Two added lines, no other edits.