### PR TITLE
Reapply packaging fix from #1634 reverted by #1622

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Reapply packaging fix so `open_instruct` installs correctly as a third-party dependency (reverted by #1622) (https://github.com/allenai/open-instruct/pull/1634).
 - Drop unused `data_types` import and inline `batch["batch"].to(device)` in `GRPOTrainModule` (https://github.com/allenai/open-instruct/pull/1635).
 - Use incremental binary checkpoint for SFT tokenization resume, eliminating O(N²) re-serialization (https://github.com/allenai/open-instruct/pull/1633).
 - Extract numpy SFT conversion helpers into `open_instruct.numpy_dataset_conversion` (https://github.com/allenai/open-instruct/pull/1622).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,11 @@ dependencies = [
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools]
-py-modules = ["open_instruct"]
+[tool.setuptools.packages.find]
+include = ["open_instruct", "open_instruct.*"]
+
+[tool.setuptools.exclude-package-data]
+"open_instruct" = ["test_data/*", "test_data/**/*"]
 
 [tool.uv.extra-build-dependencies]
 flash-attn = [{ requirement = "torch", match-runtime = true }]


### PR DESCRIPTION
## Summary
- #1622 accidentally reverted the `pyproject.toml` packaging fix from #1634, restoring the broken `py-modules = ["open_instruct"]` declaration that prevents installing `open_instruct` as a third-party dependency.
- Reapplies #1634's `[tool.setuptools.packages.find]` + `exclude-package-data` config.

## Test plan
- [ ] `uv pip install "git+https://github.com/allenai/open-instruct@reapply-1634-packaging-fix"` imports cleanly.

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)