### PR TITLE
Clamp loss-mask count in _get_batch_logps to avoid div-by-zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `_get_batch_logps` division-by-zero in `dpo_utils.py` when `average_log_prob=True` and a sequence has every label masked (`-100`), by clamping the token count to `min=1` to match the padding-free variant.
 - Fix `verify_sentence_constraint` not recognising `!` as a sentence terminator, causing IFEval sentence-count checks to undercount any response containing exclamations (https://github.com/allenai/open-instruct/pull/1612).
 - Fix `DataPreparationActor` hanging on shutdown by killing the actor with `ray.kill()` during cleanup (https://github.com/allenai/open-instruct/pull/1611).
 - Fix empty optimizer group error with torch 2.10 and DeepSpeed in `finetune.py`, `dpo_tune_cache.py`, and `utils.py`. (https://github.com/allenai/open-instruct/pull/1598)

--- a/open_instruct/dpo_utils.py
+++ b/open_instruct/dpo_utils.py
@@ -707,7 +707,7 @@ def _get_batch_logps(
     loss_mask = labels[:, 1:] != -100
 
     if average_log_prob:
-        return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
+        return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1).clamp(min=1)
     else:
         return (per_token_logps * loss_mask).sum(-1)
 


### PR DESCRIPTION
## Bug

`_get_batch_logps` in `open_instruct/dpo_utils.py` can return NaN/Inf
when called with `average_log_prob=True` and a sequence whose every
label is `-100`, corrupting DPO training gradients silently.

## Root cause

```python
if average_log_prob:
    return (per_token_logps * loss_mask).sum(-1) / loss_mask.sum(-1)
```

`loss_mask = labels[:, 1:] != -100`. If a sequence in the batch has
every label equal to -100 (e.g. a prompt-only example that left no
response tokens under the effective `max_length`), `loss_mask.sum(-1)`
is exactly 0 for that row and the division produces `NaN`/`Inf`,
which then propagates into the DPO loss and gradients.

The padding-free sibling `padding_free_collator.get_batch_logps`
performs the same reduction and already guards the division with
`.clamp(min=1)`:

```python
return segment_sums / segment_counts.clamp(min=1)
```

so the two code paths currently disagree.

## Why the fix is correct

- `per_token_logps * loss_mask` is already zero wherever `loss_mask`
  is False, so the numerator is 0 for fully-masked sequences.
- Clamping the denominator to `min=1` makes fully-masked sequences
  yield `0.0 / 1 = 0.0` instead of `NaN`, which is the well-defined
  fallback the rest of the loss already assumes (and matches the
  padding-free variant).
- No behaviour change when at least one token is unmasked (the clamp
  is a no-op for positive counts).

## Change

`open_instruct/dpo_utils.py`: add `.clamp(min=1)` to the denominator
in `_get_batch_logps`. `CHANGELOG.md`: add one line under "Fixed".