### PR TITLE
Add dynamic versioning based on git tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+open_instruct/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix hardcoded project version (https://github.com/allenai/open-instruct/pull/1636) by using setuptools scm's automatic versioning.
 - Fix weight sync on resume by initializing vLLM weight sync before the training loop and warming up the learner with a dummy forward so DeepSpeed Stage 3 params materialize before the first broadcast; accept IPC `update_info` dict in `LLMRayActor.update_weights`; replace toothless weight-sync tests with a real divergent-weight broadcast test (https://github.com/allenai/open-instruct/pull/1627).
 - Fix `verify_sentence_constraint` not recognising `!` as a sentence terminator, causing IFEval sentence-count checks to undercount any response containing exclamations (https://github.com/allenai/open-instruct/pull/1612).
 - Fix `DataPreparationActor` hanging on shutdown by killing the actor with `ray.kill()` during cleanup (https://github.com/allenai/open-instruct/pull/1611).

--- a/open_instruct/__init__.py
+++ b/open_instruct/__init__.py
@@ -1,0 +1,1 @@
+from open_instruct._version import __version__

--- a/open_instruct/__init__.py
+++ b/open_instruct/__init__.py
@@ -1,1 +1,4 @@
-from open_instruct._version import __version__
+try:
+    from open_instruct._version import __version__
+except ImportError:
+    __version__ = "0.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "open-instruct"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Train open, instruction-following language models"
 readme = "README.md"
 requires-python = "==3.12.*"
@@ -48,11 +48,14 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 py-modules = ["open_instruct"]
+
+[tool.setuptools_scm]
+write_to = "open_instruct/_version.py"
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]

--- a/uv.lock
+++ b/uv.lock
@@ -2779,7 +2779,6 @@ wheels = [
 
 [[package]]
 name = "open-instruct"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "accelerate", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },


### PR DESCRIPTION
Project version was being hardcoded to 0.1.0 (uv init default) instead of recognising release tags. This also means `uv pip show open-instruct` will unhelpfully show 0.1.0.

I have changed this to be autogenerated based on the release tag + any additional commits (eg. `0.2.1.dev106+g6644898d1.d20260424`) using [setuptools_scm](https://pypi.org/project/setuptools-scm/).