### PR TITLE
Now, SFT tokenization streams directly to disk, making it ~9.4x faster. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Stream SFT tokenization tokens/labels directly to disk and iterate the dataset in batched numpy format, removing in-memory accumulation and speeding up the collect loop; posts periodic Beaker description updates during tokenization.
+- Speed up SFT tokenization collect loop with batched numpy iteration and vectorized per-sample label/attention ops.
 - Use incremental binary checkpoint for SFT tokenization resume, eliminating O(N²) re-serialization (https://github.com/allenai/open-instruct/pull/1633).
 - Extract numpy SFT conversion helpers into `open_instruct.numpy_dataset_conversion` (https://github.com/allenai/open-instruct/pull/1622).
 - Simplified model step tracking logic (https://github.com/allenai/open-instruct/pull/1616).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Speed up SFT tokenization collect loop with batched numpy iteration and vectorized per-sample label/attention ops.
+- Stream SFT tokens/labels/boundaries directly to `_*.partial.bin` files and derive per-dataset stats at the end from disk, dropping the explicit `_checkpoint.json` file. `--resume` now works by truncating the partial files to a consistent sample boundary.
 - Use incremental binary checkpoint for SFT tokenization resume, eliminating O(N²) re-serialization (https://github.com/allenai/open-instruct/pull/1633).
 - Extract numpy SFT conversion helpers into `open_instruct.numpy_dataset_conversion` (https://github.com/allenai/open-instruct/pull/1622).
 - Simplified model step tracking logic (https://github.com/allenai/open-instruct/pull/1616).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Stream SFT tokenization tokens/labels directly to disk and iterate the dataset in batched numpy format, removing in-memory accumulation and speeding up the collect loop; posts periodic Beaker description updates during tokenization.
 - Use incremental binary checkpoint for SFT tokenization resume, eliminating O(N²) re-serialization (https://github.com/allenai/open-instruct/pull/1633).
 - Extract numpy SFT conversion helpers into `open_instruct.numpy_dataset_conversion` (https://github.com/allenai/open-instruct/pull/1622).
 - Simplified model step tracking logic (https://github.com/allenai/open-instruct/pull/1616).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Speed up SFT tokenization collect loop with batched numpy iteration and vectorized per-sample label/attention ops.
-- Stream SFT tokens/labels/boundaries directly to `_*.partial.bin` files and derive per-dataset stats at the end from disk, dropping the explicit `_checkpoint.json` file. `--resume` now works by truncating the partial files to a consistent sample boundary.
+- Speed up SFT tokenization collect loop with batched numpy iteration and vectorized per-sample label/attention ops (https://github.com/allenai/open-instruct/pull/1631).
+- Stream SFT tokens/labels/boundaries directly to `_*.partial.bin` files and derive per-dataset stats at the end from disk, dropping the explicit `_checkpoint.json` file. `--resume` now works by truncating the partial files to a consistent sample boundary (https://github.com/allenai/open-instruct/pull/1631).
 - Use incremental binary checkpoint for SFT tokenization resume, eliminating O(N²) re-serialization (https://github.com/allenai/open-instruct/pull/1633).
 - Extract numpy SFT conversion helpers into `open_instruct.numpy_dataset_conversion` (https://github.com/allenai/open-instruct/pull/1622).
 - Simplified model step tracking logic (https://github.com/allenai/open-instruct/pull/1616).

--- a/docs/verify-tokenization.md
+++ b/docs/verify-tokenization.md
@@ -124,3 +124,13 @@ diverging artifact to find the first mismatching byte range.
 - If you've already produced a full-scale `origin/main` reference on
   weka, point the compare's reference side at it to skip re-running the
   full mixer.
+
+## Golden reference run
+
+There is an existing full-scale `origin/main` tokenization on weka that
+you can compare against without re-running the full mixer:
+
+- Beaker experiment: <https://beaker.org/ex/01KPRDGYEM81EASNNSBZ2HA7KA>
+- Output directory: `/weka/oe-adapt-default/finbarrt/dataset/olmo-hybrid-main-repro`
+
+Point the compare's reference side at that directory.

--- a/docs/verify-tokenization.md
+++ b/docs/verify-tokenization.md
@@ -21,7 +21,10 @@ The compare produces a `sha256` for every output artifact:
   `output_directory` (these vary by run and aren't meaningful to compare)
 
 Skip `dataset_statistics.txt` (human-readable dupe), the `tokenizer/`
-dir, and any `_checkpoint*` files.
+dir, any `_checkpoint*` files, and the `_tokens.partial.bin` /
+`_labels.partial.bin` scratch files used during the collect loop (they
+are removed on successful completion but may linger after an aborted
+run).
 
 ## Step 1: two image builds
 
@@ -81,7 +84,7 @@ import hashlib, gzip, json, os, sys
 new, ref = sys.argv[1], sys.argv[2]
 fail = 0
 for name in sorted(set(os.listdir(new)) | set(os.listdir(ref))):
-    if name.startswith("_checkpoint") or name in ("dataset_statistics.txt", "tokenizer"):
+    if name.startswith("_checkpoint") or name in ("_tokens.partial.bin", "_labels.partial.bin", "dataset_statistics.txt", "tokenizer"):
         continue
     a, b = os.path.join(new, name), os.path.join(ref, name)
     if not (os.path.isfile(a) and os.path.isfile(b)):

--- a/docs/verify-tokenization.md
+++ b/docs/verify-tokenization.md
@@ -21,10 +21,7 @@ The compare produces a `sha256` for every output artifact:
   `output_directory` (these vary by run and aren't meaningful to compare)
 
 Skip `dataset_statistics.txt` (human-readable dupe), the `tokenizer/`
-dir, any `_checkpoint*` files, and the `_tokens.partial.bin` /
-`_labels.partial.bin` scratch files used during the collect loop (they
-are removed on successful completion but may linger after an aborted
-run).
+dir, and any `_checkpoint*` files.
 
 ## Step 1: two image builds
 
@@ -84,7 +81,7 @@ import hashlib, gzip, json, os, sys
 new, ref = sys.argv[1], sys.argv[2]
 fail = 0
 for name in sorted(set(os.listdir(new)) | set(os.listdir(ref))):
-    if name.startswith("_checkpoint") or name in ("_tokens.partial.bin", "_labels.partial.bin", "dataset_statistics.txt", "tokenizer"):
+    if name.startswith("_checkpoint") or name in ("dataset_statistics.txt", "tokenizer"):
         continue
     a, b = os.path.join(new, name), os.path.join(ref, name)
     if not (os.path.isfile(a) and os.path.isfile(b)):

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -259,10 +259,6 @@ def convert_hf_to_numpy_sft(
 
     logger.info("Collecting tokens from dataset...")
     total_samples = len(train_dataset)
-    loop_start_time = time.perf_counter()
-    utils.maybe_update_beaker_description(
-        current_step=start_idx, total_steps=total_samples, start_time=loop_start_time
-    )
 
     if start_idx >= total_samples:
         train_dataset_iter = train_dataset.select([])
@@ -337,7 +333,7 @@ def convert_hf_to_numpy_sft(
                     num_samples_skipped += 1
                     per_dataset_filtered[dataset_source] += 1
 
-                assert all(mask == 1 for mask in sample_attention), (
+                assert (sample_attention == 1).all(), (
                     f"Expected all attention mask values to be 1, but found: {sample_attention}"
                 )
 

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -9,6 +9,7 @@ The output layout for each `output_dir` is:
 """
 
 import gzip
+import itertools
 import json
 import os
 import pathlib
@@ -30,33 +31,170 @@ _CHECKPOINT_TOKEN_IDS_FILENAME = "_checkpoint_token_ids.bin"
 _CHECKPOINT_LABELS_MASK_FILENAME = "_checkpoint_labels_mask.bin"
 _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME = "_checkpoint_document_boundaries.bin"
 
+_CHECKPOINT_TOKEN_DTYPE = np.uint32
+_CHECKPOINT_LABELS_DTYPE = np.uint8
 _CHECKPOINT_BOUNDARIES_DTYPE = np.int64
 
 
-def save_checkpoint(output_dir: str, checkpoint_data: dict[str, Any]) -> None:
-    checkpoint_path = os.path.join(output_dir, _CHECKPOINT_FILENAME)
-    tmp_path = checkpoint_path + ".tmp"
+def _append_bytes(path: pathlib.Path, data: bytes) -> None:
+    with open(path, "ab") as f:
+        f.write(data)
+
+
+def _truncate_to(path: pathlib.Path, size: int) -> None:
+    if not path.exists():
+        raise RuntimeError(f"Checkpoint file {path} does not exist.")
+    current_size = path.stat().st_size
+    if current_size == size:
+        return
+    if current_size < size:
+        raise RuntimeError(
+            f"Checkpoint file {path} is smaller than expected ({current_size} < {size}); data is corrupted."
+        )
+    with open(path, "r+b") as f:
+        f.truncate(size)
+
+
+def save_checkpoint(
+    output_dir: pathlib.Path,
+    samples_processed: int,
+    token_ids: list[int],
+    labels_mask: list[int],
+    document_boundaries: list[tuple[int, int]],
+    scalar_state: dict[str, Any],
+    prev_tokens_written: int,
+    prev_samples_written: int,
+) -> tuple[int, int, int]:
+    """Append new array data to the binary files, then atomically update the JSON
+    metadata. Returns (tokens_written, samples_written, bytes_appended); the first
+    two should be passed back as prev_* on the next call.
+    """
+    tokens_path = output_dir / _CHECKPOINT_TOKEN_IDS_FILENAME
+    labels_path = output_dir / _CHECKPOINT_LABELS_MASK_FILENAME
+    boundaries_path = output_dir / _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME
+    json_path = output_dir / _CHECKPOINT_FILENAME
+
+    # The JSON file is rewritten atomically (write-temp + rename) *after* the binary
+    # appends, so it is the source of truth for how much has been durably committed.
+    # If a previous run crashed between the binary append and the JSON rename, the
+    # binary files may contain trailing bytes beyond `prev_*_written`. Truncate any
+    # such uncommitted bytes before appending this batch so the files stay in
+    # lock-step with the JSON metadata.
+    token_size = np.dtype(_CHECKPOINT_TOKEN_DTYPE).itemsize
+    labels_size = np.dtype(_CHECKPOINT_LABELS_DTYPE).itemsize
+    boundary_size = np.dtype(_CHECKPOINT_BOUNDARIES_DTYPE).itemsize
+    if prev_tokens_written > 0:
+        _truncate_to(tokens_path, prev_tokens_written * token_size)
+        _truncate_to(labels_path, prev_tokens_written * labels_size)
+    if prev_samples_written > 0:
+        _truncate_to(boundaries_path, prev_samples_written * 2 * boundary_size)
+
+    new_tokens = np.fromiter(
+        itertools.islice(token_ids, prev_tokens_written, None),
+        dtype=_CHECKPOINT_TOKEN_DTYPE,
+        count=len(token_ids) - prev_tokens_written,
+    ).tobytes()
+    new_labels = np.fromiter(
+        itertools.islice(labels_mask, prev_tokens_written, None),
+        dtype=_CHECKPOINT_LABELS_DTYPE,
+        count=len(labels_mask) - prev_tokens_written,
+    ).tobytes()
+    new_boundaries = np.asarray(
+        document_boundaries[prev_samples_written:], dtype=_CHECKPOINT_BOUNDARIES_DTYPE
+    ).tobytes()
+
+    _append_bytes(tokens_path, new_tokens)
+    _append_bytes(labels_path, new_labels)
+    _append_bytes(boundaries_path, new_boundaries)
+    bytes_appended = len(new_tokens) + len(new_labels) + len(new_boundaries)
+
+    tokens_written = len(token_ids)
+    samples_written = len(document_boundaries)
+
+    meta = {
+        **scalar_state,
+        "samples_processed": samples_processed,
+        "tokens_written": tokens_written,
+        "samples_written": samples_written,
+    }
+    tmp_path = json_path.with_suffix(json_path.suffix + ".tmp")
     with open(tmp_path, "w") as f:
-        json.dump(checkpoint_data, f)
-    os.rename(tmp_path, checkpoint_path)
+        json.dump(meta, f)
+    tmp_path.rename(json_path)
+
+    return tokens_written, samples_written, bytes_appended
 
 
-def load_checkpoint(output_dir: str) -> dict[str, Any] | None:
-    checkpoint_path = os.path.join(output_dir, _CHECKPOINT_FILENAME)
-    if os.path.exists(checkpoint_path):
-        with open(checkpoint_path) as f:
-            return json.load(f)
-    return None
+def load_checkpoint(output_dir: pathlib.Path) -> dict[str, Any] | None:
+    json_path = output_dir / _CHECKPOINT_FILENAME
+    if not json_path.exists():
+        return None
+    with open(json_path) as f:
+        meta = json.load(f)
+
+    if "token_ids" in meta:
+        document_boundaries = [tuple(b) for b in meta["document_boundaries"]]
+        return {
+            "samples_processed": meta["samples_processed"],
+            "token_ids": meta["token_ids"],
+            "labels_mask": meta["labels_mask"],
+            "document_boundaries": document_boundaries,
+            "current_position": meta["current_position"],
+            "num_samples_skipped": meta["num_samples_skipped"],
+            "per_dataset_counts": meta["per_dataset_counts"],
+            "per_dataset_tokens": meta["per_dataset_tokens"],
+            "per_dataset_trainable_tokens": meta["per_dataset_trainable_tokens"],
+            "per_dataset_filtered": meta["per_dataset_filtered"],
+            "tokens_written": 0,
+            "samples_written": 0,
+        }
+
+    tokens_written = meta["tokens_written"]
+    samples_written = meta["samples_written"]
+
+    tokens_path = output_dir / _CHECKPOINT_TOKEN_IDS_FILENAME
+    labels_path = output_dir / _CHECKPOINT_LABELS_MASK_FILENAME
+    boundaries_path = output_dir / _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME
+
+    if tokens_written > 0:
+        _truncate_to(tokens_path, tokens_written * np.dtype(_CHECKPOINT_TOKEN_DTYPE).itemsize)
+        _truncate_to(labels_path, tokens_written * np.dtype(_CHECKPOINT_LABELS_DTYPE).itemsize)
+    if samples_written > 0:
+        _truncate_to(boundaries_path, samples_written * 2 * np.dtype(_CHECKPOINT_BOUNDARIES_DTYPE).itemsize)
+
+    token_ids = np.fromfile(tokens_path, dtype=_CHECKPOINT_TOKEN_DTYPE, count=tokens_written).tolist()
+    labels_mask = np.fromfile(labels_path, dtype=_CHECKPOINT_LABELS_DTYPE, count=tokens_written).tolist()
+    boundaries_flat = np.fromfile(boundaries_path, dtype=_CHECKPOINT_BOUNDARIES_DTYPE, count=samples_written * 2)
+    boundaries_flat = boundaries_flat.reshape(-1, 2)
+    document_boundaries = [(int(s), int(e)) for s, e in boundaries_flat]
+
+    return {
+        "samples_processed": meta["samples_processed"],
+        "token_ids": token_ids,
+        "labels_mask": labels_mask,
+        "document_boundaries": document_boundaries,
+        "current_position": meta["current_position"],
+        "num_samples_skipped": meta["num_samples_skipped"],
+        "per_dataset_counts": meta["per_dataset_counts"],
+        "per_dataset_tokens": meta["per_dataset_tokens"],
+        "per_dataset_trainable_tokens": meta["per_dataset_trainable_tokens"],
+        "per_dataset_filtered": meta["per_dataset_filtered"],
+        "tokens_written": tokens_written,
+        "samples_written": samples_written,
+    }
 
 
-def remove_checkpoint(output_dir: str) -> None:
-    for name in (
+def remove_checkpoint(output_dir: pathlib.Path) -> None:
+    for filename in (
         _CHECKPOINT_FILENAME,
         _CHECKPOINT_TOKEN_IDS_FILENAME,
         _CHECKPOINT_LABELS_MASK_FILENAME,
         _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME,
     ):
-        pathlib.Path(output_dir, name).unlink(missing_ok=True)
+        path = output_dir / filename
+        if path.exists():
+            path.unlink()
+            logger.info(f"Removed checkpoint file: {path}")
 
 
 def _select_token_dtype(vocab_size: int):
@@ -66,25 +204,21 @@ def _select_token_dtype(vocab_size: int):
     raise ValueError(f"Vocab size {vocab_size} is too big for any numpy integer dtype!")
 
 
-def _write_memmap_chunked_from_file(
-    base_filename: str, source_path: str, total_items: int, dtype, max_size_gb: int = 1
+def _write_memmap_chunked(
+    base_filename: str, data: list[int], dtype, max_size_bytes: int = 1024**3
 ) -> list[tuple[int, int]]:
     item_size = np.dtype(dtype).itemsize
-    chunk_size = int((max_size_gb * 1024**3) // item_size)
+    chunk_size = max_size_bytes // item_size
     chunk_boundaries: list[tuple[int, int]] = []
 
-    if total_items == 0:
-        return chunk_boundaries
-
-    src = np.memmap(source_path, mode="r", dtype=dtype, shape=(total_items,))
-    for chunk_idx, i in enumerate(range(0, total_items, chunk_size)):
-        end = min(i + chunk_size, total_items)
-        filename = f"{base_filename}_part_{chunk_idx:04d}.npy"
-        dst = np.memmap(filename, mode="w+", dtype=dtype, shape=(end - i,))
-        dst[:] = src[i:end]
-        dst.flush()
-        chunk_boundaries.append((i, end))
-        logger.info(f"Written {filename} ({(end - i) * item_size / 1024**3:.2f} GB)")
+    for i in range(0, len(data), chunk_size):
+        chunk_data = data[i : i + chunk_size]
+        filename = f"{base_filename}_part_{i // chunk_size:04d}.npy"
+        mmap = np.memmap(filename, mode="w+", dtype=dtype, shape=(len(chunk_data),))
+        mmap[:] = chunk_data
+        mmap.flush()
+        chunk_boundaries.append((i, i + len(chunk_data)))
+        logger.info(f"Written {filename} ({len(chunk_data) * item_size / 1024**3:.2f} GB)")
 
     return chunk_boundaries
 
@@ -150,6 +284,7 @@ def convert_hf_to_numpy_sft(
     lets it pick up where it left off.
     """
     os.makedirs(output_dir, exist_ok=True)
+    output_path = pathlib.Path(output_dir)
 
     logger.info("Verify these values match the tokenizer config used in Olmo-core:")
     logger.info(f"Tokenizer vocab_size: {tc.tokenizer.vocab_size}")
@@ -189,56 +324,30 @@ def convert_hf_to_numpy_sft(
         logger.info(f"Selecting {num_examples} examples for debugging")
         train_dataset = train_dataset.select(range(num_examples))
 
-    vocab_size = tc.tokenizer.vocab_size
-    token_dtype = _select_token_dtype(vocab_size)
-    token_dtype_name = np.dtype(token_dtype).name
-    token_item_size = np.dtype(token_dtype).itemsize
-    logger.info(f"Using dtype '{token_dtype_name}' for token_ids based on vocab size {vocab_size}")
-
-    tokens_path = os.path.join(output_dir, _CHECKPOINT_TOKEN_IDS_FILENAME)
-    labels_path = os.path.join(output_dir, _CHECKPOINT_LABELS_MASK_FILENAME)
-    boundaries_path = os.path.join(output_dir, _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME)
-    boundary_item_size = np.dtype(_CHECKPOINT_BOUNDARIES_DTYPE).itemsize
-
-    checkpoint = load_checkpoint(output_dir) if resume else None
+    checkpoint = load_checkpoint(output_path) if resume else None
     if checkpoint:
-        if checkpoint.get("token_dtype") != token_dtype_name:
-            raise ValueError(
-                f"Checkpoint token_dtype {checkpoint.get('token_dtype')!r} does not match current "
-                f"{token_dtype_name!r}. Refusing to resume."
-            )
-        if not (os.path.exists(tokens_path) and os.path.exists(labels_path) and os.path.exists(boundaries_path)):
-            raise FileNotFoundError(
-                f"Checkpoint present but partial token/label/boundary files missing in {output_dir}. "
-                "Delete the checkpoint to restart."
-            )
         start_idx = checkpoint["samples_processed"]
+        token_ids = checkpoint["token_ids"]
+        labels_mask = checkpoint["labels_mask"]
+        document_boundaries = checkpoint["document_boundaries"]
         current_position = checkpoint["current_position"]
         num_samples_skipped = checkpoint["num_samples_skipped"]
         per_dataset_counts = checkpoint["per_dataset_counts"]
         per_dataset_tokens = checkpoint["per_dataset_tokens"]
         per_dataset_trainable_tokens = checkpoint["per_dataset_trainable_tokens"]
         per_dataset_filtered = checkpoint["per_dataset_filtered"]
-        total_tokens = checkpoint["total_tokens"]
-        total_trainable_tokens = checkpoint["total_trainable_tokens"]
-        max_token_id = checkpoint["max_token_id"]
-        tokens_bytes = checkpoint["tokens_bytes"]
-        labels_bytes = checkpoint["labels_bytes"]
-        boundaries_bytes = checkpoint["boundaries_bytes"]
-        os.truncate(tokens_path, tokens_bytes)
-        os.truncate(labels_path, labels_bytes)
-        os.truncate(boundaries_path, boundaries_bytes)
-        boundaries_flat = np.fromfile(boundaries_path, dtype=_CHECKPOINT_BOUNDARIES_DTYPE).reshape(-1, 2)
-        document_boundaries = [(int(s), int(e)) for s, e in boundaries_flat]
+        last_tokens_written = checkpoint["tokens_written"]
+        last_samples_written = checkpoint["samples_written"]
         logger.info("=== RESUMING from checkpoint ===")
         logger.info(f"  Samples already processed: {start_idx:,}")
-        logger.info(f"  Tokens collected: {total_tokens:,}")
+        logger.info(f"  Tokens collected: {len(token_ids):,}")
         logger.info(f"  Remaining samples: {len(train_dataset) - start_idx:,}")
     else:
         if resume:
             logger.info("No checkpoint found, starting from beginning...")
-        remove_checkpoint(output_dir)
         start_idx = 0
+        token_ids = []
+        labels_mask = []
         document_boundaries = []
         current_position = 0
         num_samples_skipped = 0
@@ -246,21 +355,17 @@ def convert_hf_to_numpy_sft(
         per_dataset_tokens = {}
         per_dataset_trainable_tokens = {}
         per_dataset_filtered = {}
-        total_tokens = 0
-        total_trainable_tokens = 0
-        max_token_id = 0
+        last_tokens_written = 0
+        last_samples_written = 0
 
     logger.info("Collecting tokens from dataset...")
     total_samples = len(train_dataset)
+    loop_start_time = time.perf_counter()
+    utils.maybe_update_beaker_description(
+        current_step=start_idx, total_steps=total_samples, start_time=loop_start_time
+    )
 
-    if start_idx >= total_samples:
-        train_dataset_iter = train_dataset.select([])
-    elif start_idx > 0:
-        train_dataset_iter = train_dataset.select(range(start_idx, total_samples))
-    else:
-        train_dataset_iter = train_dataset
-
-    train_dataset_iter = train_dataset_iter.with_format("numpy")
+    train_dataset_iter = train_dataset.select(range(start_idx, total_samples)).with_format("numpy")
 
     input_ids_key = dataset_transformation.INPUT_IDS_KEY
     labels_key = dataset_transformation.LABELS_KEY
@@ -275,141 +380,107 @@ def convert_hf_to_numpy_sft(
         initial=start_idx,
         total=total_samples,
     )
+    idx = start_idx - 1
+    for batch in train_dataset_iter.iter(batch_size=1000):
+        batch_input_ids = batch[input_ids_key]
+        batch_labels = batch[labels_key]
+        batch_attention = batch[attention_mask_key]
+        batch_sources = batch.get(dataset_source_key, ["unknown"] * len(batch_input_ids))
 
-    collect_start = time.perf_counter()
-    utils.maybe_update_beaker_description(current_step=start_idx, total_steps=total_samples, start_time=collect_start)
-    last_description_update = collect_start
-    with (
-        open(tokens_path, "ab") as tokens_fh,
-        open(labels_path, "ab") as labels_fh,
-        open(boundaries_path, "ab") as boundaries_fh,
-    ):
-        idx = start_idx - 1
-        last_checkpoint_idx = start_idx
-        for batch in train_dataset_iter.iter(batch_size=1000):
-            batch_input_ids = batch[input_ids_key]
-            batch_labels = batch[labels_key]
-            batch_attention = batch[attention_mask_key]
-            batch_sources = batch.get(dataset_source_key, ["unknown"] * len(batch_input_ids))
+        for sample_tokens, sample_labels, sample_attention, dataset_source in zip(
+            batch_input_ids, batch_labels, batch_attention, batch_sources
+        ):
+            idx += 1
+            sample_length = len(sample_tokens)
+            dataset_source = str(dataset_source)
 
-            for sample_tokens, sample_labels, sample_attention, dataset_source in zip(
-                batch_input_ids, batch_labels, batch_attention, batch_sources
-            ):
-                idx += 1
-                sample_length = len(sample_tokens)
+            if dataset_source not in per_dataset_counts:
+                per_dataset_counts[dataset_source] = 0
+                per_dataset_tokens[dataset_source] = 0
+                per_dataset_trainable_tokens[dataset_source] = 0
+                per_dataset_filtered[dataset_source] = 0
 
-                if dataset_source not in per_dataset_counts:
-                    per_dataset_counts[dataset_source] = 0
-                    per_dataset_tokens[dataset_source] = 0
-                    per_dataset_trainable_tokens[dataset_source] = 0
-                    per_dataset_filtered[dataset_source] = 0
+            sample_label_mask = (sample_labels != -100).astype(np.uint8)
+            trainable_tokens_in_sample = int(sample_label_mask.sum())
 
-                tokens_arr = np.asarray(sample_tokens, dtype=token_dtype)
-                labels_arr = np.asarray(sample_labels)
-                labels_mask = (labels_arr != -100).astype(np.uint8)
-                trainable_tokens_in_sample = int(labels_mask.sum())
+            per_dataset_counts[dataset_source] += 1
+            per_dataset_tokens[dataset_source] += sample_length
+            per_dataset_trainable_tokens[dataset_source] += trainable_tokens_in_sample
 
-                tokens_arr.tofile(tokens_fh)
-                labels_mask.tofile(labels_fh)
+            token_ids.extend(sample_tokens.tolist())
+            labels_mask.extend(sample_label_mask.tolist())
+            document_boundaries.append((current_position, current_position + sample_length))
+            current_position += sample_length
 
-                if sample_length > 0:
-                    sample_max = int(tokens_arr.max())
-                    if sample_max > max_token_id:
-                        max_token_id = sample_max
+            if trainable_tokens_in_sample == 0:
+                num_samples_skipped += 1
+                per_dataset_filtered[dataset_source] += 1
 
-                boundary = np.array(
-                    [current_position, current_position + sample_length], dtype=_CHECKPOINT_BOUNDARIES_DTYPE
-                )
-                boundary.tofile(boundaries_fh)
-                document_boundaries.append((current_position, current_position + sample_length))
-                current_position += sample_length
-                total_tokens += sample_length
-                total_trainable_tokens += trainable_tokens_in_sample
+            assert (sample_attention == 1).all(), (
+                f"Expected all attention mask values to be 1, but found: {sample_attention}"
+            )
 
-                per_dataset_counts[dataset_source] += 1
-                per_dataset_tokens[dataset_source] += sample_length
-                per_dataset_trainable_tokens[dataset_source] += trainable_tokens_in_sample
-
-                if trainable_tokens_in_sample == 0:
-                    num_samples_skipped += 1
-                    per_dataset_filtered[dataset_source] += 1
-
-                assert (sample_attention == 1).all(), (
-                    f"Expected all attention mask values to be 1, but found: {sample_attention}"
-                )
-
-            progress.update(len(batch_input_ids))
-
-            now = time.perf_counter()
-            if now - last_description_update >= 30.0:
-                utils.maybe_update_beaker_description(
-                    current_step=idx + 1, total_steps=total_samples, start_time=collect_start
-                )
-                last_description_update = now
-
-            if idx + 1 - last_checkpoint_idx >= checkpoint_interval:
-                tokens_fh.flush()
-                labels_fh.flush()
-                boundaries_fh.flush()
-                os.fsync(tokens_fh.fileno())
-                os.fsync(labels_fh.fileno())
-                os.fsync(boundaries_fh.fileno())
-                save_checkpoint(
-                    output_dir,
-                    {
-                        "samples_processed": idx + 1,
+            if (idx + 1) % checkpoint_interval == 0 and idx > start_idx:
+                checkpoint_start = time.perf_counter()
+                last_tokens_written, last_samples_written, checkpoint_bytes = save_checkpoint(
+                    output_path,
+                    samples_processed=idx + 1,
+                    token_ids=token_ids,
+                    labels_mask=labels_mask,
+                    document_boundaries=document_boundaries,
+                    scalar_state={
                         "current_position": current_position,
                         "num_samples_skipped": num_samples_skipped,
                         "per_dataset_counts": per_dataset_counts,
                         "per_dataset_tokens": per_dataset_tokens,
                         "per_dataset_trainable_tokens": per_dataset_trainable_tokens,
                         "per_dataset_filtered": per_dataset_filtered,
-                        "total_tokens": total_tokens,
-                        "total_trainable_tokens": total_trainable_tokens,
-                        "max_token_id": max_token_id,
-                        "tokens_bytes": total_tokens * token_item_size,
-                        "labels_bytes": total_tokens,
-                        "boundaries_bytes": len(document_boundaries) * 2 * boundary_item_size,
-                        "token_dtype": token_dtype_name,
                     },
+                    prev_tokens_written=last_tokens_written,
+                    prev_samples_written=last_samples_written,
                 )
-                last_checkpoint_idx = idx + 1
-                logger.info(f"Checkpoint saved at sample {idx + 1:,} ({total_tokens:,} tokens)")
+                elapsed = time.perf_counter() - checkpoint_start
+                logger.info(
+                    f"Checkpoint saved at sample {idx + 1:,} ({len(token_ids):,} tokens) "
+                    f"in {elapsed:.2f}s [{checkpoint_bytes / (1024 * 1024):.1f} MiB, "
+                    f"{checkpoint_bytes / (1024 * 1024) / elapsed:.1f} MiB/s]"
+                )
+                utils.maybe_update_beaker_description(
+                    current_step=idx + 1, total_steps=total_samples, start_time=loop_start_time
+                )
 
+        progress.update(len(batch_input_ids))
     progress.close()
-    utils.maybe_update_beaker_description(
-        current_step=total_samples, total_steps=total_samples, start_time=collect_start
-    )
-    collect_elapsed = time.perf_counter() - collect_start
-    samples_processed = max(0, total_samples - start_idx)
-    rate = samples_processed / collect_elapsed if collect_elapsed > 0 else 0.0
-    logger.info(f"Collect loop: {samples_processed:,} samples in {collect_elapsed:.2f}s ({rate:.1f} samples/s)")
 
     total_instances = len(train_dataset)
+    total_tokens = len(token_ids)
+    total_trainable_tokens = sum(labels_mask)
 
     logger.info(f"Total sequences: {total_instances}")
     logger.info(f"Total tokens: {total_tokens}")
-    logger.info(f"Maximum token ID: {max_token_id}")
+    logger.info(f"Maximum token ID: {max(token_ids) if token_ids else 0}")
     logger.info(f"Labels mask sum (trainable tokens): {total_trainable_tokens}")
     logger.info("Writing data to numpy files...")
     logger.info(f"Number of samples that should be skipped: {num_samples_skipped}")
 
+    vocab_size = tc.tokenizer.vocab_size
+    token_dtype = _select_token_dtype(vocab_size)
+    logger.info(f"Using dtype '{token_dtype}' for token_ids based on vocab size {vocab_size}")
+
     logger.info(f"Writing converted data to {output_dir}")
-    token_chunk_boundaries = _write_memmap_chunked_from_file(
-        f"{output_dir}/token_ids", tokens_path, total_tokens, token_dtype
-    )
+    token_chunk_boundaries = _write_memmap_chunked(f"{output_dir}/token_ids", token_ids, token_dtype)
     _write_metadata_for_chunks(f"{output_dir}/token_ids", document_boundaries, token_chunk_boundaries)
 
-    labels_src = np.memmap(labels_path, mode="r", dtype=np.uint8, shape=(total_tokens,)) if total_tokens else None
     for i, (start, end) in enumerate(token_chunk_boundaries):
+        chunk_data = labels_mask[start:end]
         filename = f"{output_dir}/labels_mask_part_{i:04d}.npy"
-        mmap = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(end - start,))
-        mmap[:] = labels_src[start:end].astype(np.bool_)
+        mmap = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(len(chunk_data),))
+        mmap[:] = chunk_data
         mmap.flush()
-        logger.info(f"Written {filename} ({(end - start) * np.dtype(np.bool_).itemsize / 1024**3:.2f} GB)")
+        logger.info(f"Written {filename} ({len(chunk_data) * np.dtype(np.bool_).itemsize / 1024**3:.2f} GB)")
 
     logger.info("Data conversion completed successfully!")
-    remove_checkpoint(output_dir)
+    remove_checkpoint(output_path)
 
     write_dataset_statistics(
         output_dir=output_dir,

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -11,6 +11,7 @@ The output layout for each `output_dir` is:
 import gzip
 import json
 import os
+import pathlib
 import sys
 import time
 from datetime import datetime
@@ -48,18 +49,9 @@ def load_checkpoint(output_dir: str) -> dict[str, Any] | None:
     return None
 
 
-def remove_checkpoint(output_dir: str) -> None:
-    checkpoint_path = os.path.join(output_dir, _CHECKPOINT_FILENAME)
-    if os.path.exists(checkpoint_path):
-        os.remove(checkpoint_path)
-        logger.info(f"Removed checkpoint file: {checkpoint_path}")
-
-
 def _remove_partial_files(output_dir: str) -> None:
     for name in (_TOKENS_PARTIAL_FILENAME, _LABELS_PARTIAL_FILENAME):
-        path = os.path.join(output_dir, name)
-        if os.path.exists(path):
-            os.remove(path)
+        pathlib.Path(output_dir, name).unlink(missing_ok=True)
 
 
 def _select_token_dtype(vocab_size: int):
@@ -413,7 +405,7 @@ def convert_hf_to_numpy_sft(
     _write_labels_memmap_from_file(output_dir, labels_partial_path, token_chunk_boundaries)
 
     logger.info("Data conversion completed successfully!")
-    remove_checkpoint(output_dir)
+    pathlib.Path(output_dir, _CHECKPOINT_FILENAME).unlink(missing_ok=True)
     _remove_partial_files(output_dir)
 
     write_dataset_statistics(

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -103,9 +103,11 @@ def _recover_partial_state(
 ) -> tuple[int, int]:
     # Boundaries file is the commit log: its last complete (start,end) pair determines how many
     # bytes of tokens/labels are valid; trailing bytes from an incomplete write get truncated.
-    for path in (tokens_path, labels_path, boundaries_path):
-        if not path.exists():
-            return 0, 0
+    paths = (tokens_path, labels_path, boundaries_path)
+    if not all(p.exists() for p in paths):
+        for p in paths:
+            p.unlink(missing_ok=True)
+        return 0, 0
 
     pair_bytes = 2 * np.dtype(_BOUNDARIES_DTYPE).itemsize
     boundaries_size = boundaries_path.stat().st_size
@@ -158,7 +160,7 @@ def _aggregate_stats(
 
     labels_mm = np.memmap(labels_path, mode="r", dtype=np.uint8, shape=(total_tokens,))
     starts = boundaries[:, 0].astype(np.intp)
-    trainable_counts = np.add.reduceat(labels_mm.astype(np.int64), starts)
+    trainable_counts = np.add.reduceat(labels_mm, starts, dtype=np.int64)
     zero_length_mask = sample_lengths == 0
     if zero_length_mask.any():
         trainable_counts = np.where(zero_length_mask, 0, trainable_counts)

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -9,10 +9,8 @@ The output layout for each `output_dir` is:
 """
 
 import gzip
-import itertools
 import json
 import os
-import pathlib
 import sys
 import time
 from datetime import datetime
@@ -26,175 +24,12 @@ from open_instruct import dataset_transformation, logger_utils, utils
 logger = logger_utils.setup_logger(__name__)
 
 
-_CHECKPOINT_FILENAME = "_checkpoint.json"
-_CHECKPOINT_TOKEN_IDS_FILENAME = "_checkpoint_token_ids.bin"
-_CHECKPOINT_LABELS_MASK_FILENAME = "_checkpoint_labels_mask.bin"
-_CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME = "_checkpoint_document_boundaries.bin"
+_PARTIAL_TOKEN_IDS_FILENAME = "_tokens.partial.bin"
+_PARTIAL_LABELS_MASK_FILENAME = "_labels.partial.bin"
+_PARTIAL_BOUNDARIES_FILENAME = "_boundaries.partial.bin"
 
-_CHECKPOINT_TOKEN_DTYPE = np.uint32
-_CHECKPOINT_LABELS_DTYPE = np.uint8
-_CHECKPOINT_BOUNDARIES_DTYPE = np.int64
-
-
-def _append_bytes(path: pathlib.Path, data: bytes) -> None:
-    with open(path, "ab") as f:
-        f.write(data)
-
-
-def _truncate_to(path: pathlib.Path, size: int) -> None:
-    if not path.exists():
-        raise RuntimeError(f"Checkpoint file {path} does not exist.")
-    current_size = path.stat().st_size
-    if current_size == size:
-        return
-    if current_size < size:
-        raise RuntimeError(
-            f"Checkpoint file {path} is smaller than expected ({current_size} < {size}); data is corrupted."
-        )
-    with open(path, "r+b") as f:
-        f.truncate(size)
-
-
-def save_checkpoint(
-    output_dir: pathlib.Path,
-    samples_processed: int,
-    token_ids: list[int],
-    labels_mask: list[int],
-    document_boundaries: list[tuple[int, int]],
-    scalar_state: dict[str, Any],
-    prev_tokens_written: int,
-    prev_samples_written: int,
-) -> tuple[int, int, int]:
-    """Append new array data to the binary files, then atomically update the JSON
-    metadata. Returns (tokens_written, samples_written, bytes_appended); the first
-    two should be passed back as prev_* on the next call.
-    """
-    tokens_path = output_dir / _CHECKPOINT_TOKEN_IDS_FILENAME
-    labels_path = output_dir / _CHECKPOINT_LABELS_MASK_FILENAME
-    boundaries_path = output_dir / _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME
-    json_path = output_dir / _CHECKPOINT_FILENAME
-
-    # The JSON file is rewritten atomically (write-temp + rename) *after* the binary
-    # appends, so it is the source of truth for how much has been durably committed.
-    # If a previous run crashed between the binary append and the JSON rename, the
-    # binary files may contain trailing bytes beyond `prev_*_written`. Truncate any
-    # such uncommitted bytes before appending this batch so the files stay in
-    # lock-step with the JSON metadata.
-    token_size = np.dtype(_CHECKPOINT_TOKEN_DTYPE).itemsize
-    labels_size = np.dtype(_CHECKPOINT_LABELS_DTYPE).itemsize
-    boundary_size = np.dtype(_CHECKPOINT_BOUNDARIES_DTYPE).itemsize
-    if prev_tokens_written > 0:
-        _truncate_to(tokens_path, prev_tokens_written * token_size)
-        _truncate_to(labels_path, prev_tokens_written * labels_size)
-    if prev_samples_written > 0:
-        _truncate_to(boundaries_path, prev_samples_written * 2 * boundary_size)
-
-    new_tokens = np.fromiter(
-        itertools.islice(token_ids, prev_tokens_written, None),
-        dtype=_CHECKPOINT_TOKEN_DTYPE,
-        count=len(token_ids) - prev_tokens_written,
-    ).tobytes()
-    new_labels = np.fromiter(
-        itertools.islice(labels_mask, prev_tokens_written, None),
-        dtype=_CHECKPOINT_LABELS_DTYPE,
-        count=len(labels_mask) - prev_tokens_written,
-    ).tobytes()
-    new_boundaries = np.asarray(
-        document_boundaries[prev_samples_written:], dtype=_CHECKPOINT_BOUNDARIES_DTYPE
-    ).tobytes()
-
-    _append_bytes(tokens_path, new_tokens)
-    _append_bytes(labels_path, new_labels)
-    _append_bytes(boundaries_path, new_boundaries)
-    bytes_appended = len(new_tokens) + len(new_labels) + len(new_boundaries)
-
-    tokens_written = len(token_ids)
-    samples_written = len(document_boundaries)
-
-    meta = {
-        **scalar_state,
-        "samples_processed": samples_processed,
-        "tokens_written": tokens_written,
-        "samples_written": samples_written,
-    }
-    tmp_path = json_path.with_suffix(json_path.suffix + ".tmp")
-    with open(tmp_path, "w") as f:
-        json.dump(meta, f)
-    tmp_path.rename(json_path)
-
-    return tokens_written, samples_written, bytes_appended
-
-
-def load_checkpoint(output_dir: pathlib.Path) -> dict[str, Any] | None:
-    json_path = output_dir / _CHECKPOINT_FILENAME
-    if not json_path.exists():
-        return None
-    with open(json_path) as f:
-        meta = json.load(f)
-
-    if "token_ids" in meta:
-        document_boundaries = [tuple(b) for b in meta["document_boundaries"]]
-        return {
-            "samples_processed": meta["samples_processed"],
-            "token_ids": meta["token_ids"],
-            "labels_mask": meta["labels_mask"],
-            "document_boundaries": document_boundaries,
-            "current_position": meta["current_position"],
-            "num_samples_skipped": meta["num_samples_skipped"],
-            "per_dataset_counts": meta["per_dataset_counts"],
-            "per_dataset_tokens": meta["per_dataset_tokens"],
-            "per_dataset_trainable_tokens": meta["per_dataset_trainable_tokens"],
-            "per_dataset_filtered": meta["per_dataset_filtered"],
-            "tokens_written": 0,
-            "samples_written": 0,
-        }
-
-    tokens_written = meta["tokens_written"]
-    samples_written = meta["samples_written"]
-
-    tokens_path = output_dir / _CHECKPOINT_TOKEN_IDS_FILENAME
-    labels_path = output_dir / _CHECKPOINT_LABELS_MASK_FILENAME
-    boundaries_path = output_dir / _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME
-
-    if tokens_written > 0:
-        _truncate_to(tokens_path, tokens_written * np.dtype(_CHECKPOINT_TOKEN_DTYPE).itemsize)
-        _truncate_to(labels_path, tokens_written * np.dtype(_CHECKPOINT_LABELS_DTYPE).itemsize)
-    if samples_written > 0:
-        _truncate_to(boundaries_path, samples_written * 2 * np.dtype(_CHECKPOINT_BOUNDARIES_DTYPE).itemsize)
-
-    token_ids = np.fromfile(tokens_path, dtype=_CHECKPOINT_TOKEN_DTYPE, count=tokens_written).tolist()
-    labels_mask = np.fromfile(labels_path, dtype=_CHECKPOINT_LABELS_DTYPE, count=tokens_written).tolist()
-    boundaries_flat = np.fromfile(boundaries_path, dtype=_CHECKPOINT_BOUNDARIES_DTYPE, count=samples_written * 2)
-    boundaries_flat = boundaries_flat.reshape(-1, 2)
-    document_boundaries = [(int(s), int(e)) for s, e in boundaries_flat]
-
-    return {
-        "samples_processed": meta["samples_processed"],
-        "token_ids": token_ids,
-        "labels_mask": labels_mask,
-        "document_boundaries": document_boundaries,
-        "current_position": meta["current_position"],
-        "num_samples_skipped": meta["num_samples_skipped"],
-        "per_dataset_counts": meta["per_dataset_counts"],
-        "per_dataset_tokens": meta["per_dataset_tokens"],
-        "per_dataset_trainable_tokens": meta["per_dataset_trainable_tokens"],
-        "per_dataset_filtered": meta["per_dataset_filtered"],
-        "tokens_written": tokens_written,
-        "samples_written": samples_written,
-    }
-
-
-def remove_checkpoint(output_dir: pathlib.Path) -> None:
-    for filename in (
-        _CHECKPOINT_FILENAME,
-        _CHECKPOINT_TOKEN_IDS_FILENAME,
-        _CHECKPOINT_LABELS_MASK_FILENAME,
-        _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME,
-    ):
-        path = output_dir / filename
-        if path.exists():
-            path.unlink()
-            logger.info(f"Removed checkpoint file: {path}")
+_BOUNDARIES_DTYPE = np.int64
+_BOUNDARY_PAIR_BYTES = 2 * np.dtype(_BOUNDARIES_DTYPE).itemsize
 
 
 def _select_token_dtype(vocab_size: int):
@@ -204,35 +39,46 @@ def _select_token_dtype(vocab_size: int):
     raise ValueError(f"Vocab size {vocab_size} is too big for any numpy integer dtype!")
 
 
-def _write_memmap_chunked(
-    base_filename: str, data: list[int], dtype, max_size_bytes: int = 1024**3
+def _flush_partial_files(*file_handles) -> None:
+    """Flush + fsync the given partial files so a crash leaves them recoverable."""
+    for fh in file_handles:
+        fh.flush()
+        os.fsync(fh.fileno())
+
+
+def _write_memmap_chunked_from_file(
+    base_filename: str, source_path: str, total_items: int, dtype, max_size_gb: int = 1
 ) -> list[tuple[int, int]]:
     item_size = np.dtype(dtype).itemsize
-    chunk_size = max_size_bytes // item_size
+    chunk_size = int((max_size_gb * 1024**3) // item_size)
     chunk_boundaries: list[tuple[int, int]] = []
 
-    for i in range(0, len(data), chunk_size):
-        chunk_data = data[i : i + chunk_size]
-        filename = f"{base_filename}_part_{i // chunk_size:04d}.npy"
-        mmap = np.memmap(filename, mode="w+", dtype=dtype, shape=(len(chunk_data),))
-        mmap[:] = chunk_data
-        mmap.flush()
-        chunk_boundaries.append((i, i + len(chunk_data)))
-        logger.info(f"Written {filename} ({len(chunk_data) * item_size / 1024**3:.2f} GB)")
+    if total_items == 0:
+        return chunk_boundaries
+
+    src = np.memmap(source_path, mode="r", dtype=dtype, shape=(total_items,))
+    for chunk_idx, i in enumerate(range(0, total_items, chunk_size)):
+        end = min(i + chunk_size, total_items)
+        filename = f"{base_filename}_part_{chunk_idx:04d}.npy"
+        dst = np.memmap(filename, mode="w+", dtype=dtype, shape=(end - i,))
+        dst[:] = src[i:end]
+        dst.flush()
+        chunk_boundaries.append((i, end))
+        logger.info(f"Written {filename} ({(end - i) * item_size / 1024**3:.2f} GB)")
 
     return chunk_boundaries
 
 
 def _write_metadata_for_chunks(
-    base_filename: str, document_boundaries: list[tuple[int, int]], chunk_boundaries: list[tuple[int, int]]
+    base_filename: str, document_boundaries: np.ndarray, chunk_boundaries: list[tuple[int, int]]
 ) -> None:
     for chunk_idx, (chunk_start, chunk_end) in enumerate(chunk_boundaries):
         metadata_filename = f"{base_filename}_part_{chunk_idx:04d}.csv.gz"
         with gzip.open(metadata_filename, "wt") as f:
             for doc_start, doc_end in document_boundaries:
                 if doc_end > chunk_start and doc_start < chunk_end:
-                    adjusted_start = max(0, doc_start - chunk_start)
-                    adjusted_end = min(chunk_end - chunk_start, doc_end - chunk_start)
+                    adjusted_start = max(0, int(doc_start) - chunk_start)
+                    adjusted_end = min(chunk_end - chunk_start, int(doc_end) - chunk_start)
                     if adjusted_end > adjusted_start:
                         f.write(f"{adjusted_start},{adjusted_end}\n")
         logger.info(f"Written metadata {metadata_filename}")
@@ -258,6 +104,115 @@ def _save_tokenizer(tc: dataset_transformation.TokenizerConfig, output_dir: str)
             logger.info(f"Added chat_template from {chat_template_path} to tokenizer_config.json")
 
 
+def _recover_partial_state(
+    tokens_path: str, labels_path: str, boundaries_path: str, token_item_size: int
+) -> tuple[int, int]:
+    """Truncate the three partial files to a consistent state and return (num_samples, current_position).
+
+    Boundaries file is treated as the commit log: its last complete (start,end) pair determines
+    how many bytes of tokens/labels are valid. Any trailing bytes are truncated off.
+    """
+    for path in (tokens_path, labels_path, boundaries_path):
+        if not os.path.exists(path):
+            return 0, 0
+
+    boundaries_size = os.path.getsize(boundaries_path)
+    valid_bytes = (boundaries_size // _BOUNDARY_PAIR_BYTES) * _BOUNDARY_PAIR_BYTES
+    if valid_bytes != boundaries_size:
+        os.truncate(boundaries_path, valid_bytes)
+
+    num_samples = valid_bytes // _BOUNDARY_PAIR_BYTES
+    if num_samples == 0:
+        os.truncate(tokens_path, 0)
+        os.truncate(labels_path, 0)
+        return 0, 0
+
+    boundaries = np.memmap(boundaries_path, mode="r", dtype=_BOUNDARIES_DTYPE, shape=(num_samples, 2))
+    current_position = int(boundaries[-1, 1])
+    del boundaries
+
+    os.truncate(tokens_path, current_position * token_item_size)
+    os.truncate(labels_path, current_position)
+    return num_samples, current_position
+
+
+def _aggregate_stats(
+    train_dataset,
+    boundaries_path: str,
+    labels_path: str,
+    tokens_path: str,
+    num_samples: int,
+    total_tokens: int,
+    token_dtype,
+) -> dict[str, Any]:
+    """Compute per-dataset and overall statistics from the on-disk partial files.
+
+    Runs once at the end. Reads the dataset_source column directly from the HF
+    dataset (cheap Arrow column access; no tokenization), then aggregates via
+    vectorized numpy ops over the labels/boundaries partial files.
+    """
+    per_dataset_counts: dict[str, int] = {}
+    per_dataset_tokens: dict[str, int] = {}
+    per_dataset_trainable_tokens: dict[str, int] = {}
+    per_dataset_filtered: dict[str, int] = {}
+
+    if num_samples == 0:
+        return {
+            "per_dataset_counts": per_dataset_counts,
+            "per_dataset_tokens": per_dataset_tokens,
+            "per_dataset_trainable_tokens": per_dataset_trainable_tokens,
+            "per_dataset_filtered": per_dataset_filtered,
+            "total_trainable_tokens": 0,
+            "num_samples_skipped": 0,
+            "max_token_id": 0,
+        }
+
+    boundaries = np.memmap(boundaries_path, mode="r", dtype=_BOUNDARIES_DTYPE, shape=(num_samples, 2))
+    sample_lengths = (boundaries[:, 1] - boundaries[:, 0]).astype(np.int64)
+
+    labels_mm = np.memmap(labels_path, mode="r", dtype=np.uint8, shape=(total_tokens,))
+    starts = boundaries[:, 0].astype(np.intp)
+    trainable_counts = np.add.reduceat(labels_mm.astype(np.int64), starts)
+    zero_length_mask = sample_lengths == 0
+    if zero_length_mask.any():
+        trainable_counts = np.where(zero_length_mask, 0, trainable_counts)
+
+    num_samples_skipped = int((trainable_counts == 0).sum())
+    total_trainable_tokens = int(trainable_counts.sum())
+
+    sources = train_dataset[dataset_transformation.DATASET_ORIGIN_KEY]
+    if len(sources) != num_samples:
+        raise ValueError(
+            f"Dataset source column length {len(sources)} does not match number of processed "
+            f"samples {num_samples}. Partial files may have been produced with a different dataset."
+        )
+
+    for source, length, trainable in zip(sources, sample_lengths.tolist(), trainable_counts.tolist()):
+        if source not in per_dataset_counts:
+            per_dataset_counts[source] = 0
+            per_dataset_tokens[source] = 0
+            per_dataset_trainable_tokens[source] = 0
+            per_dataset_filtered[source] = 0
+        per_dataset_counts[source] += 1
+        per_dataset_tokens[source] += int(length)
+        per_dataset_trainable_tokens[source] += int(trainable)
+        if trainable == 0:
+            per_dataset_filtered[source] += 1
+
+    tokens_mm = np.memmap(tokens_path, mode="r", dtype=token_dtype, shape=(total_tokens,))
+    max_token_id = int(tokens_mm.max()) if total_tokens > 0 else 0
+
+    return {
+        "per_dataset_counts": per_dataset_counts,
+        "per_dataset_tokens": per_dataset_tokens,
+        "per_dataset_trainable_tokens": per_dataset_trainable_tokens,
+        "per_dataset_filtered": per_dataset_filtered,
+        "total_trainable_tokens": total_trainable_tokens,
+        "num_samples_skipped": num_samples_skipped,
+        "max_token_id": max_token_id,
+    }
+
+
 def convert_hf_to_numpy_sft(
     output_dir: str,
     dataset_mixer_list: list[str],
@@ -272,19 +227,19 @@ def convert_hf_to_numpy_sft(
     dataset_skip_cache: bool = False,
     dataset_config_hash: str | None = None,
     shuffle_seed: int = 42,
-    checkpoint_interval: int = 100_000,
     resume: bool = False,
     visualize: bool = False,
     tokenizer_config_only: bool = False,
     num_examples: int = 0,
+    batch_size: int = 1000,
 ) -> None:
     """Tokenize `dataset_mixer_list` and write OLMo-core numpy SFT files to `output_dir`.
 
-    Safe to call again after interruption when `resume=True`: an on-disk checkpoint
-    lets it pick up where it left off.
+    Tokens/labels/boundaries stream directly to `_*.partial.bin` files in `output_dir`.
+    If `resume=True` and those files already exist, the run continues from where the
+    previous one left off. On successful completion, the partial files are deleted.
     """
     os.makedirs(output_dir, exist_ok=True)
-    output_path = pathlib.Path(output_dir)
 
     logger.info("Verify these values match the tokenizer config used in Olmo-core:")
     logger.info(f"Tokenizer vocab_size: {tc.tokenizer.vocab_size}")
@@ -324,53 +279,46 @@ def convert_hf_to_numpy_sft(
         logger.info(f"Selecting {num_examples} examples for debugging")
         train_dataset = train_dataset.select(range(num_examples))
 
-    checkpoint = load_checkpoint(output_path) if resume else None
-    if checkpoint:
-        start_idx = checkpoint["samples_processed"]
-        token_ids = checkpoint["token_ids"]
-        labels_mask = checkpoint["labels_mask"]
-        document_boundaries = checkpoint["document_boundaries"]
-        current_position = checkpoint["current_position"]
-        num_samples_skipped = checkpoint["num_samples_skipped"]
-        per_dataset_counts = checkpoint["per_dataset_counts"]
-        per_dataset_tokens = checkpoint["per_dataset_tokens"]
-        per_dataset_trainable_tokens = checkpoint["per_dataset_trainable_tokens"]
-        per_dataset_filtered = checkpoint["per_dataset_filtered"]
-        last_tokens_written = checkpoint["tokens_written"]
-        last_samples_written = checkpoint["samples_written"]
-        logger.info("=== RESUMING from checkpoint ===")
-        logger.info(f"  Samples already processed: {start_idx:,}")
-        logger.info(f"  Tokens collected: {len(token_ids):,}")
-        logger.info(f"  Remaining samples: {len(train_dataset) - start_idx:,}")
+    vocab_size = tc.tokenizer.vocab_size
+    token_dtype = _select_token_dtype(vocab_size)
+    token_dtype_name = np.dtype(token_dtype).name
+    token_item_size = np.dtype(token_dtype).itemsize
+    logger.info(f"Using dtype '{token_dtype_name}' for token_ids based on vocab size {vocab_size}")
+
+    tokens_path = os.path.join(output_dir, _PARTIAL_TOKEN_IDS_FILENAME)
+    labels_path = os.path.join(output_dir, _PARTIAL_LABELS_MASK_FILENAME)
+    boundaries_path = os.path.join(output_dir, _PARTIAL_BOUNDARIES_FILENAME)
+
+    if resume:
+        start_idx, current_position = _recover_partial_state(
+            tokens_path, labels_path, boundaries_path, token_item_size
+        )
+        if start_idx > 0:
+            logger.info(f"=== RESUMING from partial files: {start_idx:,} samples / {current_position:,} tokens ===")
+        else:
+            logger.info("No recoverable partial files found, starting from beginning...")
     else:
-        if resume:
-            logger.info("No checkpoint found, starting from beginning...")
+        for path in (tokens_path, labels_path, boundaries_path):
+            if os.path.exists(path):
+                os.remove(path)
         start_idx = 0
-        token_ids = []
-        labels_mask = []
-        document_boundaries = []
         current_position = 0
-        num_samples_skipped = 0
-        per_dataset_counts = {}
-        per_dataset_tokens = {}
-        per_dataset_trainable_tokens = {}
-        per_dataset_filtered = {}
-        last_tokens_written = 0
-        last_samples_written = 0
 
-    logger.info("Collecting tokens from dataset...")
     total_samples = len(train_dataset)
-    loop_start_time = time.perf_counter()
-    utils.maybe_update_beaker_description(
-        current_step=start_idx, total_steps=total_samples, start_time=loop_start_time
-    )
+    logger.info("Collecting tokens from dataset...")
 
-    train_dataset_iter = train_dataset.select(range(start_idx, total_samples)).with_format("numpy")
+    if start_idx >= total_samples:
+        train_dataset_iter = train_dataset.select([])
+    elif start_idx > 0:
+        train_dataset_iter = train_dataset.select(range(start_idx, total_samples))
+    else:
+        train_dataset_iter = train_dataset
+
+    train_dataset_iter = train_dataset_iter.with_format("numpy")
 
     input_ids_key = dataset_transformation.INPUT_IDS_KEY
     labels_key = dataset_transformation.LABELS_KEY
     attention_mask_key = dataset_transformation.ATTENTION_MASK_KEY
-    dataset_source_key = dataset_transformation.DATASET_ORIGIN_KEY
 
     progress = tqdm(
         desc="Collecting tokens",
@@ -380,131 +328,121 @@ def convert_hf_to_numpy_sft(
         initial=start_idx,
         total=total_samples,
     )
-    last_description_update = loop_start_time
+
+    collect_start = time.perf_counter()
+    utils.maybe_update_beaker_description(current_step=start_idx, total_steps=total_samples, start_time=collect_start)
+    last_description_update = collect_start
     idx = start_idx - 1
-    for batch in train_dataset_iter.iter(batch_size=1000):
-        batch_input_ids = batch[input_ids_key]
-        batch_labels = batch[labels_key]
-        batch_attention = batch[attention_mask_key]
-        batch_sources = batch.get(dataset_source_key, ["unknown"] * len(batch_input_ids))
+    with (
+        open(tokens_path, "ab") as tokens_fh,
+        open(labels_path, "ab") as labels_fh,
+        open(boundaries_path, "ab") as boundaries_fh,
+    ):
+        for batch in train_dataset_iter.iter(batch_size=batch_size):
+            batch_input_ids = batch[input_ids_key]
+            batch_labels = batch[labels_key]
+            batch_attention = batch[attention_mask_key]
 
-        for sample_tokens, sample_labels, sample_attention, dataset_source in zip(
-            batch_input_ids, batch_labels, batch_attention, batch_sources
-        ):
-            idx += 1
-            sample_length = len(sample_tokens)
-            dataset_source = str(dataset_source)
+            for sample_tokens, sample_labels, sample_attention in zip(batch_input_ids, batch_labels, batch_attention):
+                idx += 1
+                sample_length = len(sample_tokens)
 
-            if dataset_source not in per_dataset_counts:
-                per_dataset_counts[dataset_source] = 0
-                per_dataset_tokens[dataset_source] = 0
-                per_dataset_trainable_tokens[dataset_source] = 0
-                per_dataset_filtered[dataset_source] = 0
+                tokens_arr = np.asarray(sample_tokens, dtype=token_dtype)
+                labels_arr = np.asarray(sample_labels)
+                labels_mask = (labels_arr != -100).astype(np.uint8)
 
-            sample_label_mask = (sample_labels != -100).astype(np.uint8)
-            trainable_tokens_in_sample = int(sample_label_mask.sum())
-
-            per_dataset_counts[dataset_source] += 1
-            per_dataset_tokens[dataset_source] += sample_length
-            per_dataset_trainable_tokens[dataset_source] += trainable_tokens_in_sample
-
-            token_ids.extend(sample_tokens.tolist())
-            labels_mask.extend(sample_label_mask.tolist())
-            document_boundaries.append((current_position, current_position + sample_length))
-            current_position += sample_length
-
-            if trainable_tokens_in_sample == 0:
-                num_samples_skipped += 1
-                per_dataset_filtered[dataset_source] += 1
-
-            assert (sample_attention == 1).all(), (
-                f"Expected all attention mask values to be 1, but found: {sample_attention}"
-            )
-
-            if (idx + 1) % checkpoint_interval == 0 and idx > start_idx:
-                checkpoint_start = time.perf_counter()
-                last_tokens_written, last_samples_written, checkpoint_bytes = save_checkpoint(
-                    output_path,
-                    samples_processed=idx + 1,
-                    token_ids=token_ids,
-                    labels_mask=labels_mask,
-                    document_boundaries=document_boundaries,
-                    scalar_state={
-                        "current_position": current_position,
-                        "num_samples_skipped": num_samples_skipped,
-                        "per_dataset_counts": per_dataset_counts,
-                        "per_dataset_tokens": per_dataset_tokens,
-                        "per_dataset_trainable_tokens": per_dataset_trainable_tokens,
-                        "per_dataset_filtered": per_dataset_filtered,
-                    },
-                    prev_tokens_written=last_tokens_written,
-                    prev_samples_written=last_samples_written,
+                tokens_arr.tofile(tokens_fh)
+                labels_mask.tofile(labels_fh)
+                np.array([current_position, current_position + sample_length], dtype=_BOUNDARIES_DTYPE).tofile(
+                    boundaries_fh
                 )
-                elapsed = time.perf_counter() - checkpoint_start
-                logger.info(
-                    f"Checkpoint saved at sample {idx + 1:,} ({len(token_ids):,} tokens) "
-                    f"in {elapsed:.2f}s [{checkpoint_bytes / (1024 * 1024):.1f} MiB, "
-                    f"{checkpoint_bytes / (1024 * 1024) / elapsed:.1f} MiB/s]"
+                current_position += sample_length
+
+                assert (sample_attention == 1).all(), (
+                    f"Expected all attention mask values to be 1, but found: {sample_attention}"
                 )
+
+            progress.update(len(batch_input_ids))
+            _flush_partial_files(tokens_fh, labels_fh, boundaries_fh)
+
+            now = time.perf_counter()
+            if now - last_description_update >= 30.0:
                 utils.maybe_update_beaker_description(
-                    current_step=idx + 1, total_steps=total_samples, start_time=loop_start_time
+                    current_step=idx + 1, total_steps=total_samples, start_time=collect_start
                 )
-                last_description_update = time.perf_counter()
+                last_description_update = now
 
-        progress.update(len(batch_input_ids))
-
-        now = time.perf_counter()
-        if now - last_description_update >= 30.0:
-            utils.maybe_update_beaker_description(
-                current_step=idx + 1, total_steps=total_samples, start_time=loop_start_time
-            )
-            last_description_update = now
     progress.close()
+    utils.maybe_update_beaker_description(
+        current_step=total_samples, total_steps=total_samples, start_time=collect_start
+    )
+    collect_elapsed = time.perf_counter() - collect_start
+    samples_processed = max(0, total_samples - start_idx)
+    rate = samples_processed / collect_elapsed if collect_elapsed > 0 else 0.0
+    logger.info(f"Collect loop: {samples_processed:,} samples in {collect_elapsed:.2f}s ({rate:.1f} samples/s)")
 
-    total_instances = len(train_dataset)
-    total_tokens = len(token_ids)
-    total_trainable_tokens = sum(labels_mask)
+    total_tokens = current_position
+    logger.info("Aggregating per-dataset statistics from disk...")
+    stats_start = time.perf_counter()
+    stats = _aggregate_stats(
+        train_dataset=train_dataset,
+        boundaries_path=boundaries_path,
+        labels_path=labels_path,
+        tokens_path=tokens_path,
+        num_samples=total_samples,
+        total_tokens=total_tokens,
+        token_dtype=token_dtype,
+    )
+    logger.info(f"Stats aggregation: {time.perf_counter() - stats_start:.2f}s")
 
-    logger.info(f"Total sequences: {total_instances}")
+    logger.info(f"Total sequences: {total_samples}")
     logger.info(f"Total tokens: {total_tokens}")
-    logger.info(f"Maximum token ID: {max(token_ids) if token_ids else 0}")
-    logger.info(f"Labels mask sum (trainable tokens): {total_trainable_tokens}")
-    logger.info("Writing data to numpy files...")
-    logger.info(f"Number of samples that should be skipped: {num_samples_skipped}")
-
-    vocab_size = tc.tokenizer.vocab_size
-    token_dtype = _select_token_dtype(vocab_size)
-    logger.info(f"Using dtype '{token_dtype}' for token_ids based on vocab size {vocab_size}")
+    logger.info(f"Maximum token ID: {stats['max_token_id']}")
+    logger.info(f"Labels mask sum (trainable tokens): {stats['total_trainable_tokens']}")
+    logger.info(f"Number of samples that should be skipped: {stats['num_samples_skipped']}")
 
     logger.info(f"Writing converted data to {output_dir}")
-    token_chunk_boundaries = _write_memmap_chunked(f"{output_dir}/token_ids", token_ids, token_dtype)
-    _write_metadata_for_chunks(f"{output_dir}/token_ids", document_boundaries, token_chunk_boundaries)
+    token_chunk_boundaries = _write_memmap_chunked_from_file(
+        f"{output_dir}/token_ids", tokens_path, total_tokens, token_dtype
+    )
 
+    document_boundaries = (
+        np.memmap(boundaries_path, mode="r", dtype=_BOUNDARIES_DTYPE, shape=(total_samples, 2))
+        if total_samples > 0
+        else np.zeros((0, 2), dtype=_BOUNDARIES_DTYPE)
+    )
+    _write_metadata_for_chunks(f"{output_dir}/token_ids", document_boundaries, token_chunk_boundaries)
+    del document_boundaries
+
+    labels_src = np.memmap(labels_path, mode="r", dtype=np.uint8, shape=(total_tokens,)) if total_tokens else None
     for i, (start, end) in enumerate(token_chunk_boundaries):
-        chunk_data = labels_mask[start:end]
         filename = f"{output_dir}/labels_mask_part_{i:04d}.npy"
-        mmap = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(len(chunk_data),))
-        mmap[:] = chunk_data
+        mmap = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(end - start,))
+        mmap[:] = labels_src[start:end].astype(np.bool_)
         mmap.flush()
-        logger.info(f"Written {filename} ({len(chunk_data) * np.dtype(np.bool_).itemsize / 1024**3:.2f} GB)")
+        logger.info(f"Written {filename} ({(end - start) * np.dtype(np.bool_).itemsize / 1024**3:.2f} GB)")
+    del labels_src
+
+    for path in (tokens_path, labels_path, boundaries_path):
+        if os.path.exists(path):
+            os.remove(path)
 
     logger.info("Data conversion completed successfully!")
-    remove_checkpoint(output_path)
 
     write_dataset_statistics(
         output_dir=output_dir,
         dataset_statistics=dataset_statistics,
-        total_instances=total_instances,
+        total_instances=total_samples,
         total_tokens=total_tokens,
-        total_trainable_tokens=total_trainable_tokens,
-        num_samples_skipped=num_samples_skipped,
+        total_trainable_tokens=stats["total_trainable_tokens"],
+        num_samples_skipped=stats["num_samples_skipped"],
         tokenizer_name=tc.tokenizer_name_or_path,
         max_seq_length=max_seq_length,
         chat_template_name=tc.chat_template_name,
-        per_dataset_counts=per_dataset_counts,
-        per_dataset_tokens=per_dataset_tokens,
-        per_dataset_trainable_tokens=per_dataset_trainable_tokens,
-        per_dataset_filtered=per_dataset_filtered,
+        per_dataset_counts=stats["per_dataset_counts"],
+        per_dataset_tokens=stats["per_dataset_tokens"],
+        per_dataset_trainable_tokens=stats["per_dataset_trainable_tokens"],
+        per_dataset_filtered=stats["per_dataset_filtered"],
     )
 
 

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -11,6 +11,7 @@ The output layout for each `output_dir` is:
 import gzip
 import json
 import os
+import pathlib
 import sys
 import time
 from datetime import datetime
@@ -24,12 +25,7 @@ from open_instruct import dataset_transformation, logger_utils, utils
 logger = logger_utils.setup_logger(__name__)
 
 
-_PARTIAL_TOKEN_IDS_FILENAME = "_tokens.partial.bin"
-_PARTIAL_LABELS_MASK_FILENAME = "_labels.partial.bin"
-_PARTIAL_BOUNDARIES_FILENAME = "_boundaries.partial.bin"
-
 _BOUNDARIES_DTYPE = np.int64
-_BOUNDARY_PAIR_BYTES = 2 * np.dtype(_BOUNDARIES_DTYPE).itemsize
 
 
 def _select_token_dtype(vocab_size: int):
@@ -47,7 +43,7 @@ def _flush_partial_files(*file_handles) -> None:
 
 
 def _write_memmap_chunked_from_file(
-    base_filename: str, source_path: str, total_items: int, dtype, max_size_gb: int = 1
+    base_filename: pathlib.Path, source_path: pathlib.Path, total_items: int, dtype, max_size_gb: int = 1
 ) -> list[tuple[int, int]]:
     item_size = np.dtype(dtype).itemsize
     chunk_size = int((max_size_gb * 1024**3) // item_size)
@@ -59,7 +55,7 @@ def _write_memmap_chunked_from_file(
     src = np.memmap(source_path, mode="r", dtype=dtype, shape=(total_items,))
     for chunk_idx, i in enumerate(range(0, total_items, chunk_size)):
         end = min(i + chunk_size, total_items)
-        filename = f"{base_filename}_part_{chunk_idx:04d}.npy"
+        filename = base_filename.with_name(f"{base_filename.name}_part_{chunk_idx:04d}.npy")
         dst = np.memmap(filename, mode="w+", dtype=dtype, shape=(end - i,))
         dst[:] = src[i:end]
         dst.flush()
@@ -70,10 +66,10 @@ def _write_memmap_chunked_from_file(
 
 
 def _write_metadata_for_chunks(
-    base_filename: str, document_boundaries: np.ndarray, chunk_boundaries: list[tuple[int, int]]
+    base_filename: pathlib.Path, document_boundaries: np.ndarray, chunk_boundaries: list[tuple[int, int]]
 ) -> None:
     for chunk_idx, (chunk_start, chunk_end) in enumerate(chunk_boundaries):
-        metadata_filename = f"{base_filename}_part_{chunk_idx:04d}.csv.gz"
+        metadata_filename = base_filename.with_name(f"{base_filename.name}_part_{chunk_idx:04d}.csv.gz")
         with gzip.open(metadata_filename, "wt", encoding="utf-8") as f:
             for doc_start, doc_end in document_boundaries:
                 if doc_end > chunk_start and doc_start < chunk_end:
@@ -84,28 +80,27 @@ def _write_metadata_for_chunks(
         logger.info(f"Written metadata {metadata_filename}")
 
 
-def _save_tokenizer(tc: dataset_transformation.TokenizerConfig, output_dir: str) -> None:
-    tokenizer_output_dir = os.path.join(output_dir, "tokenizer")
-    os.makedirs(tokenizer_output_dir, exist_ok=True)
+def _save_tokenizer(tc: dataset_transformation.TokenizerConfig, output_dir: pathlib.Path) -> None:
+    tokenizer_output_dir = output_dir / "tokenizer"
+    tokenizer_output_dir.mkdir(parents=True, exist_ok=True)
     logger.info(f"Saving tokenizer to {tokenizer_output_dir}...")
-    tc.tokenizer.save_pretrained(tokenizer_output_dir)
+    tc.tokenizer.save_pretrained(str(tokenizer_output_dir))
 
-    chat_template_path = os.path.join(tokenizer_output_dir, "chat_template.jinja")
-    tokenizer_config_path = os.path.join(tokenizer_output_dir, "tokenizer_config.json")
-    if os.path.exists(chat_template_path) and os.path.exists(tokenizer_config_path):
-        with open(chat_template_path) as f:
-            chat_template_content = f.read()
-        with open(tokenizer_config_path) as f:
+    chat_template_path = tokenizer_output_dir / "chat_template.jinja"
+    tokenizer_config_path = tokenizer_output_dir / "tokenizer_config.json"
+    if chat_template_path.exists() and tokenizer_config_path.exists():
+        chat_template_content = chat_template_path.read_text()
+        with tokenizer_config_path.open() as f:
             tokenizer_config = json.load(f)
         if "chat_template" not in tokenizer_config:
             tokenizer_config["chat_template"] = chat_template_content
-            with open(tokenizer_config_path, "w") as f:
+            with tokenizer_config_path.open("w") as f:
                 json.dump(tokenizer_config, f, indent=2)
             logger.info(f"Added chat_template from {chat_template_path} to tokenizer_config.json")
 
 
 def _recover_partial_state(
-    tokens_path: str, labels_path: str, boundaries_path: str, token_item_size: int
+    tokens_path: pathlib.Path, labels_path: pathlib.Path, boundaries_path: pathlib.Path, token_item_size: int
 ) -> tuple[int, int]:
     """Truncate the three partial files to a consistent state and return (num_samples, current_position).
 
@@ -113,15 +108,16 @@ def _recover_partial_state(
     how many bytes of tokens/labels are valid. Any trailing bytes are truncated off.
     """
     for path in (tokens_path, labels_path, boundaries_path):
-        if not os.path.exists(path):
+        if not path.exists():
             return 0, 0
 
-    boundaries_size = os.path.getsize(boundaries_path)
-    valid_bytes = (boundaries_size // _BOUNDARY_PAIR_BYTES) * _BOUNDARY_PAIR_BYTES
+    pair_bytes = 2 * np.dtype(_BOUNDARIES_DTYPE).itemsize
+    boundaries_size = boundaries_path.stat().st_size
+    valid_bytes = (boundaries_size // pair_bytes) * pair_bytes
     if valid_bytes != boundaries_size:
         os.truncate(boundaries_path, valid_bytes)
 
-    num_samples = valid_bytes // _BOUNDARY_PAIR_BYTES
+    num_samples = valid_bytes // pair_bytes
     if num_samples == 0:
         os.truncate(tokens_path, 0)
         os.truncate(labels_path, 0)
@@ -138,9 +134,9 @@ def _recover_partial_state(
 
 def _aggregate_stats(
     train_dataset,
-    boundaries_path: str,
-    labels_path: str,
-    tokens_path: str,
+    boundaries_path: pathlib.Path,
+    labels_path: pathlib.Path,
+    tokens_path: pathlib.Path,
     num_samples: int,
     total_tokens: int,
     token_dtype,
@@ -214,7 +210,7 @@ def _aggregate_stats(
 
 
 def convert_hf_to_numpy_sft(
-    output_dir: str,
+    output_dir: pathlib.Path,
     dataset_mixer_list: list[str],
     dataset_mixer_list_splits: list[str],
     tc: dataset_transformation.TokenizerConfig,
@@ -239,7 +235,7 @@ def convert_hf_to_numpy_sft(
     If `resume=True` and those files already exist, the run continues from where the
     previous one left off. On successful completion, the partial files are deleted.
     """
-    os.makedirs(output_dir, exist_ok=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info("Verify these values match the tokenizer config used in Olmo-core:")
     logger.info(f"Tokenizer vocab_size: {tc.tokenizer.vocab_size}")
@@ -285,9 +281,9 @@ def convert_hf_to_numpy_sft(
     token_item_size = np.dtype(token_dtype).itemsize
     logger.info(f"Using dtype '{token_dtype_name}' for token_ids based on vocab size {vocab_size}")
 
-    tokens_path = os.path.join(output_dir, _PARTIAL_TOKEN_IDS_FILENAME)
-    labels_path = os.path.join(output_dir, _PARTIAL_LABELS_MASK_FILENAME)
-    boundaries_path = os.path.join(output_dir, _PARTIAL_BOUNDARIES_FILENAME)
+    tokens_path = output_dir / "_tokens.partial.bin"
+    labels_path = output_dir / "_labels.partial.bin"
+    boundaries_path = output_dir / "_boundaries.partial.bin"
 
     if resume:
         start_idx, current_position = _recover_partial_state(
@@ -299,8 +295,7 @@ def convert_hf_to_numpy_sft(
             logger.info("No recoverable partial files found, starting from beginning...")
     else:
         for path in (tokens_path, labels_path, boundaries_path):
-            if os.path.exists(path):
-                os.remove(path)
+            path.unlink(missing_ok=True)
         start_idx = 0
         current_position = 0
 
@@ -334,9 +329,9 @@ def convert_hf_to_numpy_sft(
     last_description_update = collect_start
     idx = start_idx - 1
     with (
-        open(tokens_path, "ab") as tokens_fh,
-        open(labels_path, "ab") as labels_fh,
-        open(boundaries_path, "ab") as boundaries_fh,
+        tokens_path.open("ab") as tokens_fh,
+        labels_path.open("ab") as labels_fh,
+        boundaries_path.open("ab") as boundaries_fh,
     ):
         for batch in train_dataset_iter.iter(batch_size=batch_size):
             batch_input_ids = batch[input_ids_key]
@@ -402,21 +397,20 @@ def convert_hf_to_numpy_sft(
     logger.info(f"Number of samples that should be skipped: {stats['num_samples_skipped']}")
 
     logger.info(f"Writing converted data to {output_dir}")
-    token_chunk_boundaries = _write_memmap_chunked_from_file(
-        f"{output_dir}/token_ids", tokens_path, total_tokens, token_dtype
-    )
+    token_ids_base = output_dir / "token_ids"
+    token_chunk_boundaries = _write_memmap_chunked_from_file(token_ids_base, tokens_path, total_tokens, token_dtype)
 
     document_boundaries = (
         np.memmap(boundaries_path, mode="r", dtype=_BOUNDARIES_DTYPE, shape=(total_samples, 2))
         if total_samples > 0
         else np.zeros((0, 2), dtype=_BOUNDARIES_DTYPE)
     )
-    _write_metadata_for_chunks(f"{output_dir}/token_ids", document_boundaries, token_chunk_boundaries)
+    _write_metadata_for_chunks(token_ids_base, document_boundaries, token_chunk_boundaries)
     del document_boundaries
 
     labels_src = np.memmap(labels_path, mode="r", dtype=np.uint8, shape=(total_tokens,)) if total_tokens else None
     for i, (start, end) in enumerate(token_chunk_boundaries):
-        filename = f"{output_dir}/labels_mask_part_{i:04d}.npy"
+        filename = output_dir / f"labels_mask_part_{i:04d}.npy"
         mmap = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(end - start,))
         mmap[:] = labels_src[start:end].astype(np.bool_)
         mmap.flush()
@@ -424,8 +418,7 @@ def convert_hf_to_numpy_sft(
     del labels_src
 
     for path in (tokens_path, labels_path, boundaries_path):
-        if os.path.exists(path):
-            os.remove(path)
+        path.unlink(missing_ok=True)
 
     logger.info("Data conversion completed successfully!")
 
@@ -447,7 +440,7 @@ def convert_hf_to_numpy_sft(
 
 
 def write_dataset_statistics(
-    output_dir: str,
+    output_dir: pathlib.Path,
     dataset_statistics: dict[str, Any],
     total_instances: int,
     total_tokens: int,
@@ -496,7 +489,7 @@ def write_dataset_statistics(
 
     stats_data = {
         "timestamp": timestamp,
-        "output_directory": output_dir,
+        "output_directory": str(output_dir),
         "configuration": {
             "tokenizer": tokenizer_name,
             "max_sequence_length": max_seq_length,
@@ -514,13 +507,13 @@ def write_dataset_statistics(
         },
     }
 
-    json_path = os.path.join(output_dir, "dataset_statistics.json")
-    with open(json_path, "w") as f:
+    json_path = output_dir / "dataset_statistics.json"
+    with json_path.open("w") as f:
         json.dump(stats_data, f, indent=2)
     logger.info(f"Written dataset statistics to {json_path}")
 
-    text_path = os.path.join(output_dir, "dataset_statistics.txt")
-    with open(text_path, "w") as f:
+    text_path = output_dir / "dataset_statistics.txt"
+    with text_path.open("w") as f:
         f.write("Dataset Statistics Report\n")
         f.write("=" * 80 + "\n")
         f.write(f"Generated: {timestamp}\n")

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -74,7 +74,7 @@ def _write_metadata_for_chunks(
 ) -> None:
     for chunk_idx, (chunk_start, chunk_end) in enumerate(chunk_boundaries):
         metadata_filename = f"{base_filename}_part_{chunk_idx:04d}.csv.gz"
-        with gzip.open(metadata_filename, "wt") as f:
+        with gzip.open(metadata_filename, "wt", encoding="utf-8") as f:
             for doc_start, doc_end in document_boundaries:
                 if doc_end > chunk_start and doc_start < chunk_end:
                     adjusted_start = max(0, int(doc_start) - chunk_start)

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -9,13 +9,10 @@ The output layout for each `output_dir` is:
 """
 
 import gzip
-import itertools
 import json
 import os
-import pathlib
 import sys
 import time
-from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, Literal
 
@@ -24,178 +21,45 @@ from tqdm import tqdm
 
 from open_instruct import dataset_transformation, logger_utils, utils
 
+_COLLECT_BATCH_SIZE = 1000
+_BEAKER_DESCRIPTION_INTERVAL_SECONDS = 30.0
+
 logger = logger_utils.setup_logger(__name__)
 
 
 _CHECKPOINT_FILENAME = "_checkpoint.json"
-_CHECKPOINT_TOKEN_IDS_FILENAME = "_checkpoint_token_ids.bin"
-_CHECKPOINT_LABELS_MASK_FILENAME = "_checkpoint_labels_mask.bin"
-_CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME = "_checkpoint_document_boundaries.bin"
-
-_CHECKPOINT_TOKEN_DTYPE = np.uint32
-_CHECKPOINT_LABELS_DTYPE = np.uint8
-_CHECKPOINT_BOUNDARIES_DTYPE = np.int64
+_TOKENS_PARTIAL_FILENAME = "_tokens.partial.bin"
+_LABELS_PARTIAL_FILENAME = "_labels.partial.bin"
 
 
-def _append_bytes(path: pathlib.Path, data: bytes) -> None:
-    with open(path, "ab") as f:
-        f.write(data)
-
-
-def _truncate_to(path: pathlib.Path, size: int) -> None:
-    if not path.exists():
-        raise RuntimeError(f"Checkpoint file {path} does not exist.")
-    current_size = path.stat().st_size
-    if current_size == size:
-        return
-    if current_size < size:
-        raise RuntimeError(
-            f"Checkpoint file {path} is smaller than expected ({current_size} < {size}); data is corrupted."
-        )
-    with open(path, "r+b") as f:
-        f.truncate(size)
-
-
-def save_checkpoint(
-    output_dir: pathlib.Path,
-    samples_processed: int,
-    token_ids: list[int],
-    labels_mask: list[int],
-    document_boundaries: list[tuple[int, int]],
-    scalar_state: dict[str, Any],
-    prev_tokens_written: int,
-    prev_samples_written: int,
-) -> tuple[int, int, int]:
-    """Append new array data to the binary files, then atomically update the JSON
-    metadata. Returns (tokens_written, samples_written, bytes_appended); the first
-    two should be passed back as prev_* on the next call.
-    """
-    tokens_path = output_dir / _CHECKPOINT_TOKEN_IDS_FILENAME
-    labels_path = output_dir / _CHECKPOINT_LABELS_MASK_FILENAME
-    boundaries_path = output_dir / _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME
-    json_path = output_dir / _CHECKPOINT_FILENAME
-
-    # The JSON file is rewritten atomically (write-temp + rename) *after* the binary
-    # appends, so it is the source of truth for how much has been durably committed.
-    # If a previous run crashed between the binary append and the JSON rename, the
-    # binary files may contain trailing bytes beyond `prev_*_written`. Truncate any
-    # such uncommitted bytes before appending this batch so the files stay in
-    # lock-step with the JSON metadata.
-    token_size = np.dtype(_CHECKPOINT_TOKEN_DTYPE).itemsize
-    labels_size = np.dtype(_CHECKPOINT_LABELS_DTYPE).itemsize
-    boundary_size = np.dtype(_CHECKPOINT_BOUNDARIES_DTYPE).itemsize
-    if prev_tokens_written > 0:
-        _truncate_to(tokens_path, prev_tokens_written * token_size)
-        _truncate_to(labels_path, prev_tokens_written * labels_size)
-    if prev_samples_written > 0:
-        _truncate_to(boundaries_path, prev_samples_written * 2 * boundary_size)
-
-    new_tokens = np.fromiter(
-        itertools.islice(token_ids, prev_tokens_written, None),
-        dtype=_CHECKPOINT_TOKEN_DTYPE,
-        count=len(token_ids) - prev_tokens_written,
-    ).tobytes()
-    new_labels = np.fromiter(
-        itertools.islice(labels_mask, prev_tokens_written, None),
-        dtype=_CHECKPOINT_LABELS_DTYPE,
-        count=len(labels_mask) - prev_tokens_written,
-    ).tobytes()
-    new_boundaries = np.asarray(
-        document_boundaries[prev_samples_written:], dtype=_CHECKPOINT_BOUNDARIES_DTYPE
-    ).tobytes()
-
-    _append_bytes(tokens_path, new_tokens)
-    _append_bytes(labels_path, new_labels)
-    _append_bytes(boundaries_path, new_boundaries)
-    bytes_appended = len(new_tokens) + len(new_labels) + len(new_boundaries)
-
-    tokens_written = len(token_ids)
-    samples_written = len(document_boundaries)
-
-    meta = {
-        **scalar_state,
-        "samples_processed": samples_processed,
-        "tokens_written": tokens_written,
-        "samples_written": samples_written,
-    }
-    tmp_path = json_path.with_suffix(json_path.suffix + ".tmp")
+def save_checkpoint(output_dir: str, checkpoint_data: dict[str, Any]) -> None:
+    checkpoint_path = os.path.join(output_dir, _CHECKPOINT_FILENAME)
+    tmp_path = checkpoint_path + ".tmp"
     with open(tmp_path, "w") as f:
-        json.dump(meta, f)
-    tmp_path.rename(json_path)
-
-    return tokens_written, samples_written, bytes_appended
+        json.dump(checkpoint_data, f)
+    os.rename(tmp_path, checkpoint_path)
 
 
-def load_checkpoint(output_dir: pathlib.Path) -> dict[str, Any] | None:
-    json_path = output_dir / _CHECKPOINT_FILENAME
-    if not json_path.exists():
-        return None
-    with open(json_path) as f:
-        meta = json.load(f)
-
-    if "token_ids" in meta:
-        document_boundaries = [tuple(b) for b in meta["document_boundaries"]]
-        return {
-            "samples_processed": meta["samples_processed"],
-            "token_ids": meta["token_ids"],
-            "labels_mask": meta["labels_mask"],
-            "document_boundaries": document_boundaries,
-            "current_position": meta["current_position"],
-            "num_samples_skipped": meta["num_samples_skipped"],
-            "per_dataset_counts": meta["per_dataset_counts"],
-            "per_dataset_tokens": meta["per_dataset_tokens"],
-            "per_dataset_trainable_tokens": meta["per_dataset_trainable_tokens"],
-            "per_dataset_filtered": meta["per_dataset_filtered"],
-            "tokens_written": 0,
-            "samples_written": 0,
-        }
-
-    tokens_written = meta["tokens_written"]
-    samples_written = meta["samples_written"]
-
-    tokens_path = output_dir / _CHECKPOINT_TOKEN_IDS_FILENAME
-    labels_path = output_dir / _CHECKPOINT_LABELS_MASK_FILENAME
-    boundaries_path = output_dir / _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME
-
-    if tokens_written > 0:
-        _truncate_to(tokens_path, tokens_written * np.dtype(_CHECKPOINT_TOKEN_DTYPE).itemsize)
-        _truncate_to(labels_path, tokens_written * np.dtype(_CHECKPOINT_LABELS_DTYPE).itemsize)
-    if samples_written > 0:
-        _truncate_to(boundaries_path, samples_written * 2 * np.dtype(_CHECKPOINT_BOUNDARIES_DTYPE).itemsize)
-
-    token_ids = np.fromfile(tokens_path, dtype=_CHECKPOINT_TOKEN_DTYPE, count=tokens_written).tolist()
-    labels_mask = np.fromfile(labels_path, dtype=_CHECKPOINT_LABELS_DTYPE, count=tokens_written).tolist()
-    boundaries_flat = np.fromfile(boundaries_path, dtype=_CHECKPOINT_BOUNDARIES_DTYPE, count=samples_written * 2)
-    boundaries_flat = boundaries_flat.reshape(-1, 2)
-    document_boundaries = [(int(s), int(e)) for s, e in boundaries_flat]
-
-    return {
-        "samples_processed": meta["samples_processed"],
-        "token_ids": token_ids,
-        "labels_mask": labels_mask,
-        "document_boundaries": document_boundaries,
-        "current_position": meta["current_position"],
-        "num_samples_skipped": meta["num_samples_skipped"],
-        "per_dataset_counts": meta["per_dataset_counts"],
-        "per_dataset_tokens": meta["per_dataset_tokens"],
-        "per_dataset_trainable_tokens": meta["per_dataset_trainable_tokens"],
-        "per_dataset_filtered": meta["per_dataset_filtered"],
-        "tokens_written": tokens_written,
-        "samples_written": samples_written,
-    }
+def load_checkpoint(output_dir: str) -> dict[str, Any] | None:
+    checkpoint_path = os.path.join(output_dir, _CHECKPOINT_FILENAME)
+    if os.path.exists(checkpoint_path):
+        with open(checkpoint_path) as f:
+            return json.load(f)
+    return None
 
 
-def remove_checkpoint(output_dir: pathlib.Path) -> None:
-    for filename in (
-        _CHECKPOINT_FILENAME,
-        _CHECKPOINT_TOKEN_IDS_FILENAME,
-        _CHECKPOINT_LABELS_MASK_FILENAME,
-        _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME,
-    ):
-        path = output_dir / filename
-        if path.exists():
-            path.unlink()
-            logger.info(f"Removed checkpoint file: {path}")
+def remove_checkpoint(output_dir: str) -> None:
+    checkpoint_path = os.path.join(output_dir, _CHECKPOINT_FILENAME)
+    if os.path.exists(checkpoint_path):
+        os.remove(checkpoint_path)
+        logger.info(f"Removed checkpoint file: {checkpoint_path}")
+
+
+def _remove_partial_files(output_dir: str) -> None:
+    for name in (_TOKENS_PARTIAL_FILENAME, _LABELS_PARTIAL_FILENAME):
+        path = os.path.join(output_dir, name)
+        if os.path.exists(path):
+            os.remove(path)
 
 
 def _select_token_dtype(vocab_size: int):
@@ -205,37 +69,58 @@ def _select_token_dtype(vocab_size: int):
     raise ValueError(f"Vocab size {vocab_size} is too big for any numpy integer dtype!")
 
 
-def _write_memmap_chunked(
-    base_filename: str, data: list[int], dtype, max_size_bytes: int = 1024**3
+def _write_memmap_chunked_from_file(
+    base_filename: str, source_path: str, total_items: int, dtype, max_size_gb: int = 1
 ) -> list[tuple[int, int]]:
     item_size = np.dtype(dtype).itemsize
-    chunk_size = max_size_bytes // item_size
+    chunk_size = int((max_size_gb * 1024**3) // item_size)
     chunk_boundaries: list[tuple[int, int]] = []
 
-    for i in range(0, len(data), chunk_size):
-        chunk_data = data[i : i + chunk_size]
-        filename = f"{base_filename}_part_{i // chunk_size:04d}.npy"
-        mmap = np.memmap(filename, mode="w+", dtype=dtype, shape=(len(chunk_data),))
-        mmap[:] = chunk_data
-        mmap.flush()
-        chunk_boundaries.append((i, i + len(chunk_data)))
-        logger.info(f"Written {filename} ({len(chunk_data) * item_size / 1024**3:.2f} GB)")
+    if total_items == 0:
+        return chunk_boundaries
+
+    src = np.memmap(source_path, mode="r", dtype=dtype, shape=(total_items,))
+    for chunk_idx, i in enumerate(range(0, total_items, chunk_size)):
+        end = min(i + chunk_size, total_items)
+        filename = f"{base_filename}_part_{chunk_idx:04d}.npy"
+        dst = np.memmap(filename, mode="w+", dtype=dtype, shape=(end - i,))
+        dst[:] = src[i:end]
+        dst.flush()
+        chunk_boundaries.append((i, end))
+        logger.info(f"Written {filename} ({(end - i) * item_size / 1024**3:.2f} GB)")
 
     return chunk_boundaries
+
+
+def _write_labels_memmap_from_file(output_dir: str, source_path: str, chunk_boundaries: list[tuple[int, int]]) -> None:
+    src = np.memmap(source_path, mode="r", dtype=np.uint8, shape=(sum(e - s for s, e in chunk_boundaries),))
+    for i, (start, end) in enumerate(chunk_boundaries):
+        filename = f"{output_dir}/labels_mask_part_{i:04d}.npy"
+        dst = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(end - start,))
+        dst[:] = src[start:end].astype(np.bool_)
+        dst.flush()
+        logger.info(f"Written {filename} ({(end - start) * np.dtype(np.bool_).itemsize / 1024**3:.2f} GB)")
 
 
 def _write_metadata_for_chunks(
     base_filename: str, document_boundaries: list[tuple[int, int]], chunk_boundaries: list[tuple[int, int]]
 ) -> None:
+    doc_idx = 0
+    num_docs = len(document_boundaries)
     for chunk_idx, (chunk_start, chunk_end) in enumerate(chunk_boundaries):
         metadata_filename = f"{base_filename}_part_{chunk_idx:04d}.csv.gz"
+        while doc_idx < num_docs and document_boundaries[doc_idx][1] <= chunk_start:
+            doc_idx += 1
         with gzip.open(metadata_filename, "wt") as f:
-            for doc_start, doc_end in document_boundaries:
+            scan_idx = doc_idx
+            while scan_idx < num_docs and document_boundaries[scan_idx][0] < chunk_end:
+                doc_start, doc_end = document_boundaries[scan_idx]
                 if doc_end > chunk_start and doc_start < chunk_end:
                     adjusted_start = max(0, doc_start - chunk_start)
                     adjusted_end = min(chunk_end - chunk_start, doc_end - chunk_start)
                     if adjusted_end > adjusted_start:
                         f.write(f"{adjusted_start},{adjusted_end}\n")
+                scan_idx += 1
         logger.info(f"Written metadata {metadata_filename}")
 
 
@@ -285,7 +170,6 @@ def convert_hf_to_numpy_sft(
     lets it pick up where it left off.
     """
     os.makedirs(output_dir, exist_ok=True)
-    output_path = pathlib.Path(output_dir)
 
     logger.info("Verify these values match the tokenizer config used in Olmo-core:")
     logger.info(f"Tokenizer vocab_size: {tc.tokenizer.vocab_size}")
@@ -325,30 +209,51 @@ def convert_hf_to_numpy_sft(
         logger.info(f"Selecting {num_examples} examples for debugging")
         train_dataset = train_dataset.select(range(num_examples))
 
-    checkpoint = load_checkpoint(output_path) if resume else None
+    vocab_size = tc.tokenizer.vocab_size
+    token_dtype = _select_token_dtype(vocab_size)
+    token_dtype_name = np.dtype(token_dtype).name
+    token_item_size = np.dtype(token_dtype).itemsize
+    logger.info(f"Using dtype '{token_dtype_name}' for token_ids based on vocab size {vocab_size}")
+
+    tokens_partial_path = os.path.join(output_dir, _TOKENS_PARTIAL_FILENAME)
+    labels_partial_path = os.path.join(output_dir, _LABELS_PARTIAL_FILENAME)
+
+    checkpoint = load_checkpoint(output_dir) if resume else None
     if checkpoint:
+        if checkpoint.get("token_dtype") != token_dtype_name:
+            raise ValueError(
+                f"Checkpoint token_dtype {checkpoint.get('token_dtype')!r} does not match current "
+                f"{token_dtype_name!r}. Refusing to resume."
+            )
+        if not (os.path.exists(tokens_partial_path) and os.path.exists(labels_partial_path)):
+            raise FileNotFoundError(
+                f"Checkpoint present but partial token/label files missing in {output_dir}. "
+                "Delete the checkpoint to restart."
+            )
         start_idx = checkpoint["samples_processed"]
-        token_ids = checkpoint["token_ids"]
-        labels_mask = checkpoint["labels_mask"]
-        document_boundaries = checkpoint["document_boundaries"]
+        document_boundaries = [tuple(b) for b in checkpoint["document_boundaries"]]
         current_position = checkpoint["current_position"]
         num_samples_skipped = checkpoint["num_samples_skipped"]
         per_dataset_counts = checkpoint["per_dataset_counts"]
         per_dataset_tokens = checkpoint["per_dataset_tokens"]
         per_dataset_trainable_tokens = checkpoint["per_dataset_trainable_tokens"]
         per_dataset_filtered = checkpoint["per_dataset_filtered"]
-        last_tokens_written = checkpoint["tokens_written"]
-        last_samples_written = checkpoint["samples_written"]
+        total_tokens = checkpoint["total_tokens"]
+        total_trainable_tokens = checkpoint["total_trainable_tokens"]
+        max_token_id = checkpoint["max_token_id"]
+        tokens_bytes = checkpoint["tokens_bytes"]
+        labels_bytes = checkpoint["labels_bytes"]
+        os.truncate(tokens_partial_path, tokens_bytes)
+        os.truncate(labels_partial_path, labels_bytes)
         logger.info("=== RESUMING from checkpoint ===")
         logger.info(f"  Samples already processed: {start_idx:,}")
-        logger.info(f"  Tokens collected: {len(token_ids):,}")
+        logger.info(f"  Tokens collected: {total_tokens:,}")
         logger.info(f"  Remaining samples: {len(train_dataset) - start_idx:,}")
     else:
         if resume:
             logger.info("No checkpoint found, starting from beginning...")
+        _remove_partial_files(output_dir)
         start_idx = 0
-        token_ids = []
-        labels_mask = []
         document_boundaries = []
         current_position = 0
         num_samples_skipped = 0
@@ -356,118 +261,160 @@ def convert_hf_to_numpy_sft(
         per_dataset_tokens = {}
         per_dataset_trainable_tokens = {}
         per_dataset_filtered = {}
-        last_tokens_written = 0
-        last_samples_written = 0
+        total_tokens = 0
+        total_trainable_tokens = 0
+        max_token_id = 0
 
     logger.info("Collecting tokens from dataset...")
-    sample: Mapping[str, Any]
     total_samples = len(train_dataset)
     loop_start_time = time.perf_counter()
     utils.maybe_update_beaker_description(
         current_step=start_idx, total_steps=total_samples, start_time=loop_start_time
     )
 
-    train_dataset_iter = train_dataset.select(range(start_idx, total_samples))
+    if start_idx >= total_samples:
+        train_dataset_iter = train_dataset.select([])
+    elif start_idx > 0:
+        train_dataset_iter = train_dataset.select(range(start_idx, total_samples))
+    else:
+        train_dataset_iter = train_dataset
 
-    for idx, sample in enumerate(
-        tqdm(
-            train_dataset_iter,
-            desc="Collecting tokens",
-            file=sys.stdout,
-            bar_format="{l_bar}{bar}{r_bar}\n",
-            mininterval=10.0,
-            initial=start_idx,
-            total=total_samples,
-        ),
-        start=start_idx,
-    ):
-        sample_length = len(sample[dataset_transformation.INPUT_IDS_KEY])
-        sample_tokens = sample[dataset_transformation.INPUT_IDS_KEY]
-        sample_labels = sample[dataset_transformation.LABELS_KEY]
-        dataset_source = sample.get(dataset_transformation.DATASET_ORIGIN_KEY, "unknown")
+    train_dataset_iter = train_dataset_iter.with_format("numpy")
 
-        if dataset_source not in per_dataset_counts:
-            per_dataset_counts[dataset_source] = 0
-            per_dataset_tokens[dataset_source] = 0
-            per_dataset_trainable_tokens[dataset_source] = 0
-            per_dataset_filtered[dataset_source] = 0
+    input_ids_key = dataset_transformation.INPUT_IDS_KEY
+    labels_key = dataset_transformation.LABELS_KEY
+    attention_mask_key = dataset_transformation.ATTENTION_MASK_KEY
+    dataset_source_key = dataset_transformation.DATASET_ORIGIN_KEY
 
-        per_dataset_counts[dataset_source] += 1
-        per_dataset_tokens[dataset_source] += sample_length
-        trainable_tokens_in_sample = sum(1 for label in sample_labels if label != -100)
-        per_dataset_trainable_tokens[dataset_source] += trainable_tokens_in_sample
+    progress = tqdm(
+        desc="Collecting tokens",
+        file=sys.stdout,
+        bar_format="{l_bar}{bar}{r_bar}\n",
+        mininterval=10.0,
+        initial=start_idx,
+        total=total_samples,
+    )
 
-        token_ids.extend(sample_tokens)
-        labels_mask.extend([1 if label != -100 else 0 for label in sample_labels])
-        document_boundaries.append((current_position, current_position + sample_length))
-        current_position += sample_length
+    collect_start = time.perf_counter()
+    utils.maybe_update_beaker_description(current_step=start_idx, total_steps=total_samples, start_time=collect_start)
+    last_description_update = collect_start
+    with open(tokens_partial_path, "ab") as tokens_fh, open(labels_partial_path, "ab") as labels_fh:
+        idx = start_idx - 1
+        last_checkpoint_idx = start_idx
+        for batch in train_dataset_iter.iter(batch_size=_COLLECT_BATCH_SIZE):
+            batch_input_ids = batch[input_ids_key]
+            batch_labels = batch[labels_key]
+            batch_attention = batch[attention_mask_key]
+            batch_sources = batch.get(dataset_source_key, ["unknown"] * len(batch_input_ids))
 
-        if all(label == -100 for label in sample_labels):
-            num_samples_skipped += 1
-            per_dataset_filtered[dataset_source] += 1
+            for sample_tokens, sample_labels, sample_attention, dataset_source in zip(
+                batch_input_ids, batch_labels, batch_attention, batch_sources
+            ):
+                idx += 1
+                sample_length = len(sample_tokens)
 
-        assert all(mask == 1 for mask in sample[dataset_transformation.ATTENTION_MASK_KEY]), (
-            f"Expected all attention mask values to be 1, but found: {sample[dataset_transformation.ATTENTION_MASK_KEY]}"
-        )
+                if dataset_source not in per_dataset_counts:
+                    per_dataset_counts[dataset_source] = 0
+                    per_dataset_tokens[dataset_source] = 0
+                    per_dataset_trainable_tokens[dataset_source] = 0
+                    per_dataset_filtered[dataset_source] = 0
 
-        if (idx + 1) % checkpoint_interval == 0 and idx > start_idx:
-            checkpoint_start = time.perf_counter()
-            last_tokens_written, last_samples_written, checkpoint_bytes = save_checkpoint(
-                output_path,
-                samples_processed=idx + 1,
-                token_ids=token_ids,
-                labels_mask=labels_mask,
-                document_boundaries=document_boundaries,
-                scalar_state={
-                    "current_position": current_position,
-                    "num_samples_skipped": num_samples_skipped,
-                    "per_dataset_counts": per_dataset_counts,
-                    "per_dataset_tokens": per_dataset_tokens,
-                    "per_dataset_trainable_tokens": per_dataset_trainable_tokens,
-                    "per_dataset_filtered": per_dataset_filtered,
-                },
-                prev_tokens_written=last_tokens_written,
-                prev_samples_written=last_samples_written,
-            )
-            elapsed = time.perf_counter() - checkpoint_start
-            logger.info(
-                f"Checkpoint saved at sample {idx + 1:,} ({len(token_ids):,} tokens) "
-                f"in {elapsed:.2f}s [{checkpoint_bytes / (1024 * 1024):.1f} MiB, "
-                f"{checkpoint_bytes / (1024 * 1024) / elapsed:.1f} MiB/s]"
-            )
-            utils.maybe_update_beaker_description(
-                current_step=idx + 1, total_steps=total_samples, start_time=loop_start_time
-            )
+                tokens_arr = np.asarray(sample_tokens, dtype=token_dtype)
+                labels_arr = np.asarray(sample_labels)
+                labels_mask = (labels_arr != -100).astype(np.uint8)
+                trainable_tokens_in_sample = int(labels_mask.sum())
+
+                tokens_arr.tofile(tokens_fh)
+                labels_mask.tofile(labels_fh)
+
+                if sample_length > 0:
+                    sample_max = int(tokens_arr.max())
+                    if sample_max > max_token_id:
+                        max_token_id = sample_max
+
+                document_boundaries.append((current_position, current_position + sample_length))
+                current_position += sample_length
+                total_tokens += sample_length
+                total_trainable_tokens += trainable_tokens_in_sample
+
+                per_dataset_counts[dataset_source] += 1
+                per_dataset_tokens[dataset_source] += sample_length
+                per_dataset_trainable_tokens[dataset_source] += trainable_tokens_in_sample
+
+                if trainable_tokens_in_sample == 0:
+                    num_samples_skipped += 1
+                    per_dataset_filtered[dataset_source] += 1
+
+                assert all(mask == 1 for mask in sample_attention), (
+                    f"Expected all attention mask values to be 1, but found: {sample_attention}"
+                )
+
+            progress.update(len(batch_input_ids))
+
+            now = time.perf_counter()
+            if now - last_description_update >= _BEAKER_DESCRIPTION_INTERVAL_SECONDS:
+                utils.maybe_update_beaker_description(
+                    current_step=idx + 1, total_steps=total_samples, start_time=collect_start
+                )
+                last_description_update = now
+
+            if idx + 1 - last_checkpoint_idx >= checkpoint_interval:
+                tokens_fh.flush()
+                labels_fh.flush()
+                os.fsync(tokens_fh.fileno())
+                os.fsync(labels_fh.fileno())
+                save_checkpoint(
+                    output_dir,
+                    {
+                        "samples_processed": idx + 1,
+                        "document_boundaries": document_boundaries,
+                        "current_position": current_position,
+                        "num_samples_skipped": num_samples_skipped,
+                        "per_dataset_counts": per_dataset_counts,
+                        "per_dataset_tokens": per_dataset_tokens,
+                        "per_dataset_trainable_tokens": per_dataset_trainable_tokens,
+                        "per_dataset_filtered": per_dataset_filtered,
+                        "total_tokens": total_tokens,
+                        "total_trainable_tokens": total_trainable_tokens,
+                        "max_token_id": max_token_id,
+                        "tokens_bytes": total_tokens * token_item_size,
+                        "labels_bytes": total_tokens,
+                        "token_dtype": token_dtype_name,
+                    },
+                )
+                last_checkpoint_idx = idx + 1
+                logger.info(f"Checkpoint saved at sample {idx + 1:,} ({total_tokens:,} tokens)")
+
+    progress.close()
+    utils.maybe_update_beaker_description(
+        current_step=total_samples, total_steps=total_samples, start_time=collect_start
+    )
+    collect_elapsed = time.perf_counter() - collect_start
+    samples_processed = max(0, total_samples - start_idx)
+    rate = samples_processed / collect_elapsed if collect_elapsed > 0 else 0.0
+    logger.info(f"Collect loop: {samples_processed:,} samples in {collect_elapsed:.2f}s ({rate:.1f} samples/s)")
+
+    train_dataset = dataset_transformation.remove_dataset_source_field(train_dataset)
 
     total_instances = len(train_dataset)
-    total_tokens = len(token_ids)
-    total_trainable_tokens = sum(labels_mask)
 
     logger.info(f"Total sequences: {total_instances}")
     logger.info(f"Total tokens: {total_tokens}")
-    logger.info(f"Maximum token ID: {max(token_ids) if token_ids else 0}")
+    logger.info(f"Maximum token ID: {max_token_id}")
     logger.info(f"Labels mask sum (trainable tokens): {total_trainable_tokens}")
     logger.info("Writing data to numpy files...")
     logger.info(f"Number of samples that should be skipped: {num_samples_skipped}")
 
-    vocab_size = tc.tokenizer.vocab_size
-    token_dtype = _select_token_dtype(vocab_size)
-    logger.info(f"Using dtype '{token_dtype}' for token_ids based on vocab size {vocab_size}")
-
     logger.info(f"Writing converted data to {output_dir}")
-    token_chunk_boundaries = _write_memmap_chunked(f"{output_dir}/token_ids", token_ids, token_dtype)
+    token_chunk_boundaries = _write_memmap_chunked_from_file(
+        f"{output_dir}/token_ids", tokens_partial_path, total_tokens, token_dtype
+    )
     _write_metadata_for_chunks(f"{output_dir}/token_ids", document_boundaries, token_chunk_boundaries)
-
-    for i, (start, end) in enumerate(token_chunk_boundaries):
-        chunk_data = labels_mask[start:end]
-        filename = f"{output_dir}/labels_mask_part_{i:04d}.npy"
-        mmap = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(len(chunk_data),))
-        mmap[:] = chunk_data
-        mmap.flush()
-        logger.info(f"Written {filename} ({len(chunk_data) * np.dtype(np.bool_).itemsize / 1024**3:.2f} GB)")
+    _write_labels_memmap_from_file(output_dir, labels_partial_path, token_chunk_boundaries)
 
     logger.info("Data conversion completed successfully!")
-    remove_checkpoint(output_path)
+    remove_checkpoint(output_dir)
+    _remove_partial_files(output_dir)
 
     write_dataset_statistics(
         output_dir=output_dir,

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -26,8 +26,11 @@ logger = logger_utils.setup_logger(__name__)
 
 
 _CHECKPOINT_FILENAME = "_checkpoint.json"
-_TOKENS_PARTIAL_FILENAME = "_tokens.partial.bin"
-_LABELS_PARTIAL_FILENAME = "_labels.partial.bin"
+_CHECKPOINT_TOKEN_IDS_FILENAME = "_checkpoint_token_ids.bin"
+_CHECKPOINT_LABELS_MASK_FILENAME = "_checkpoint_labels_mask.bin"
+_CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME = "_checkpoint_document_boundaries.bin"
+
+_CHECKPOINT_BOUNDARIES_DTYPE = np.int64
 
 
 def save_checkpoint(output_dir: str, checkpoint_data: dict[str, Any]) -> None:
@@ -47,7 +50,12 @@ def load_checkpoint(output_dir: str) -> dict[str, Any] | None:
 
 
 def remove_checkpoint(output_dir: str) -> None:
-    for name in (_CHECKPOINT_FILENAME, _TOKENS_PARTIAL_FILENAME, _LABELS_PARTIAL_FILENAME):
+    for name in (
+        _CHECKPOINT_FILENAME,
+        _CHECKPOINT_TOKEN_IDS_FILENAME,
+        _CHECKPOINT_LABELS_MASK_FILENAME,
+        _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME,
+    ):
         pathlib.Path(output_dir, name).unlink(missing_ok=True)
 
 
@@ -187,8 +195,10 @@ def convert_hf_to_numpy_sft(
     token_item_size = np.dtype(token_dtype).itemsize
     logger.info(f"Using dtype '{token_dtype_name}' for token_ids based on vocab size {vocab_size}")
 
-    tokens_partial_path = os.path.join(output_dir, _TOKENS_PARTIAL_FILENAME)
-    labels_partial_path = os.path.join(output_dir, _LABELS_PARTIAL_FILENAME)
+    tokens_path = os.path.join(output_dir, _CHECKPOINT_TOKEN_IDS_FILENAME)
+    labels_path = os.path.join(output_dir, _CHECKPOINT_LABELS_MASK_FILENAME)
+    boundaries_path = os.path.join(output_dir, _CHECKPOINT_DOCUMENT_BOUNDARIES_FILENAME)
+    boundary_item_size = np.dtype(_CHECKPOINT_BOUNDARIES_DTYPE).itemsize
 
     checkpoint = load_checkpoint(output_dir) if resume else None
     if checkpoint:
@@ -197,13 +207,12 @@ def convert_hf_to_numpy_sft(
                 f"Checkpoint token_dtype {checkpoint.get('token_dtype')!r} does not match current "
                 f"{token_dtype_name!r}. Refusing to resume."
             )
-        if not (os.path.exists(tokens_partial_path) and os.path.exists(labels_partial_path)):
+        if not (os.path.exists(tokens_path) and os.path.exists(labels_path) and os.path.exists(boundaries_path)):
             raise FileNotFoundError(
-                f"Checkpoint present but partial token/label files missing in {output_dir}. "
+                f"Checkpoint present but partial token/label/boundary files missing in {output_dir}. "
                 "Delete the checkpoint to restart."
             )
         start_idx = checkpoint["samples_processed"]
-        document_boundaries = [tuple(b) for b in checkpoint["document_boundaries"]]
         current_position = checkpoint["current_position"]
         num_samples_skipped = checkpoint["num_samples_skipped"]
         per_dataset_counts = checkpoint["per_dataset_counts"]
@@ -215,8 +224,12 @@ def convert_hf_to_numpy_sft(
         max_token_id = checkpoint["max_token_id"]
         tokens_bytes = checkpoint["tokens_bytes"]
         labels_bytes = checkpoint["labels_bytes"]
-        os.truncate(tokens_partial_path, tokens_bytes)
-        os.truncate(labels_partial_path, labels_bytes)
+        boundaries_bytes = checkpoint["boundaries_bytes"]
+        os.truncate(tokens_path, tokens_bytes)
+        os.truncate(labels_path, labels_bytes)
+        os.truncate(boundaries_path, boundaries_bytes)
+        boundaries_flat = np.fromfile(boundaries_path, dtype=_CHECKPOINT_BOUNDARIES_DTYPE).reshape(-1, 2)
+        document_boundaries = [(int(s), int(e)) for s, e in boundaries_flat]
         logger.info("=== RESUMING from checkpoint ===")
         logger.info(f"  Samples already processed: {start_idx:,}")
         logger.info(f"  Tokens collected: {total_tokens:,}")
@@ -266,7 +279,11 @@ def convert_hf_to_numpy_sft(
     collect_start = time.perf_counter()
     utils.maybe_update_beaker_description(current_step=start_idx, total_steps=total_samples, start_time=collect_start)
     last_description_update = collect_start
-    with open(tokens_partial_path, "ab") as tokens_fh, open(labels_partial_path, "ab") as labels_fh:
+    with (
+        open(tokens_path, "ab") as tokens_fh,
+        open(labels_path, "ab") as labels_fh,
+        open(boundaries_path, "ab") as boundaries_fh,
+    ):
         idx = start_idx - 1
         last_checkpoint_idx = start_idx
         for batch in train_dataset_iter.iter(batch_size=1000):
@@ -300,6 +317,10 @@ def convert_hf_to_numpy_sft(
                     if sample_max > max_token_id:
                         max_token_id = sample_max
 
+                boundary = np.array(
+                    [current_position, current_position + sample_length], dtype=_CHECKPOINT_BOUNDARIES_DTYPE
+                )
+                boundary.tofile(boundaries_fh)
                 document_boundaries.append((current_position, current_position + sample_length))
                 current_position += sample_length
                 total_tokens += sample_length
@@ -329,13 +350,14 @@ def convert_hf_to_numpy_sft(
             if idx + 1 - last_checkpoint_idx >= checkpoint_interval:
                 tokens_fh.flush()
                 labels_fh.flush()
+                boundaries_fh.flush()
                 os.fsync(tokens_fh.fileno())
                 os.fsync(labels_fh.fileno())
+                os.fsync(boundaries_fh.fileno())
                 save_checkpoint(
                     output_dir,
                     {
                         "samples_processed": idx + 1,
-                        "document_boundaries": document_boundaries,
                         "current_position": current_position,
                         "num_samples_skipped": num_samples_skipped,
                         "per_dataset_counts": per_dataset_counts,
@@ -347,6 +369,7 @@ def convert_hf_to_numpy_sft(
                         "max_token_id": max_token_id,
                         "tokens_bytes": total_tokens * token_item_size,
                         "labels_bytes": total_tokens,
+                        "boundaries_bytes": len(document_boundaries) * 2 * boundary_item_size,
                         "token_dtype": token_dtype_name,
                     },
                 )
@@ -373,13 +396,11 @@ def convert_hf_to_numpy_sft(
 
     logger.info(f"Writing converted data to {output_dir}")
     token_chunk_boundaries = _write_memmap_chunked_from_file(
-        f"{output_dir}/token_ids", tokens_partial_path, total_tokens, token_dtype
+        f"{output_dir}/token_ids", tokens_path, total_tokens, token_dtype
     )
     _write_metadata_for_chunks(f"{output_dir}/token_ids", document_boundaries, token_chunk_boundaries)
 
-    labels_src = (
-        np.memmap(labels_partial_path, mode="r", dtype=np.uint8, shape=(total_tokens,)) if total_tokens else None
-    )
+    labels_src = np.memmap(labels_path, mode="r", dtype=np.uint8, shape=(total_tokens,)) if total_tokens else None
     for i, (start, end) in enumerate(token_chunk_boundaries):
         filename = f"{output_dir}/labels_mask_part_{i:04d}.npy"
         mmap = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(end - start,))

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -380,6 +380,7 @@ def convert_hf_to_numpy_sft(
         initial=start_idx,
         total=total_samples,
     )
+    last_description_update = loop_start_time
     idx = start_idx - 1
     for batch in train_dataset_iter.iter(batch_size=1000):
         batch_input_ids = batch[input_ids_key]
@@ -448,8 +449,16 @@ def convert_hf_to_numpy_sft(
                 utils.maybe_update_beaker_description(
                     current_step=idx + 1, total_steps=total_samples, start_time=loop_start_time
                 )
+                last_description_update = time.perf_counter()
 
         progress.update(len(batch_input_ids))
+
+        now = time.perf_counter()
+        if now - last_description_update >= 30.0:
+            utils.maybe_update_beaker_description(
+                current_step=idx + 1, total_steps=total_samples, start_time=loop_start_time
+            )
+            last_description_update = now
     progress.close()
 
     total_instances = len(train_dataset)

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -35,9 +35,8 @@ def _select_token_dtype(vocab_size: int):
     raise ValueError(f"Vocab size {vocab_size} is too big for any numpy integer dtype!")
 
 
-def _flush_partial_files(*file_handles) -> None:
-    """Flush + fsync the given partial files so a crash leaves them recoverable."""
-    for fh in file_handles:
+def _flush_partial_files(tokens_fh, labels_fh, boundaries_fh) -> None:
+    for fh in (tokens_fh, labels_fh, boundaries_fh):
         fh.flush()
         os.fsync(fh.fileno())
 
@@ -102,11 +101,8 @@ def _save_tokenizer(tc: dataset_transformation.TokenizerConfig, output_dir: path
 def _recover_partial_state(
     tokens_path: pathlib.Path, labels_path: pathlib.Path, boundaries_path: pathlib.Path, token_item_size: int
 ) -> tuple[int, int]:
-    """Truncate the three partial files to a consistent state and return (num_samples, current_position).
-
-    Boundaries file is treated as the commit log: its last complete (start,end) pair determines
-    how many bytes of tokens/labels are valid. Any trailing bytes are truncated off.
-    """
+    # Boundaries file is the commit log: its last complete (start,end) pair determines how many
+    # bytes of tokens/labels are valid; trailing bytes from an incomplete write get truncated.
     for path in (tokens_path, labels_path, boundaries_path):
         if not path.exists():
             return 0, 0
@@ -141,12 +137,6 @@ def _aggregate_stats(
     total_tokens: int,
     token_dtype,
 ) -> dict[str, Any]:
-    """Compute per-dataset and overall statistics from the on-disk partial files.
-
-    Runs once at the end. Reads the dataset_source column directly from the HF
-    dataset (cheap Arrow column access; no tokenization), then aggregates via
-    vectorized numpy ops over the labels/boundaries partial files.
-    """
     per_dataset_counts: dict[str, int] = {}
     per_dataset_tokens: dict[str, int] = {}
     per_dataset_trainable_tokens: dict[str, int] = {}
@@ -229,12 +219,6 @@ def convert_hf_to_numpy_sft(
     num_examples: int = 0,
     batch_size: int = 1000,
 ) -> None:
-    """Tokenize `dataset_mixer_list` and write OLMo-core numpy SFT files to `output_dir`.
-
-    Tokens/labels/boundaries stream directly to `_*.partial.bin` files in `output_dir`.
-    If `resume=True` and those files already exist, the run continues from where the
-    previous one left off. On successful completion, the partial files are deleted.
-    """
     output_dir.mkdir(parents=True, exist_ok=True)
 
     logger.info("Verify these values match the tokenizer config used in Olmo-core:")
@@ -277,9 +261,8 @@ def convert_hf_to_numpy_sft(
 
     vocab_size = tc.tokenizer.vocab_size
     token_dtype = _select_token_dtype(vocab_size)
-    token_dtype_name = np.dtype(token_dtype).name
     token_item_size = np.dtype(token_dtype).itemsize
-    logger.info(f"Using dtype '{token_dtype_name}' for token_ids based on vocab size {vocab_size}")
+    logger.info(f"Using dtype '{np.dtype(token_dtype).name}' for token_ids based on vocab size {vocab_size}")
 
     tokens_path = output_dir / "_tokens.partial.bin"
     labels_path = output_dir / "_labels.partial.bin"
@@ -302,10 +285,8 @@ def convert_hf_to_numpy_sft(
     total_samples = len(train_dataset)
     logger.info("Collecting tokens from dataset...")
 
-    if start_idx >= total_samples:
-        train_dataset_iter = train_dataset.select([])
-    elif start_idx > 0:
-        train_dataset_iter = train_dataset.select(range(start_idx, total_samples))
+    if start_idx > 0:
+        train_dataset_iter = train_dataset.select(range(min(start_idx, total_samples), total_samples))
     else:
         train_dataset_iter = train_dataset
 

--- a/open_instruct/numpy_dataset_conversion.py
+++ b/open_instruct/numpy_dataset_conversion.py
@@ -22,9 +22,6 @@ from tqdm import tqdm
 
 from open_instruct import dataset_transformation, logger_utils, utils
 
-_COLLECT_BATCH_SIZE = 1000
-_BEAKER_DESCRIPTION_INTERVAL_SECONDS = 30.0
-
 logger = logger_utils.setup_logger(__name__)
 
 
@@ -49,8 +46,8 @@ def load_checkpoint(output_dir: str) -> dict[str, Any] | None:
     return None
 
 
-def _remove_partial_files(output_dir: str) -> None:
-    for name in (_TOKENS_PARTIAL_FILENAME, _LABELS_PARTIAL_FILENAME):
+def remove_checkpoint(output_dir: str) -> None:
+    for name in (_CHECKPOINT_FILENAME, _TOKENS_PARTIAL_FILENAME, _LABELS_PARTIAL_FILENAME):
         pathlib.Path(output_dir, name).unlink(missing_ok=True)
 
 
@@ -84,35 +81,18 @@ def _write_memmap_chunked_from_file(
     return chunk_boundaries
 
 
-def _write_labels_memmap_from_file(output_dir: str, source_path: str, chunk_boundaries: list[tuple[int, int]]) -> None:
-    src = np.memmap(source_path, mode="r", dtype=np.uint8, shape=(sum(e - s for s, e in chunk_boundaries),))
-    for i, (start, end) in enumerate(chunk_boundaries):
-        filename = f"{output_dir}/labels_mask_part_{i:04d}.npy"
-        dst = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(end - start,))
-        dst[:] = src[start:end].astype(np.bool_)
-        dst.flush()
-        logger.info(f"Written {filename} ({(end - start) * np.dtype(np.bool_).itemsize / 1024**3:.2f} GB)")
-
-
 def _write_metadata_for_chunks(
     base_filename: str, document_boundaries: list[tuple[int, int]], chunk_boundaries: list[tuple[int, int]]
 ) -> None:
-    doc_idx = 0
-    num_docs = len(document_boundaries)
     for chunk_idx, (chunk_start, chunk_end) in enumerate(chunk_boundaries):
         metadata_filename = f"{base_filename}_part_{chunk_idx:04d}.csv.gz"
-        while doc_idx < num_docs and document_boundaries[doc_idx][1] <= chunk_start:
-            doc_idx += 1
         with gzip.open(metadata_filename, "wt") as f:
-            scan_idx = doc_idx
-            while scan_idx < num_docs and document_boundaries[scan_idx][0] < chunk_end:
-                doc_start, doc_end = document_boundaries[scan_idx]
+            for doc_start, doc_end in document_boundaries:
                 if doc_end > chunk_start and doc_start < chunk_end:
                     adjusted_start = max(0, doc_start - chunk_start)
                     adjusted_end = min(chunk_end - chunk_start, doc_end - chunk_start)
                     if adjusted_end > adjusted_start:
                         f.write(f"{adjusted_start},{adjusted_end}\n")
-                scan_idx += 1
         logger.info(f"Written metadata {metadata_filename}")
 
 
@@ -244,7 +224,7 @@ def convert_hf_to_numpy_sft(
     else:
         if resume:
             logger.info("No checkpoint found, starting from beginning...")
-        _remove_partial_files(output_dir)
+        remove_checkpoint(output_dir)
         start_idx = 0
         document_boundaries = []
         current_position = 0
@@ -289,7 +269,7 @@ def convert_hf_to_numpy_sft(
     with open(tokens_partial_path, "ab") as tokens_fh, open(labels_partial_path, "ab") as labels_fh:
         idx = start_idx - 1
         last_checkpoint_idx = start_idx
-        for batch in train_dataset_iter.iter(batch_size=_COLLECT_BATCH_SIZE):
+        for batch in train_dataset_iter.iter(batch_size=1000):
             batch_input_ids = batch[input_ids_key]
             batch_labels = batch[labels_key]
             batch_attention = batch[attention_mask_key]
@@ -340,7 +320,7 @@ def convert_hf_to_numpy_sft(
             progress.update(len(batch_input_ids))
 
             now = time.perf_counter()
-            if now - last_description_update >= _BEAKER_DESCRIPTION_INTERVAL_SECONDS:
+            if now - last_description_update >= 30.0:
                 utils.maybe_update_beaker_description(
                     current_step=idx + 1, total_steps=total_samples, start_time=collect_start
                 )
@@ -382,8 +362,6 @@ def convert_hf_to_numpy_sft(
     rate = samples_processed / collect_elapsed if collect_elapsed > 0 else 0.0
     logger.info(f"Collect loop: {samples_processed:,} samples in {collect_elapsed:.2f}s ({rate:.1f} samples/s)")
 
-    train_dataset = dataset_transformation.remove_dataset_source_field(train_dataset)
-
     total_instances = len(train_dataset)
 
     logger.info(f"Total sequences: {total_instances}")
@@ -398,11 +376,19 @@ def convert_hf_to_numpy_sft(
         f"{output_dir}/token_ids", tokens_partial_path, total_tokens, token_dtype
     )
     _write_metadata_for_chunks(f"{output_dir}/token_ids", document_boundaries, token_chunk_boundaries)
-    _write_labels_memmap_from_file(output_dir, labels_partial_path, token_chunk_boundaries)
+
+    labels_src = (
+        np.memmap(labels_partial_path, mode="r", dtype=np.uint8, shape=(total_tokens,)) if total_tokens else None
+    )
+    for i, (start, end) in enumerate(token_chunk_boundaries):
+        filename = f"{output_dir}/labels_mask_part_{i:04d}.npy"
+        mmap = np.memmap(filename, mode="w+", dtype=np.bool_, shape=(end - start,))
+        mmap[:] = labels_src[start:end].astype(np.bool_)
+        mmap.flush()
+        logger.info(f"Written {filename} ({(end - start) * np.dtype(np.bool_).itemsize / 1024**3:.2f} GB)")
 
     logger.info("Data conversion completed successfully!")
-    pathlib.Path(output_dir, _CHECKPOINT_FILENAME).unlink(missing_ok=True)
-    _remove_partial_files(output_dir)
+    remove_checkpoint(output_dir)
 
     write_dataset_statistics(
         output_dir=output_dir,

--- a/open_instruct/test_numpy_dataset_conversion.py
+++ b/open_instruct/test_numpy_dataset_conversion.py
@@ -8,6 +8,7 @@ import gc
 import gzip
 import json
 import os
+import pathlib
 import shutil
 import tempfile
 import unittest
@@ -63,8 +64,8 @@ class TestWriteMemmapChunked(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp_dir.cleanup)
-        self.base = os.path.join(self.tmp_dir.name, "token_ids")
-        self.source_path = os.path.join(self.tmp_dir.name, "source.bin")
+        self.base = pathlib.Path(self.tmp_dir.name) / "token_ids"
+        self.source_path = pathlib.Path(self.tmp_dir.name) / "source.bin"
 
     def _write_source(self, data, dtype):
         np.asarray(data, dtype=dtype).tofile(self.source_path)
@@ -106,7 +107,7 @@ class TestWriteMetadataForChunks(unittest.TestCase):
     def setUp(self):
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp_dir.cleanup)
-        self.base = os.path.join(self.tmp_dir.name, "token_ids")
+        self.base = pathlib.Path(self.tmp_dir.name) / "token_ids"
 
     def _read_chunk_rows(self, chunk_idx):
         path = f"{self.base}_part_{chunk_idx:04d}.csv.gz"
@@ -141,7 +142,7 @@ class TestSaveTokenizer(unittest.TestCase):
         )
 
     def test_saves_tokenizer_files(self):
-        numpy_dataset_conversion._save_tokenizer(self.tc, self.tmp_dir.name)
+        numpy_dataset_conversion._save_tokenizer(self.tc, pathlib.Path(self.tmp_dir.name))
         tokenizer_dir = os.path.join(self.tmp_dir.name, "tokenizer")
         self.assertTrue(os.path.isdir(tokenizer_dir))
         self.assertTrue(os.path.exists(os.path.join(tokenizer_dir, "tokenizer_config.json")))
@@ -180,7 +181,7 @@ class TestWriteDatasetStatistics(unittest.TestCase):
             ]
         }
         numpy_dataset_conversion.write_dataset_statistics(
-            output_dir=self.tmp_dir.name,
+            output_dir=pathlib.Path(self.tmp_dir.name),
             dataset_statistics=dataset_stats,
             total_instances=13,
             total_tokens=1000,
@@ -214,7 +215,7 @@ class TestWriteDatasetStatistics(unittest.TestCase):
 
     def test_zero_totals_does_not_divide_by_zero(self):
         numpy_dataset_conversion.write_dataset_statistics(
-            output_dir=self.tmp_dir.name,
+            output_dir=pathlib.Path(self.tmp_dir.name),
             dataset_statistics={"per_dataset_stats": []},
             total_instances=0,
             total_tokens=0,
@@ -271,7 +272,7 @@ class TestConvertHfToNumpySft(unittest.TestCase):
         )
 
     def test_end_to_end_small(self):
-        output_dir = os.path.join(self.temp_dir.name, "out_e2e")
+        output_dir = pathlib.Path(self.temp_dir.name) / "out_e2e"
         numpy_dataset_conversion.convert_hf_to_numpy_sft(
             output_dir=output_dir,
             dataset_mixer_list=[os.path.join(TEST_DATA_DIR, "sft_sample.jsonl"), "1.0"],
@@ -284,21 +285,21 @@ class TestConvertHfToNumpySft(unittest.TestCase):
             dataset_local_cache_dir=self.temp_dir.name,
             num_examples=2,
         )
-        token_file = os.path.join(output_dir, "token_ids_part_0000.npy")
-        labels_file = os.path.join(output_dir, "labels_mask_part_0000.npy")
-        metadata_file = os.path.join(output_dir, "token_ids_part_0000.csv.gz")
-        stats_json = os.path.join(output_dir, "dataset_statistics.json")
+        token_file = output_dir / "token_ids_part_0000.npy"
+        labels_file = output_dir / "labels_mask_part_0000.npy"
+        metadata_file = output_dir / "token_ids_part_0000.csv.gz"
+        stats_json = output_dir / "dataset_statistics.json"
 
-        self.assertTrue(os.path.exists(token_file))
-        self.assertTrue(os.path.exists(labels_file))
-        self.assertTrue(os.path.exists(metadata_file))
-        self.assertTrue(os.path.exists(stats_json))
-        self.assertTrue(os.path.isdir(os.path.join(output_dir, "tokenizer")))
+        self.assertTrue(token_file.exists())
+        self.assertTrue(labels_file.exists())
+        self.assertTrue(metadata_file.exists())
+        self.assertTrue(stats_json.exists())
+        self.assertTrue((output_dir / "tokenizer").is_dir())
         for partial in ("_tokens.partial.bin", "_labels.partial.bin", "_boundaries.partial.bin"):
-            self.assertFalse(os.path.exists(os.path.join(output_dir, partial)))
+            self.assertFalse((output_dir / partial).exists())
 
-        token_size = os.path.getsize(token_file)
-        labels_size = os.path.getsize(labels_file)
+        token_size = token_file.stat().st_size
+        labels_size = labels_file.stat().st_size
         self.assertGreater(token_size, 0)
         self.assertGreater(labels_size, 0)
 
@@ -359,10 +360,10 @@ class TestResumeEquivalence(unittest.TestCase):
         )
 
     def test_one_shot_matches_interrupt_plus_resume(self):
-        golden = os.path.join(self.temp_dir.name, "golden")
+        golden = pathlib.Path(self.temp_dir.name) / "golden"
         self._run(golden, resume=False)
 
-        interrupted = os.path.join(self.temp_dir.name, "interrupted")
+        interrupted = pathlib.Path(self.temp_dir.name) / "interrupted"
         real_flush = numpy_dataset_conversion._flush_partial_files
         call_count = {"n": 0}
 
@@ -380,26 +381,25 @@ class TestResumeEquivalence(unittest.TestCase):
             self._run(interrupted, resume=False)
 
         self.assertTrue(
-            os.path.exists(os.path.join(interrupted, "_boundaries.partial.bin")),
-            "interrupted run should have left partial files behind",
+            (interrupted / "_boundaries.partial.bin").exists(), "interrupted run should have left partial files behind"
         )
 
         self._run(interrupted, resume=True)
 
         artifacts = sorted(
-            name
-            for name in os.listdir(golden)
-            if name.startswith("token_ids_part_") or name.startswith("labels_mask_part_")
+            p.name
+            for p in golden.iterdir()
+            if p.name.startswith("token_ids_part_") or p.name.startswith("labels_mask_part_")
         )
         self.assertGreater(len(artifacts), 0, "golden run produced no artifacts")
         for name in artifacts:
-            golden_path = os.path.join(golden, name)
-            interrupted_path = os.path.join(interrupted, name)
+            golden_path = golden / name
+            interrupted_path = interrupted / name
             if name.endswith(".gz"):
                 with gzip.open(golden_path, "rb") as f1, gzip.open(interrupted_path, "rb") as f2:
                     self.assertEqual(f1.read(), f2.read(), msg=f"mismatch in {name}")
             else:
-                with open(golden_path, "rb") as f1, open(interrupted_path, "rb") as f2:
+                with golden_path.open("rb") as f1, interrupted_path.open("rb") as f2:
                     self.assertEqual(f1.read(), f2.read(), msg=f"mismatch in {name}")
 
 

--- a/open_instruct/test_numpy_dataset_conversion.py
+++ b/open_instruct/test_numpy_dataset_conversion.py
@@ -8,13 +8,13 @@ import gc
 import gzip
 import json
 import os
-import pathlib
 import shutil
 import tempfile
 import unittest
 import unittest.mock
 
 import numpy as np
+from parameterized import parameterized
 
 from open_instruct import dataset_transformation, numpy_dataset_conversion
 
@@ -38,106 +38,25 @@ def _get_tokenizer_path():
 TOKENIZER_PATH = _get_tokenizer_path()
 
 
-class TestIncrementalCheckpoint(unittest.TestCase):
-    def setUp(self):
-        self.tmp_dir = tempfile.TemporaryDirectory()
-        self.addCleanup(self.tmp_dir.cleanup)
-        self.output_dir = pathlib.Path(self.tmp_dir.name)
+class TestSelectTokenDtype(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("uint8_small", 2, np.uint8),
+            ("uint8_max", 256, np.uint8),
+            ("uint16_min", 257, np.uint16),
+            ("uint16_max", 65536, np.uint16),
+            ("uint32_min", 65537, np.uint32),
+            ("uint32_max", 2**32, np.uint32),
+            ("uint64_min", 2**32 + 1, np.uint64),
+        ]
+    )
+    def test_selects_expected_dtype(self, _name, vocab_size, expected_dtype):
+        result = numpy_dataset_conversion._select_token_dtype(vocab_size)
+        self.assertEqual(result, expected_dtype)
 
-    def _scalar_state(self):
-        return {
-            "current_position": 0,
-            "num_samples_skipped": 0,
-            "per_dataset_counts": {},
-            "per_dataset_tokens": {},
-            "per_dataset_trainable_tokens": {},
-            "per_dataset_filtered": {},
-        }
-
-    def test_incremental_save_appends_only_new_data(self):
-        token_ids = [1, 2, 3]
-        labels_mask = [1, 0, 1]
-        document_boundaries = [(0, 3)]
-        tw1, sw1, _ = numpy_dataset_conversion.save_checkpoint(
-            self.output_dir,
-            samples_processed=1,
-            token_ids=token_ids,
-            labels_mask=labels_mask,
-            document_boundaries=document_boundaries,
-            scalar_state=self._scalar_state(),
-            prev_tokens_written=0,
-            prev_samples_written=0,
-        )
-
-        tokens_path = self.output_dir / "_checkpoint_token_ids.bin"
-        size_after_first = tokens_path.stat().st_size
-
-        token_ids.extend([4, 5, 6, 7])
-        labels_mask.extend([0, 0, 1, 1])
-        document_boundaries.append((3, 7))
-
-        tw2, sw2, _ = numpy_dataset_conversion.save_checkpoint(
-            self.output_dir,
-            samples_processed=2,
-            token_ids=token_ids,
-            labels_mask=labels_mask,
-            document_boundaries=document_boundaries,
-            scalar_state=self._scalar_state(),
-            prev_tokens_written=tw1,
-            prev_samples_written=sw1,
-        )
-        size_after_second = tokens_path.stat().st_size
-
-        self.assertEqual(tw2, 7)
-        self.assertEqual(sw2, 2)
-        self.assertEqual(size_after_second - size_after_first, 4 * np.dtype(np.uint32).itemsize)
-
-        loaded = numpy_dataset_conversion.load_checkpoint(self.output_dir)
-        self.assertEqual(loaded["token_ids"], token_ids)
-        self.assertEqual(loaded["labels_mask"], labels_mask)
-        self.assertEqual(loaded["document_boundaries"], document_boundaries)
-
-    def test_load_raises_on_truncated_binary(self):
-        token_ids = [1, 2, 3, 4, 5]
-        labels_mask = [1, 0, 1, 0, 1]
-        document_boundaries = [(0, 5)]
-        numpy_dataset_conversion.save_checkpoint(
-            self.output_dir,
-            samples_processed=1,
-            token_ids=token_ids,
-            labels_mask=labels_mask,
-            document_boundaries=document_boundaries,
-            scalar_state=self._scalar_state(),
-            prev_tokens_written=0,
-            prev_samples_written=0,
-        )
-
-        tokens_path = self.output_dir / "_checkpoint_token_ids.bin"
-        with open(tokens_path, "r+b") as f:
-            f.truncate(np.dtype(np.uint32).itemsize)
-
-        with self.assertRaises(RuntimeError):
-            numpy_dataset_conversion.load_checkpoint(self.output_dir)
-
-    def test_load_raises_on_missing_binary(self):
-        token_ids = [1, 2, 3]
-        labels_mask = [1, 0, 1]
-        document_boundaries = [(0, 3)]
-        numpy_dataset_conversion.save_checkpoint(
-            self.output_dir,
-            samples_processed=1,
-            token_ids=token_ids,
-            labels_mask=labels_mask,
-            document_boundaries=document_boundaries,
-            scalar_state=self._scalar_state(),
-            prev_tokens_written=0,
-            prev_samples_written=0,
-        )
-
-        (self.output_dir / "_checkpoint_token_ids.bin").unlink()
-
-        with self.assertRaises(RuntimeError):
-            numpy_dataset_conversion.load_checkpoint(self.output_dir)
+    def test_raises_for_vocab_too_big(self):
+        with self.assertRaises(ValueError):
+            numpy_dataset_conversion._select_token_dtype(2**64 + 1)
 
 
 class TestWriteMemmapChunked(unittest.TestCase):
@@ -145,14 +64,38 @@ class TestWriteMemmapChunked(unittest.TestCase):
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp_dir.cleanup)
         self.base = os.path.join(self.tmp_dir.name, "token_ids")
+        self.source_path = os.path.join(self.tmp_dir.name, "source.bin")
+
+    def _write_source(self, data, dtype):
+        np.asarray(data, dtype=dtype).tofile(self.source_path)
 
     def _read_chunk(self, chunk_idx, dtype, length):
         filename = f"{self.base}_part_{chunk_idx:04d}.npy"
         return list(np.memmap(filename, mode="r", dtype=dtype, shape=(length,)))
 
+    def test_empty_data(self):
+        open(self.source_path, "wb").close()
+        result = numpy_dataset_conversion._write_memmap_chunked_from_file(
+            self.base, self.source_path, 0, np.uint16, max_size_gb=1
+        )
+        self.assertEqual(result, [])
+        self.assertFalse(os.path.exists(f"{self.base}_part_0000.npy"))
+
+    def test_single_chunk(self):
+        data = list(range(8))
+        self._write_source(data, np.uint16)
+        result = numpy_dataset_conversion._write_memmap_chunked_from_file(
+            self.base, self.source_path, len(data), np.uint16, max_size_gb=1
+        )
+        self.assertEqual(result, [(0, 8)])
+        self.assertEqual(self._read_chunk(0, np.uint16, 8), data)
+
     def test_three_chunks(self):
         data = list(range(17))
-        result = numpy_dataset_conversion._write_memmap_chunked(self.base, data, np.uint16, max_size_bytes=16)
+        self._write_source(data, np.uint16)
+        result = numpy_dataset_conversion._write_memmap_chunked_from_file(
+            self.base, self.source_path, len(data), np.uint16, max_size_gb=16 / 1024**3
+        )
         self.assertEqual(result, [(0, 8), (8, 16), (16, 17)])
         self.assertEqual(self._read_chunk(0, np.uint16, 8), data[0:8])
         self.assertEqual(self._read_chunk(1, np.uint16, 8), data[8:16])
@@ -176,6 +119,121 @@ class TestWriteMetadataForChunks(unittest.TestCase):
         numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
         self.assertEqual(self._read_chunk_rows(0), ["5,8"])
         self.assertEqual(self._read_chunk_rows(1), ["0,4"])
+
+    def test_doc_touching_boundary_is_excluded(self):
+        doc_boundaries = [(0, 8)]
+        chunk_boundaries = [(0, 8), (8, 16)]
+        numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
+        self.assertEqual(self._read_chunk_rows(0), ["0,8"])
+        self.assertEqual(self._read_chunk_rows(1), [])
+
+
+class TestSaveTokenizer(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+        self.tc = dataset_transformation.TokenizerConfig(
+            tokenizer_name_or_path=TOKENIZER_PATH,
+            tokenizer_revision="main",
+            use_fast=True,
+            chat_template_name="tulu",
+            add_bos=False,
+        )
+
+    def test_saves_tokenizer_files(self):
+        numpy_dataset_conversion._save_tokenizer(self.tc, self.tmp_dir.name)
+        tokenizer_dir = os.path.join(self.tmp_dir.name, "tokenizer")
+        self.assertTrue(os.path.isdir(tokenizer_dir))
+        self.assertTrue(os.path.exists(os.path.join(tokenizer_dir, "tokenizer_config.json")))
+
+
+class TestWriteDatasetStatistics(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+
+    def test_happy_path(self):
+        dataset_stats = {
+            "per_dataset_stats": [
+                {
+                    "dataset_name": "ds_a",
+                    "dataset_split": "train",
+                    "initial_instances": 10,
+                    "final_instances": 8,
+                    "instances_filtered": 2,
+                    "frac_or_num_samples": 1.0,
+                    "original_dataset_size": 10,
+                    "is_upsampled": False,
+                    "upsampling_factor": 1.0,
+                },
+                {
+                    "dataset_name": "ds_b",
+                    "dataset_split": "train",
+                    "initial_instances": 5,
+                    "final_instances": 5,
+                    "instances_filtered": 0,
+                    "frac_or_num_samples": 2.0,
+                    "original_dataset_size": 5,
+                    "is_upsampled": True,
+                    "upsampling_factor": 2.0,
+                },
+            ]
+        }
+        numpy_dataset_conversion.write_dataset_statistics(
+            output_dir=self.tmp_dir.name,
+            dataset_statistics=dataset_stats,
+            total_instances=13,
+            total_tokens=1000,
+            total_trainable_tokens=700,
+            num_samples_skipped=1,
+            tokenizer_name="test-tokenizer",
+            max_seq_length=4096,
+            chat_template_name="tulu",
+            per_dataset_counts={"ds_a": 8, "ds_b": 5},
+            per_dataset_tokens={"ds_a": 600, "ds_b": 400},
+            per_dataset_trainable_tokens={"ds_a": 400, "ds_b": 300},
+            per_dataset_filtered={"ds_a": 1, "ds_b": 0},
+        )
+
+        json_path = os.path.join(self.tmp_dir.name, "dataset_statistics.json")
+        with open(json_path) as f:
+            loaded = json.load(f)
+        self.assertEqual(loaded["overall_statistics"]["total_instances"], 13)
+        self.assertEqual(loaded["overall_statistics"]["total_tokens"], 1000)
+        self.assertEqual(loaded["overall_statistics"]["trainable_tokens"], 700)
+        self.assertEqual(len(loaded["per_dataset_statistics"]), 2)
+        names = {s["dataset_name"] for s in loaded["per_dataset_statistics"]}
+        self.assertEqual(names, {"ds_a", "ds_b"})
+
+        txt_path = os.path.join(self.tmp_dir.name, "dataset_statistics.txt")
+        with open(txt_path) as f:
+            txt = f.read()
+        self.assertIn("ds_a", txt)
+        self.assertIn("ds_b", txt)
+        self.assertIn("Overall Statistics", txt)
+
+    def test_zero_totals_does_not_divide_by_zero(self):
+        numpy_dataset_conversion.write_dataset_statistics(
+            output_dir=self.tmp_dir.name,
+            dataset_statistics={"per_dataset_stats": []},
+            total_instances=0,
+            total_tokens=0,
+            total_trainable_tokens=0,
+            num_samples_skipped=0,
+            tokenizer_name="test-tokenizer",
+            max_seq_length=None,
+            chat_template_name=None,
+            per_dataset_counts={"ds_a": 0},
+            per_dataset_tokens={"ds_a": 0},
+            per_dataset_trainable_tokens={"ds_a": 0},
+            per_dataset_filtered={"ds_a": 0},
+        )
+        with open(os.path.join(self.tmp_dir.name, "dataset_statistics.json")) as f:
+            loaded = json.load(f)
+        overall = loaded["overall_statistics"]
+        self.assertEqual(overall["trainable_percentage"], 0)
+        self.assertEqual(overall["average_sequence_length"], 0)
+        self.assertEqual(loaded["per_dataset_statistics"][0]["avg_tokens_per_instance"], 0)
 
 
 class TestConvertHfToNumpySft(unittest.TestCase):
@@ -230,14 +288,14 @@ class TestConvertHfToNumpySft(unittest.TestCase):
         labels_file = os.path.join(output_dir, "labels_mask_part_0000.npy")
         metadata_file = os.path.join(output_dir, "token_ids_part_0000.csv.gz")
         stats_json = os.path.join(output_dir, "dataset_statistics.json")
-        checkpoint_file = os.path.join(output_dir, "_checkpoint.json")
 
         self.assertTrue(os.path.exists(token_file))
         self.assertTrue(os.path.exists(labels_file))
         self.assertTrue(os.path.exists(metadata_file))
         self.assertTrue(os.path.exists(stats_json))
         self.assertTrue(os.path.isdir(os.path.join(output_dir, "tokenizer")))
-        self.assertFalse(os.path.exists(checkpoint_file))
+        for partial in ("_tokens.partial.bin", "_labels.partial.bin", "_boundaries.partial.bin"):
+            self.assertFalse(os.path.exists(os.path.join(output_dir, partial)))
 
         token_size = os.path.getsize(token_file)
         labels_size = os.path.getsize(labels_file)
@@ -284,7 +342,7 @@ class TestResumeEquivalence(unittest.TestCase):
             add_bos=False,
         )
 
-    def _run(self, output_dir, checkpoint_interval, resume):
+    def _run(self, output_dir, resume, batch_size=10):
         numpy_dataset_conversion.convert_hf_to_numpy_sft(
             output_dir=output_dir,
             dataset_mixer_list=[os.path.join(TEST_DATA_DIR, "sft_sample.jsonl"), "1.0"],
@@ -296,32 +354,37 @@ class TestResumeEquivalence(unittest.TestCase):
             dataset_skip_cache=True,
             dataset_local_cache_dir=self.temp_dir.name,
             num_examples=50,
-            checkpoint_interval=checkpoint_interval,
             resume=resume,
+            batch_size=batch_size,
         )
 
     def test_one_shot_matches_interrupt_plus_resume(self):
         golden = os.path.join(self.temp_dir.name, "golden")
-        self._run(golden, checkpoint_interval=1000, resume=False)
+        self._run(golden, resume=False)
 
         interrupted = os.path.join(self.temp_dir.name, "interrupted")
-        real_save = numpy_dataset_conversion.save_checkpoint
+        real_flush = numpy_dataset_conversion._flush_partial_files
         call_count = {"n": 0}
 
-        def fail_after_first(*args, **kwargs):
-            result = real_save(*args, **kwargs)
+        def fail_after_two(*args, **kwargs):
+            result = real_flush(*args, **kwargs)
             call_count["n"] += 1
-            if call_count["n"] == 1:
+            if call_count["n"] == 2:
                 raise RuntimeError("simulated interrupt")
             return result
 
         with (
-            unittest.mock.patch.object(numpy_dataset_conversion, "save_checkpoint", side_effect=fail_after_first),
+            unittest.mock.patch.object(numpy_dataset_conversion, "_flush_partial_files", side_effect=fail_after_two),
             self.assertRaises(RuntimeError),
         ):
-            self._run(interrupted, checkpoint_interval=10, resume=False)
+            self._run(interrupted, resume=False)
 
-        self._run(interrupted, checkpoint_interval=10, resume=True)
+        self.assertTrue(
+            os.path.exists(os.path.join(interrupted, "_boundaries.partial.bin")),
+            "interrupted run should have left partial files behind",
+        )
+
+        self._run(interrupted, resume=True)
 
         artifacts = sorted(
             name

--- a/open_instruct/test_numpy_dataset_conversion.py
+++ b/open_instruct/test_numpy_dataset_conversion.py
@@ -8,13 +8,13 @@ import gc
 import gzip
 import json
 import os
-import pathlib
 import shutil
 import tempfile
 import unittest
 import unittest.mock
 
 import numpy as np
+from parameterized import parameterized
 
 from open_instruct import dataset_transformation, numpy_dataset_conversion
 
@@ -38,106 +38,25 @@ def _get_tokenizer_path():
 TOKENIZER_PATH = _get_tokenizer_path()
 
 
-class TestIncrementalCheckpoint(unittest.TestCase):
-    def setUp(self):
-        self.tmp_dir = tempfile.TemporaryDirectory()
-        self.addCleanup(self.tmp_dir.cleanup)
-        self.output_dir = pathlib.Path(self.tmp_dir.name)
+class TestSelectTokenDtype(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("uint8_small", 2, np.uint8),
+            ("uint8_max", 256, np.uint8),
+            ("uint16_min", 257, np.uint16),
+            ("uint16_max", 65536, np.uint16),
+            ("uint32_min", 65537, np.uint32),
+            ("uint32_max", 2**32, np.uint32),
+            ("uint64_min", 2**32 + 1, np.uint64),
+        ]
+    )
+    def test_selects_expected_dtype(self, _name, vocab_size, expected_dtype):
+        result = numpy_dataset_conversion._select_token_dtype(vocab_size)
+        self.assertEqual(result, expected_dtype)
 
-    def _scalar_state(self):
-        return {
-            "current_position": 0,
-            "num_samples_skipped": 0,
-            "per_dataset_counts": {},
-            "per_dataset_tokens": {},
-            "per_dataset_trainable_tokens": {},
-            "per_dataset_filtered": {},
-        }
-
-    def test_incremental_save_appends_only_new_data(self):
-        token_ids = [1, 2, 3]
-        labels_mask = [1, 0, 1]
-        document_boundaries = [(0, 3)]
-        tw1, sw1, _ = numpy_dataset_conversion.save_checkpoint(
-            self.output_dir,
-            samples_processed=1,
-            token_ids=token_ids,
-            labels_mask=labels_mask,
-            document_boundaries=document_boundaries,
-            scalar_state=self._scalar_state(),
-            prev_tokens_written=0,
-            prev_samples_written=0,
-        )
-
-        tokens_path = self.output_dir / "_checkpoint_token_ids.bin"
-        size_after_first = tokens_path.stat().st_size
-
-        token_ids.extend([4, 5, 6, 7])
-        labels_mask.extend([0, 0, 1, 1])
-        document_boundaries.append((3, 7))
-
-        tw2, sw2, _ = numpy_dataset_conversion.save_checkpoint(
-            self.output_dir,
-            samples_processed=2,
-            token_ids=token_ids,
-            labels_mask=labels_mask,
-            document_boundaries=document_boundaries,
-            scalar_state=self._scalar_state(),
-            prev_tokens_written=tw1,
-            prev_samples_written=sw1,
-        )
-        size_after_second = tokens_path.stat().st_size
-
-        self.assertEqual(tw2, 7)
-        self.assertEqual(sw2, 2)
-        self.assertEqual(size_after_second - size_after_first, 4 * np.dtype(np.uint32).itemsize)
-
-        loaded = numpy_dataset_conversion.load_checkpoint(self.output_dir)
-        self.assertEqual(loaded["token_ids"], token_ids)
-        self.assertEqual(loaded["labels_mask"], labels_mask)
-        self.assertEqual(loaded["document_boundaries"], document_boundaries)
-
-    def test_load_raises_on_truncated_binary(self):
-        token_ids = [1, 2, 3, 4, 5]
-        labels_mask = [1, 0, 1, 0, 1]
-        document_boundaries = [(0, 5)]
-        numpy_dataset_conversion.save_checkpoint(
-            self.output_dir,
-            samples_processed=1,
-            token_ids=token_ids,
-            labels_mask=labels_mask,
-            document_boundaries=document_boundaries,
-            scalar_state=self._scalar_state(),
-            prev_tokens_written=0,
-            prev_samples_written=0,
-        )
-
-        tokens_path = self.output_dir / "_checkpoint_token_ids.bin"
-        with open(tokens_path, "r+b") as f:
-            f.truncate(np.dtype(np.uint32).itemsize)
-
-        with self.assertRaises(RuntimeError):
-            numpy_dataset_conversion.load_checkpoint(self.output_dir)
-
-    def test_load_raises_on_missing_binary(self):
-        token_ids = [1, 2, 3]
-        labels_mask = [1, 0, 1]
-        document_boundaries = [(0, 3)]
-        numpy_dataset_conversion.save_checkpoint(
-            self.output_dir,
-            samples_processed=1,
-            token_ids=token_ids,
-            labels_mask=labels_mask,
-            document_boundaries=document_boundaries,
-            scalar_state=self._scalar_state(),
-            prev_tokens_written=0,
-            prev_samples_written=0,
-        )
-
-        (self.output_dir / "_checkpoint_token_ids.bin").unlink()
-
-        with self.assertRaises(RuntimeError):
-            numpy_dataset_conversion.load_checkpoint(self.output_dir)
+    def test_raises_for_vocab_too_big(self):
+        with self.assertRaises(ValueError):
+            numpy_dataset_conversion._select_token_dtype(2**64 + 1)
 
 
 class TestWriteMemmapChunked(unittest.TestCase):
@@ -145,14 +64,38 @@ class TestWriteMemmapChunked(unittest.TestCase):
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp_dir.cleanup)
         self.base = os.path.join(self.tmp_dir.name, "token_ids")
+        self.source_path = os.path.join(self.tmp_dir.name, "source.bin")
+
+    def _write_source(self, data, dtype):
+        np.asarray(data, dtype=dtype).tofile(self.source_path)
 
     def _read_chunk(self, chunk_idx, dtype, length):
         filename = f"{self.base}_part_{chunk_idx:04d}.npy"
         return list(np.memmap(filename, mode="r", dtype=dtype, shape=(length,)))
 
+    def test_empty_data(self):
+        open(self.source_path, "wb").close()
+        result = numpy_dataset_conversion._write_memmap_chunked_from_file(
+            self.base, self.source_path, 0, np.uint16, max_size_gb=1
+        )
+        self.assertEqual(result, [])
+        self.assertFalse(os.path.exists(f"{self.base}_part_0000.npy"))
+
+    def test_single_chunk(self):
+        data = list(range(8))
+        self._write_source(data, np.uint16)
+        result = numpy_dataset_conversion._write_memmap_chunked_from_file(
+            self.base, self.source_path, len(data), np.uint16, max_size_gb=1
+        )
+        self.assertEqual(result, [(0, 8)])
+        self.assertEqual(self._read_chunk(0, np.uint16, 8), data)
+
     def test_three_chunks(self):
         data = list(range(17))
-        result = numpy_dataset_conversion._write_memmap_chunked(self.base, data, np.uint16, max_size_bytes=16)
+        self._write_source(data, np.uint16)
+        result = numpy_dataset_conversion._write_memmap_chunked_from_file(
+            self.base, self.source_path, len(data), np.uint16, max_size_gb=16 / 1024**3
+        )
         self.assertEqual(result, [(0, 8), (8, 16), (16, 17)])
         self.assertEqual(self._read_chunk(0, np.uint16, 8), data[0:8])
         self.assertEqual(self._read_chunk(1, np.uint16, 8), data[8:16])
@@ -170,12 +113,173 @@ class TestWriteMetadataForChunks(unittest.TestCase):
         with gzip.open(path, "rt") as f:
             return [line.strip() for line in f if line.strip()]
 
+    def test_empty_document_boundaries(self):
+        numpy_dataset_conversion._write_metadata_for_chunks(self.base, [], [(0, 8), (8, 16)])
+        self.assertEqual(self._read_chunk_rows(0), [])
+        self.assertEqual(self._read_chunk_rows(1), [])
+
+    def test_docs_entirely_within_single_chunk(self):
+        doc_boundaries = [(0, 3), (3, 8)]
+        chunk_boundaries = [(0, 8)]
+        numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
+        self.assertEqual(self._read_chunk_rows(0), ["0,3", "3,8"])
+
     def test_doc_spans_two_chunks(self):
         doc_boundaries = [(5, 12)]
         chunk_boundaries = [(0, 8), (8, 16)]
         numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
         self.assertEqual(self._read_chunk_rows(0), ["5,8"])
         self.assertEqual(self._read_chunk_rows(1), ["0,4"])
+
+    def test_doc_touching_boundary_is_excluded(self):
+        doc_boundaries = [(0, 8)]
+        chunk_boundaries = [(0, 8), (8, 16)]
+        numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
+        self.assertEqual(self._read_chunk_rows(0), ["0,8"])
+        self.assertEqual(self._read_chunk_rows(1), [])
+
+    def test_doc_aligned_to_chunk_start(self):
+        doc_boundaries = [(8, 12)]
+        chunk_boundaries = [(0, 8), (8, 16)]
+        numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
+        self.assertEqual(self._read_chunk_rows(0), [])
+        self.assertEqual(self._read_chunk_rows(1), ["0,4"])
+
+
+class TestSaveTokenizer(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+        self.tc = dataset_transformation.TokenizerConfig(
+            tokenizer_name_or_path=TOKENIZER_PATH,
+            tokenizer_revision="main",
+            use_fast=True,
+            chat_template_name="tulu",
+            add_bos=False,
+        )
+
+    def test_saves_tokenizer_files(self):
+        numpy_dataset_conversion._save_tokenizer(self.tc, self.tmp_dir.name)
+        tokenizer_dir = os.path.join(self.tmp_dir.name, "tokenizer")
+        self.assertTrue(os.path.isdir(tokenizer_dir))
+        self.assertTrue(os.path.exists(os.path.join(tokenizer_dir, "tokenizer_config.json")))
+
+    def test_creates_output_dir_if_missing(self):
+        nested = os.path.join(self.tmp_dir.name, "does", "not", "exist")
+        numpy_dataset_conversion._save_tokenizer(self.tc, nested)
+        self.assertTrue(os.path.isdir(os.path.join(nested, "tokenizer")))
+
+
+class TestWriteDatasetStatistics(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+
+    def test_happy_path(self):
+        dataset_stats = {
+            "per_dataset_stats": [
+                {
+                    "dataset_name": "ds_a",
+                    "dataset_split": "train",
+                    "initial_instances": 10,
+                    "final_instances": 8,
+                    "instances_filtered": 2,
+                    "frac_or_num_samples": 1.0,
+                    "original_dataset_size": 10,
+                    "is_upsampled": False,
+                    "upsampling_factor": 1.0,
+                },
+                {
+                    "dataset_name": "ds_b",
+                    "dataset_split": "train",
+                    "initial_instances": 5,
+                    "final_instances": 5,
+                    "instances_filtered": 0,
+                    "frac_or_num_samples": 2.0,
+                    "original_dataset_size": 5,
+                    "is_upsampled": True,
+                    "upsampling_factor": 2.0,
+                },
+            ]
+        }
+        numpy_dataset_conversion.write_dataset_statistics(
+            output_dir=self.tmp_dir.name,
+            dataset_statistics=dataset_stats,
+            total_instances=13,
+            total_tokens=1000,
+            total_trainable_tokens=700,
+            num_samples_skipped=1,
+            tokenizer_name="test-tokenizer",
+            max_seq_length=4096,
+            chat_template_name="tulu",
+            per_dataset_counts={"ds_a": 8, "ds_b": 5},
+            per_dataset_tokens={"ds_a": 600, "ds_b": 400},
+            per_dataset_trainable_tokens={"ds_a": 400, "ds_b": 300},
+            per_dataset_filtered={"ds_a": 1, "ds_b": 0},
+        )
+
+        json_path = os.path.join(self.tmp_dir.name, "dataset_statistics.json")
+        with open(json_path) as f:
+            loaded = json.load(f)
+        self.assertEqual(loaded["overall_statistics"]["total_instances"], 13)
+        self.assertEqual(loaded["overall_statistics"]["total_tokens"], 1000)
+        self.assertEqual(loaded["overall_statistics"]["trainable_tokens"], 700)
+        self.assertEqual(len(loaded["per_dataset_statistics"]), 2)
+        names = {s["dataset_name"] for s in loaded["per_dataset_statistics"]}
+        self.assertEqual(names, {"ds_a", "ds_b"})
+
+        txt_path = os.path.join(self.tmp_dir.name, "dataset_statistics.txt")
+        with open(txt_path) as f:
+            txt = f.read()
+        self.assertIn("ds_a", txt)
+        self.assertIn("ds_b", txt)
+        self.assertIn("Overall Statistics", txt)
+
+    def test_zero_totals_does_not_divide_by_zero(self):
+        numpy_dataset_conversion.write_dataset_statistics(
+            output_dir=self.tmp_dir.name,
+            dataset_statistics={"per_dataset_stats": []},
+            total_instances=0,
+            total_tokens=0,
+            total_trainable_tokens=0,
+            num_samples_skipped=0,
+            tokenizer_name="test-tokenizer",
+            max_seq_length=None,
+            chat_template_name=None,
+            per_dataset_counts={"ds_a": 0},
+            per_dataset_tokens={"ds_a": 0},
+            per_dataset_trainable_tokens={"ds_a": 0},
+            per_dataset_filtered={"ds_a": 0},
+        )
+        with open(os.path.join(self.tmp_dir.name, "dataset_statistics.json")) as f:
+            loaded = json.load(f)
+        overall = loaded["overall_statistics"]
+        self.assertEqual(overall["trainable_percentage"], 0)
+        self.assertEqual(overall["average_sequence_length"], 0)
+        self.assertEqual(loaded["per_dataset_statistics"][0]["avg_tokens_per_instance"], 0)
+
+    def test_missing_pre_transform_stats_falls_back(self):
+        numpy_dataset_conversion.write_dataset_statistics(
+            output_dir=self.tmp_dir.name,
+            dataset_statistics={"per_dataset_stats": []},
+            total_instances=5,
+            total_tokens=100,
+            total_trainable_tokens=50,
+            num_samples_skipped=0,
+            tokenizer_name="test-tokenizer",
+            max_seq_length=2048,
+            chat_template_name="tulu",
+            per_dataset_counts={"ds_x": 5},
+            per_dataset_tokens={"ds_x": 100},
+            per_dataset_trainable_tokens={"ds_x": 50},
+            per_dataset_filtered={"ds_x": 0},
+        )
+        with open(os.path.join(self.tmp_dir.name, "dataset_statistics.json")) as f:
+            loaded = json.load(f)
+        stat = loaded["per_dataset_statistics"][0]
+        self.assertEqual(stat["dataset_split"], "unknown")
+        self.assertEqual(stat["initial_instances"], "N/A")
+        self.assertEqual(stat["instances_after_transformation"], "N/A")
 
 
 class TestConvertHfToNumpySft(unittest.TestCase):
@@ -211,6 +315,22 @@ class TestConvertHfToNumpySft(unittest.TestCase):
             chat_template_name="tulu",
             add_bos=False,
         )
+
+    def test_tokenizer_config_only(self):
+        output_dir = os.path.join(self.temp_dir.name, "out")
+        numpy_dataset_conversion.convert_hf_to_numpy_sft(
+            output_dir=output_dir,
+            dataset_mixer_list=[os.path.join(TEST_DATA_DIR, "sft_sample.jsonl"), "1.0"],
+            dataset_mixer_list_splits=["train"],
+            tc=self._make_tc(),
+            dataset_transform_fn=["sft_tulu_tokenize_and_truncate_v1", "sft_tulu_filter_v1"],
+            transform_fn_args=[{"max_seq_length": 4096}, {}],
+            dataset_target_columns=dataset_transformation.TOKENIZED_SFT_DATASET_KEYS,
+            tokenizer_config_only=True,
+        )
+        self.assertTrue(os.path.isdir(os.path.join(output_dir, "tokenizer")))
+        self.assertFalse(os.path.exists(os.path.join(output_dir, "token_ids_part_0000.npy")))
+        self.assertFalse(os.path.exists(os.path.join(output_dir, "dataset_statistics.json")))
 
     def test_end_to_end_small(self):
         output_dir = os.path.join(self.temp_dir.name, "out_e2e")

--- a/open_instruct/test_numpy_dataset_conversion.py
+++ b/open_instruct/test_numpy_dataset_conversion.py
@@ -113,17 +113,6 @@ class TestWriteMetadataForChunks(unittest.TestCase):
         with gzip.open(path, "rt") as f:
             return [line.strip() for line in f if line.strip()]
 
-    def test_empty_document_boundaries(self):
-        numpy_dataset_conversion._write_metadata_for_chunks(self.base, [], [(0, 8), (8, 16)])
-        self.assertEqual(self._read_chunk_rows(0), [])
-        self.assertEqual(self._read_chunk_rows(1), [])
-
-    def test_docs_entirely_within_single_chunk(self):
-        doc_boundaries = [(0, 3), (3, 8)]
-        chunk_boundaries = [(0, 8)]
-        numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
-        self.assertEqual(self._read_chunk_rows(0), ["0,3", "3,8"])
-
     def test_doc_spans_two_chunks(self):
         doc_boundaries = [(5, 12)]
         chunk_boundaries = [(0, 8), (8, 16)]
@@ -137,13 +126,6 @@ class TestWriteMetadataForChunks(unittest.TestCase):
         numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
         self.assertEqual(self._read_chunk_rows(0), ["0,8"])
         self.assertEqual(self._read_chunk_rows(1), [])
-
-    def test_doc_aligned_to_chunk_start(self):
-        doc_boundaries = [(8, 12)]
-        chunk_boundaries = [(0, 8), (8, 16)]
-        numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
-        self.assertEqual(self._read_chunk_rows(0), [])
-        self.assertEqual(self._read_chunk_rows(1), ["0,4"])
 
 
 class TestSaveTokenizer(unittest.TestCase):
@@ -163,11 +145,6 @@ class TestSaveTokenizer(unittest.TestCase):
         tokenizer_dir = os.path.join(self.tmp_dir.name, "tokenizer")
         self.assertTrue(os.path.isdir(tokenizer_dir))
         self.assertTrue(os.path.exists(os.path.join(tokenizer_dir, "tokenizer_config.json")))
-
-    def test_creates_output_dir_if_missing(self):
-        nested = os.path.join(self.tmp_dir.name, "does", "not", "exist")
-        numpy_dataset_conversion._save_tokenizer(self.tc, nested)
-        self.assertTrue(os.path.isdir(os.path.join(nested, "tokenizer")))
 
 
 class TestWriteDatasetStatistics(unittest.TestCase):
@@ -258,29 +235,6 @@ class TestWriteDatasetStatistics(unittest.TestCase):
         self.assertEqual(overall["average_sequence_length"], 0)
         self.assertEqual(loaded["per_dataset_statistics"][0]["avg_tokens_per_instance"], 0)
 
-    def test_missing_pre_transform_stats_falls_back(self):
-        numpy_dataset_conversion.write_dataset_statistics(
-            output_dir=self.tmp_dir.name,
-            dataset_statistics={"per_dataset_stats": []},
-            total_instances=5,
-            total_tokens=100,
-            total_trainable_tokens=50,
-            num_samples_skipped=0,
-            tokenizer_name="test-tokenizer",
-            max_seq_length=2048,
-            chat_template_name="tulu",
-            per_dataset_counts={"ds_x": 5},
-            per_dataset_tokens={"ds_x": 100},
-            per_dataset_trainable_tokens={"ds_x": 50},
-            per_dataset_filtered={"ds_x": 0},
-        )
-        with open(os.path.join(self.tmp_dir.name, "dataset_statistics.json")) as f:
-            loaded = json.load(f)
-        stat = loaded["per_dataset_statistics"][0]
-        self.assertEqual(stat["dataset_split"], "unknown")
-        self.assertEqual(stat["initial_instances"], "N/A")
-        self.assertEqual(stat["instances_after_transformation"], "N/A")
-
 
 class TestConvertHfToNumpySft(unittest.TestCase):
     def setUp(self):
@@ -315,22 +269,6 @@ class TestConvertHfToNumpySft(unittest.TestCase):
             chat_template_name="tulu",
             add_bos=False,
         )
-
-    def test_tokenizer_config_only(self):
-        output_dir = os.path.join(self.temp_dir.name, "out")
-        numpy_dataset_conversion.convert_hf_to_numpy_sft(
-            output_dir=output_dir,
-            dataset_mixer_list=[os.path.join(TEST_DATA_DIR, "sft_sample.jsonl"), "1.0"],
-            dataset_mixer_list_splits=["train"],
-            tc=self._make_tc(),
-            dataset_transform_fn=["sft_tulu_tokenize_and_truncate_v1", "sft_tulu_filter_v1"],
-            transform_fn_args=[{"max_seq_length": 4096}, {}],
-            dataset_target_columns=dataset_transformation.TOKENIZED_SFT_DATASET_KEYS,
-            tokenizer_config_only=True,
-        )
-        self.assertTrue(os.path.isdir(os.path.join(output_dir, "tokenizer")))
-        self.assertFalse(os.path.exists(os.path.join(output_dir, "token_ids_part_0000.npy")))
-        self.assertFalse(os.path.exists(os.path.join(output_dir, "dataset_statistics.json")))
 
     def test_end_to_end_small(self):
         output_dir = os.path.join(self.temp_dir.name, "out_e2e")

--- a/open_instruct/test_numpy_dataset_conversion.py
+++ b/open_instruct/test_numpy_dataset_conversion.py
@@ -8,13 +8,13 @@ import gc
 import gzip
 import json
 import os
+import pathlib
 import shutil
 import tempfile
 import unittest
 import unittest.mock
 
 import numpy as np
-from parameterized import parameterized
 
 from open_instruct import dataset_transformation, numpy_dataset_conversion
 
@@ -38,25 +38,106 @@ def _get_tokenizer_path():
 TOKENIZER_PATH = _get_tokenizer_path()
 
 
-class TestSelectTokenDtype(unittest.TestCase):
-    @parameterized.expand(
-        [
-            ("uint8_small", 2, np.uint8),
-            ("uint8_max", 256, np.uint8),
-            ("uint16_min", 257, np.uint16),
-            ("uint16_max", 65536, np.uint16),
-            ("uint32_min", 65537, np.uint32),
-            ("uint32_max", 2**32, np.uint32),
-            ("uint64_min", 2**32 + 1, np.uint64),
-        ]
-    )
-    def test_selects_expected_dtype(self, _name, vocab_size, expected_dtype):
-        result = numpy_dataset_conversion._select_token_dtype(vocab_size)
-        self.assertEqual(result, expected_dtype)
+class TestIncrementalCheckpoint(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+        self.output_dir = pathlib.Path(self.tmp_dir.name)
 
-    def test_raises_for_vocab_too_big(self):
-        with self.assertRaises(ValueError):
-            numpy_dataset_conversion._select_token_dtype(2**64 + 1)
+    def _scalar_state(self):
+        return {
+            "current_position": 0,
+            "num_samples_skipped": 0,
+            "per_dataset_counts": {},
+            "per_dataset_tokens": {},
+            "per_dataset_trainable_tokens": {},
+            "per_dataset_filtered": {},
+        }
+
+    def test_incremental_save_appends_only_new_data(self):
+        token_ids = [1, 2, 3]
+        labels_mask = [1, 0, 1]
+        document_boundaries = [(0, 3)]
+        tw1, sw1, _ = numpy_dataset_conversion.save_checkpoint(
+            self.output_dir,
+            samples_processed=1,
+            token_ids=token_ids,
+            labels_mask=labels_mask,
+            document_boundaries=document_boundaries,
+            scalar_state=self._scalar_state(),
+            prev_tokens_written=0,
+            prev_samples_written=0,
+        )
+
+        tokens_path = self.output_dir / "_checkpoint_token_ids.bin"
+        size_after_first = tokens_path.stat().st_size
+
+        token_ids.extend([4, 5, 6, 7])
+        labels_mask.extend([0, 0, 1, 1])
+        document_boundaries.append((3, 7))
+
+        tw2, sw2, _ = numpy_dataset_conversion.save_checkpoint(
+            self.output_dir,
+            samples_processed=2,
+            token_ids=token_ids,
+            labels_mask=labels_mask,
+            document_boundaries=document_boundaries,
+            scalar_state=self._scalar_state(),
+            prev_tokens_written=tw1,
+            prev_samples_written=sw1,
+        )
+        size_after_second = tokens_path.stat().st_size
+
+        self.assertEqual(tw2, 7)
+        self.assertEqual(sw2, 2)
+        self.assertEqual(size_after_second - size_after_first, 4 * np.dtype(np.uint32).itemsize)
+
+        loaded = numpy_dataset_conversion.load_checkpoint(self.output_dir)
+        self.assertEqual(loaded["token_ids"], token_ids)
+        self.assertEqual(loaded["labels_mask"], labels_mask)
+        self.assertEqual(loaded["document_boundaries"], document_boundaries)
+
+    def test_load_raises_on_truncated_binary(self):
+        token_ids = [1, 2, 3, 4, 5]
+        labels_mask = [1, 0, 1, 0, 1]
+        document_boundaries = [(0, 5)]
+        numpy_dataset_conversion.save_checkpoint(
+            self.output_dir,
+            samples_processed=1,
+            token_ids=token_ids,
+            labels_mask=labels_mask,
+            document_boundaries=document_boundaries,
+            scalar_state=self._scalar_state(),
+            prev_tokens_written=0,
+            prev_samples_written=0,
+        )
+
+        tokens_path = self.output_dir / "_checkpoint_token_ids.bin"
+        with open(tokens_path, "r+b") as f:
+            f.truncate(np.dtype(np.uint32).itemsize)
+
+        with self.assertRaises(RuntimeError):
+            numpy_dataset_conversion.load_checkpoint(self.output_dir)
+
+    def test_load_raises_on_missing_binary(self):
+        token_ids = [1, 2, 3]
+        labels_mask = [1, 0, 1]
+        document_boundaries = [(0, 3)]
+        numpy_dataset_conversion.save_checkpoint(
+            self.output_dir,
+            samples_processed=1,
+            token_ids=token_ids,
+            labels_mask=labels_mask,
+            document_boundaries=document_boundaries,
+            scalar_state=self._scalar_state(),
+            prev_tokens_written=0,
+            prev_samples_written=0,
+        )
+
+        (self.output_dir / "_checkpoint_token_ids.bin").unlink()
+
+        with self.assertRaises(RuntimeError):
+            numpy_dataset_conversion.load_checkpoint(self.output_dir)
 
 
 class TestWriteMemmapChunked(unittest.TestCase):
@@ -64,38 +145,14 @@ class TestWriteMemmapChunked(unittest.TestCase):
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp_dir.cleanup)
         self.base = os.path.join(self.tmp_dir.name, "token_ids")
-        self.source_path = os.path.join(self.tmp_dir.name, "source.bin")
-
-    def _write_source(self, data, dtype):
-        np.asarray(data, dtype=dtype).tofile(self.source_path)
 
     def _read_chunk(self, chunk_idx, dtype, length):
         filename = f"{self.base}_part_{chunk_idx:04d}.npy"
         return list(np.memmap(filename, mode="r", dtype=dtype, shape=(length,)))
 
-    def test_empty_data(self):
-        open(self.source_path, "wb").close()
-        result = numpy_dataset_conversion._write_memmap_chunked_from_file(
-            self.base, self.source_path, 0, np.uint16, max_size_gb=1
-        )
-        self.assertEqual(result, [])
-        self.assertFalse(os.path.exists(f"{self.base}_part_0000.npy"))
-
-    def test_single_chunk(self):
-        data = list(range(8))
-        self._write_source(data, np.uint16)
-        result = numpy_dataset_conversion._write_memmap_chunked_from_file(
-            self.base, self.source_path, len(data), np.uint16, max_size_gb=1
-        )
-        self.assertEqual(result, [(0, 8)])
-        self.assertEqual(self._read_chunk(0, np.uint16, 8), data)
-
     def test_three_chunks(self):
         data = list(range(17))
-        self._write_source(data, np.uint16)
-        result = numpy_dataset_conversion._write_memmap_chunked_from_file(
-            self.base, self.source_path, len(data), np.uint16, max_size_gb=16 / 1024**3
-        )
+        result = numpy_dataset_conversion._write_memmap_chunked(self.base, data, np.uint16, max_size_bytes=16)
         self.assertEqual(result, [(0, 8), (8, 16), (16, 17)])
         self.assertEqual(self._read_chunk(0, np.uint16, 8), data[0:8])
         self.assertEqual(self._read_chunk(1, np.uint16, 8), data[8:16])
@@ -119,121 +176,6 @@ class TestWriteMetadataForChunks(unittest.TestCase):
         numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
         self.assertEqual(self._read_chunk_rows(0), ["5,8"])
         self.assertEqual(self._read_chunk_rows(1), ["0,4"])
-
-    def test_doc_touching_boundary_is_excluded(self):
-        doc_boundaries = [(0, 8)]
-        chunk_boundaries = [(0, 8), (8, 16)]
-        numpy_dataset_conversion._write_metadata_for_chunks(self.base, doc_boundaries, chunk_boundaries)
-        self.assertEqual(self._read_chunk_rows(0), ["0,8"])
-        self.assertEqual(self._read_chunk_rows(1), [])
-
-
-class TestSaveTokenizer(unittest.TestCase):
-    def setUp(self):
-        self.tmp_dir = tempfile.TemporaryDirectory()
-        self.addCleanup(self.tmp_dir.cleanup)
-        self.tc = dataset_transformation.TokenizerConfig(
-            tokenizer_name_or_path=TOKENIZER_PATH,
-            tokenizer_revision="main",
-            use_fast=True,
-            chat_template_name="tulu",
-            add_bos=False,
-        )
-
-    def test_saves_tokenizer_files(self):
-        numpy_dataset_conversion._save_tokenizer(self.tc, self.tmp_dir.name)
-        tokenizer_dir = os.path.join(self.tmp_dir.name, "tokenizer")
-        self.assertTrue(os.path.isdir(tokenizer_dir))
-        self.assertTrue(os.path.exists(os.path.join(tokenizer_dir, "tokenizer_config.json")))
-
-
-class TestWriteDatasetStatistics(unittest.TestCase):
-    def setUp(self):
-        self.tmp_dir = tempfile.TemporaryDirectory()
-        self.addCleanup(self.tmp_dir.cleanup)
-
-    def test_happy_path(self):
-        dataset_stats = {
-            "per_dataset_stats": [
-                {
-                    "dataset_name": "ds_a",
-                    "dataset_split": "train",
-                    "initial_instances": 10,
-                    "final_instances": 8,
-                    "instances_filtered": 2,
-                    "frac_or_num_samples": 1.0,
-                    "original_dataset_size": 10,
-                    "is_upsampled": False,
-                    "upsampling_factor": 1.0,
-                },
-                {
-                    "dataset_name": "ds_b",
-                    "dataset_split": "train",
-                    "initial_instances": 5,
-                    "final_instances": 5,
-                    "instances_filtered": 0,
-                    "frac_or_num_samples": 2.0,
-                    "original_dataset_size": 5,
-                    "is_upsampled": True,
-                    "upsampling_factor": 2.0,
-                },
-            ]
-        }
-        numpy_dataset_conversion.write_dataset_statistics(
-            output_dir=self.tmp_dir.name,
-            dataset_statistics=dataset_stats,
-            total_instances=13,
-            total_tokens=1000,
-            total_trainable_tokens=700,
-            num_samples_skipped=1,
-            tokenizer_name="test-tokenizer",
-            max_seq_length=4096,
-            chat_template_name="tulu",
-            per_dataset_counts={"ds_a": 8, "ds_b": 5},
-            per_dataset_tokens={"ds_a": 600, "ds_b": 400},
-            per_dataset_trainable_tokens={"ds_a": 400, "ds_b": 300},
-            per_dataset_filtered={"ds_a": 1, "ds_b": 0},
-        )
-
-        json_path = os.path.join(self.tmp_dir.name, "dataset_statistics.json")
-        with open(json_path) as f:
-            loaded = json.load(f)
-        self.assertEqual(loaded["overall_statistics"]["total_instances"], 13)
-        self.assertEqual(loaded["overall_statistics"]["total_tokens"], 1000)
-        self.assertEqual(loaded["overall_statistics"]["trainable_tokens"], 700)
-        self.assertEqual(len(loaded["per_dataset_statistics"]), 2)
-        names = {s["dataset_name"] for s in loaded["per_dataset_statistics"]}
-        self.assertEqual(names, {"ds_a", "ds_b"})
-
-        txt_path = os.path.join(self.tmp_dir.name, "dataset_statistics.txt")
-        with open(txt_path) as f:
-            txt = f.read()
-        self.assertIn("ds_a", txt)
-        self.assertIn("ds_b", txt)
-        self.assertIn("Overall Statistics", txt)
-
-    def test_zero_totals_does_not_divide_by_zero(self):
-        numpy_dataset_conversion.write_dataset_statistics(
-            output_dir=self.tmp_dir.name,
-            dataset_statistics={"per_dataset_stats": []},
-            total_instances=0,
-            total_tokens=0,
-            total_trainable_tokens=0,
-            num_samples_skipped=0,
-            tokenizer_name="test-tokenizer",
-            max_seq_length=None,
-            chat_template_name=None,
-            per_dataset_counts={"ds_a": 0},
-            per_dataset_tokens={"ds_a": 0},
-            per_dataset_trainable_tokens={"ds_a": 0},
-            per_dataset_filtered={"ds_a": 0},
-        )
-        with open(os.path.join(self.tmp_dir.name, "dataset_statistics.json")) as f:
-            loaded = json.load(f)
-        overall = loaded["overall_statistics"]
-        self.assertEqual(overall["trainable_percentage"], 0)
-        self.assertEqual(overall["average_sequence_length"], 0)
-        self.assertEqual(loaded["per_dataset_statistics"][0]["avg_tokens_per_instance"], 0)
 
 
 class TestConvertHfToNumpySft(unittest.TestCase):

--- a/open_instruct/test_numpy_dataset_conversion.py
+++ b/open_instruct/test_numpy_dataset_conversion.py
@@ -75,7 +75,7 @@ class TestWriteMemmapChunked(unittest.TestCase):
         return list(np.memmap(filename, mode="r", dtype=dtype, shape=(length,)))
 
     def test_empty_data(self):
-        open(self.source_path, "wb").close()
+        self.source_path.touch()
         result = numpy_dataset_conversion._write_memmap_chunked_from_file(
             self.base, self.source_path, 0, np.uint16, max_size_gb=1
         )
@@ -237,30 +237,22 @@ class TestWriteDatasetStatistics(unittest.TestCase):
         self.assertEqual(loaded["per_dataset_statistics"][0]["avg_tokens_per_instance"], 0)
 
 
-class TestConvertHfToNumpySft(unittest.TestCase):
+class _NumpySftTestBase(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         self.addCleanup(self.temp_dir.cleanup)
+        self.addCleanup(gc.collect)
 
-        self.original_hf_home = os.environ.get("HF_HOME")
-        self.original_hf_datasets_cache = os.environ.get("HF_DATASETS_CACHE")
-        self.original_transformers_cache = os.environ.get("TRANSFORMERS_CACHE")
-
-        os.environ["HF_HOME"] = self.temp_dir.name
-        os.environ["HF_DATASETS_CACHE"] = os.path.join(self.temp_dir.name, "datasets")
-        os.environ["TRANSFORMERS_CACHE"] = os.path.join(self.temp_dir.name, "transformers")
-
-    def tearDown(self):
-        for key, original in [
-            ("HF_HOME", self.original_hf_home),
-            ("HF_DATASETS_CACHE", self.original_hf_datasets_cache),
-            ("TRANSFORMERS_CACHE", self.original_transformers_cache),
-        ]:
-            if original is not None:
-                os.environ[key] = original
-            else:
-                os.environ.pop(key, None)
-        gc.collect()
+        patcher = unittest.mock.patch.dict(
+            os.environ,
+            {
+                "HF_HOME": self.temp_dir.name,
+                "HF_DATASETS_CACHE": os.path.join(self.temp_dir.name, "datasets"),
+                "TRANSFORMERS_CACHE": os.path.join(self.temp_dir.name, "transformers"),
+            },
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def _make_tc(self):
         return dataset_transformation.TokenizerConfig(
@@ -271,6 +263,8 @@ class TestConvertHfToNumpySft(unittest.TestCase):
             add_bos=False,
         )
 
+
+class TestConvertHfToNumpySft(_NumpySftTestBase):
     def test_end_to_end_small(self):
         output_dir = pathlib.Path(self.temp_dir.name) / "out_e2e"
         numpy_dataset_conversion.convert_hf_to_numpy_sft(
@@ -298,10 +292,8 @@ class TestConvertHfToNumpySft(unittest.TestCase):
         for partial in ("_tokens.partial.bin", "_labels.partial.bin", "_boundaries.partial.bin"):
             self.assertFalse((output_dir / partial).exists())
 
-        token_size = token_file.stat().st_size
-        labels_size = labels_file.stat().st_size
-        self.assertGreater(token_size, 0)
-        self.assertGreater(labels_size, 0)
+        self.assertGreater(token_file.stat().st_size, 0)
+        self.assertGreater(labels_file.stat().st_size, 0)
 
         with open(stats_json) as f:
             stats = json.load(f)
@@ -309,40 +301,7 @@ class TestConvertHfToNumpySft(unittest.TestCase):
         self.assertGreater(stats["overall_statistics"]["total_tokens"], 0)
 
 
-class TestResumeEquivalence(unittest.TestCase):
-    def setUp(self):
-        self.temp_dir = tempfile.TemporaryDirectory()
-        self.addCleanup(self.temp_dir.cleanup)
-
-        self.original_hf_home = os.environ.get("HF_HOME")
-        self.original_hf_datasets_cache = os.environ.get("HF_DATASETS_CACHE")
-        self.original_transformers_cache = os.environ.get("TRANSFORMERS_CACHE")
-
-        os.environ["HF_HOME"] = self.temp_dir.name
-        os.environ["HF_DATASETS_CACHE"] = os.path.join(self.temp_dir.name, "datasets")
-        os.environ["TRANSFORMERS_CACHE"] = os.path.join(self.temp_dir.name, "transformers")
-
-    def tearDown(self):
-        for key, original in [
-            ("HF_HOME", self.original_hf_home),
-            ("HF_DATASETS_CACHE", self.original_hf_datasets_cache),
-            ("TRANSFORMERS_CACHE", self.original_transformers_cache),
-        ]:
-            if original is not None:
-                os.environ[key] = original
-            else:
-                os.environ.pop(key, None)
-        gc.collect()
-
-    def _make_tc(self):
-        return dataset_transformation.TokenizerConfig(
-            tokenizer_name_or_path=TOKENIZER_PATH,
-            tokenizer_revision="main",
-            use_fast=True,
-            chat_template_name="tulu",
-            add_bos=False,
-        )
-
+class TestResumeEquivalence(_NumpySftTestBase):
     def _run(self, output_dir, resume, batch_size=10):
         numpy_dataset_conversion.convert_hf_to_numpy_sft(
             output_dir=output_dir,
@@ -393,13 +352,11 @@ class TestResumeEquivalence(unittest.TestCase):
         )
         self.assertGreater(len(artifacts), 0, "golden run produced no artifacts")
         for name in artifacts:
-            golden_path = golden / name
-            interrupted_path = interrupted / name
             if name.endswith(".gz"):
-                with gzip.open(golden_path, "rb") as f1, gzip.open(interrupted_path, "rb") as f2:
+                with gzip.open(golden / name, "rb") as f1, gzip.open(interrupted / name, "rb") as f2:
                     self.assertEqual(f1.read(), f2.read(), msg=f"mismatch in {name}")
             else:
-                with golden_path.open("rb") as f1, interrupted_path.open("rb") as f2:
+                with (golden / name).open("rb") as f1, (interrupted / name).open("rb") as f2:
                     self.assertEqual(f1.read(), f2.read(), msg=f"mismatch in {name}")
 
 

--- a/scripts/data/convert_sft_data_for_olmocore.py
+++ b/scripts/data/convert_sft_data_for_olmocore.py
@@ -61,6 +61,7 @@ Recommendations:
 """
 
 import os
+import pathlib
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -144,7 +145,7 @@ def main(args: ConvertSFTDataArguments, tc: dataset_transformation.TokenizerConf
             transform_fn_args.append({})
 
     numpy_dataset_conversion.convert_hf_to_numpy_sft(
-        output_dir=args.output_dir,
+        output_dir=pathlib.Path(args.output_dir),
         dataset_mixer_list=args.dataset_mixer_list,
         dataset_mixer_list_splits=args.dataset_mixer_list_splits,
         tc=tc,

--- a/scripts/data/convert_sft_data_for_olmocore.py
+++ b/scripts/data/convert_sft_data_for_olmocore.py
@@ -122,11 +122,8 @@ class ConvertSFTDataArguments:
     """Only write the tokenizer config to the output directory"""
     tokenizer_config_only: bool = field(default=False)
 
-    """Resume from checkpoint if available"""
+    """Resume from previously-written partial files in output_dir, if present."""
     resume: bool = field(default=False)
-
-    """Checkpoint save interval (number of samples)"""
-    checkpoint_interval: int = field(default=100_000)
 
     """Shuffle seed for reproducible dataset ordering"""
     shuffle_seed: int = field(default=42)
@@ -160,7 +157,6 @@ def main(args: ConvertSFTDataArguments, tc: dataset_transformation.TokenizerConf
         dataset_skip_cache=args.dataset_skip_cache,
         dataset_config_hash=args.dataset_config_hash,
         shuffle_seed=args.shuffle_seed,
-        checkpoint_interval=args.checkpoint_interval,
         resume=args.resume,
         visualize=args.visualize,
         tokenizer_config_only=args.tokenizer_config_only,

--- a/scripts/slurm/sft/README.md
+++ b/scripts/slurm/sft/README.md
@@ -63,12 +63,10 @@ sbatch train_dolci_instruct.sh
 
 ### Resume Support
 
-Data preparation supports automatic resume after interruption:
-- Checkpoints saved every 50,000 samples to `_checkpoint.json`
-- Just resubmit the same script to resume
-- Checkpoint is removed on successful completion
-
-Useful for time-limited queues, preemptible instances, and fault tolerance.
+Tokens, labels, and document boundaries stream to `_*.partial.bin` files in the
+output directory as they're produced. Passing `--resume` makes a re-run pick up
+where the last one left off by truncating those files to a consistent sample
+boundary and continuing. The partial files are deleted on successful completion.
 
 ### Configuration
 

--- a/scripts/slurm/sft/prepare_dolci_instruct_data.sh
+++ b/scripts/slurm/sft/prepare_dolci_instruct_data.sh
@@ -46,8 +46,7 @@ python scripts/data/convert_sft_data_for_olmocore.py \
   --output_dir "$OUTPUT_DIR" \
   --max_seq_length 32768 \
   --visualize True \
-  --resume \
-  --checkpoint_interval 50000
+  --resume
 
 echo "=== Data preparation complete ==="
 echo "Output saved to: $OUTPUT_DIR"

--- a/scripts/slurm/sft/prepare_dolci_think_data.sh
+++ b/scripts/slurm/sft/prepare_dolci_think_data.sh
@@ -46,8 +46,7 @@ python scripts/data/convert_sft_data_for_olmocore.py \
   --output_dir "$OUTPUT_DIR" \
   --max_seq_length 32768 \
   --visualize True \
-  --resume \
-  --checkpoint_interval 50000
+  --resume
 
 echo "=== Data preparation complete ==="
 echo "Output saved to: $OUTPUT_DIR"


### PR DESCRIPTION
Changes SFT tokenization to stream tokens directly to disk instead of accumulative arrays in memory. This means we don't need explicit checkpointing anymore, and leads to a 10x speedup. 

| Run | Collect loop | Rate | Beaker |
|---|---|---|---|
| Pre-opt | 758.21s | 158.3 samples/s | [01KPPVTVJQVEBS6FF02WTAJD52](https://beaker.org/ex/01KPPVTVJQVEBS6FF02WTAJD52) |
| Post-opt | 80.65s | 1487.8 samples/s | [01KPPVT6AA44XRJ2MV6510S8K0](https://beaker.org/ex/01KPPVT6AA44XRJ2MV6510S8K0) |
| **Speedup** | **9.40×** | — | |

## Correctness 

Followed the procedure in [`docs/verify-tokenization.md`](docs/verify-tokenization.md): built an image from this branch, ran the full production mixer (`Dolci-Think-SFT-32B` + 5 tool datasets at 3.0×, `olmo123` chat template, `max_seq_length=32768`) on weka, then byte-compared against the existing `origin/main` golden at `/weka/oe-adapt-default/finbarrt/dataset/olmo-hybrid-main-repro`.

**Accuracy — byte-identical to baseline.** The compare job ([01KPY3NNQKF0FFJ8J8ECAX0JT7](https://beaker.org/ex/01KPY3NNQKF0FFJ8J8ECAX0JT7)) reports `=== PASSED ===`: all 99 `token_ids_part_*.npy`, 99 `labels_mask_part_*.npy`, 99 `token_ids_part_*.csv.gz`, and `dataset_statistics.json` (after stripping `timestamp`/`output_directory`) have matching sha256 hashes. It runs in 30m47s, vs the baseline, which took 2 days (although we also had other optimizations in #1633 which contribute to this speedup). 