### PR TITLE
Fix import error when installing open-instruct as a dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix import error when installing as dependency (https://github.com/allenai/open-instruct/pull/1634)
 - Fix weight sync on resume by initializing vLLM weight sync before the training loop and warming up the learner with a dummy forward so DeepSpeed Stage 3 params materialize before the first broadcast; accept IPC `update_info` dict in `LLMRayActor.update_weights`; replace toothless weight-sync tests with a real divergent-weight broadcast test (https://github.com/allenai/open-instruct/pull/1627).
 - Fix `verify_sentence_constraint` not recognising `!` as a sentence terminator, causing IFEval sentence-count checks to undercount any response containing exclamations (https://github.com/allenai/open-instruct/pull/1612).
 - Fix `DataPreparationActor` hanging on shutdown by killing the actor with `ray.kill()` during cleanup (https://github.com/allenai/open-instruct/pull/1611).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,9 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 include = ["open_instruct", "open_instruct.*"]
-exclude = ["open_instruct.test_data*"]
+
+[tool.setuptools.exclude-package-data]
+"open_instruct" = ["test_data/*", "test_data/**/*"]
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,9 @@ dependencies = [
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-py-modules = ["open_instruct"]
+[tool.setuptools.packages.find]
+include = ["open_instruct", "open_instruct.*"]
+exclude = ["open_instruct.test_data*"]
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]


### PR DESCRIPTION
Currently, when we install open_instruct as a third party dependency (eg. `uv pip install "git+https://github.com/allenai/open-instruct@main"`), the package fails to import and gives a module not found error. This is because 
```
[tool.setuptools]
py-modules = ["open_instruct"]
```
assumes a single file module and looks for `open_instruct.py` which doesn't exist and won't contain the entities we want to import.

I have changed this to look for everything under `open_instruct` except for the `test_data` subfolder - this should fix the import error. Let me know if any other modules/dirs should be excluded.