### PR TITLE
Fix submit_eval_jobs.py for olmo-eval-internal runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Fix `scripts/submit_eval_jobs.py`: drop the `vllm[runai]>=0.19.0` upgrade (was clobbering the image's cu12.8 wheels with cu13), pin `numpy<2.3` for numba compat, and correct the `--sampling_max_tokens` override path to `sampling_params.max_tokens=N` (https://github.com/allenai/open-instruct/pull/REPLACE_ME).
+- Fix `scripts/submit_eval_jobs.py`: drop the `vllm[runai]>=0.19.0` upgrade (was clobbering the image's cu12.8 wheels with cu13), pin `numpy<2.3` for numba compat, and correct the `--sampling_max_tokens` override path to `sampling_params.max_tokens=N` (https://github.com/allenai/open-instruct/pull/1644).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).
 - Stream SFT tokens/labels/boundaries directly to `_*.partial.bin` files and derive per-dataset stats at the end from disk, dropping the explicit `_checkpoint.json` file. `--resume` now works by truncating the partial files to a consistent sample boundary (https://github.com/allenai/open-instruct/pull/1631).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- `scripts/submit_eval_jobs.py`: default `--beaker_image` to the published `ai2/oe-data/olmo-eval-latest`, resolve `--olmo_eval_ref` to a SHA at submit time so submissions are reproducible, and collapse the install script's two `uv pip install` calls into one.
 - Fix `scripts/submit_eval_jobs.py`: drop the `vllm[runai]>=0.19.0` upgrade (was clobbering the image's cu12.8 wheels with cu13), pin `numpy<2.3` for numba compat, and correct the `--sampling_max_tokens` override path to `sampling_params.max_tokens=N` (https://github.com/allenai/open-instruct/pull/1644).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Fix `scripts/submit_eval_jobs.py`: drop the `vllm[runai]>=0.19.0` upgrade (was clobbering the image's cu12.8 wheels with cu13), pin `numpy<2.3` for numba compat, and correct the `--sampling_max_tokens` override path to `sampling_params.max_tokens=N` (https://github.com/allenai/open-instruct/pull/REPLACE_ME).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).
 - Stream SFT tokens/labels/boundaries directly to `_*.partial.bin` files and derive per-dataset stats at the end from disk, dropping the explicit `_checkpoint.json` file. `--resume` now works by truncating the partial files to a consistent sample boundary (https://github.com/allenai/open-instruct/pull/1631).

--- a/scripts/eval/install_olmo_eval.sh
+++ b/scripts/eval/install_olmo_eval.sh
@@ -2,7 +2,7 @@
 # Usage: install_olmo_eval.sh <git-ref>  (requires $GITHUB_TOKEN)
 set -euo pipefail
 
-ref="${1:?missing git ref}"
+ref="$1"
 
 cache_dir=/weka/oe-eval-default/olmo-eval-pypi-cache
 

--- a/scripts/eval/install_olmo_eval.sh
+++ b/scripts/eval/install_olmo_eval.sh
@@ -4,12 +4,22 @@ set -euo pipefail
 
 ref="$1"
 
-cache_dir=/weka/oe-eval-default/olmo-eval-pypi-cache
+export UV_PROJECT_ENVIRONMENT=/opt/venv
+export UV_CACHE_DIR=/weka/oe-eval-default/olmo-eval-pypi-cache
 
 git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/allenai/olmo-eval-internal.git" /opt/olmo-eval-internal
 cd /opt/olmo-eval-internal
 git checkout "$ref"
 
-uv pip install --cache-dir "$cache_dir" -e '.[vllm]' 'transformers>=5.4.0' 'numpy<2.3'
+# Install vllm into a separate venv that symlinks the image's torch/nvidia libs,
+# so we don't reinstall CUDA wheels. The main venv keeps the s3/clients/hf extras.
+uv pip freeze -q | grep -E '^(torch|nvidia-)' > /tmp/cuda-constraints.txt
+uv venv /opt/vllm-venv
+for pkg in /opt/venv/lib/python*/site-packages/torch* /opt/venv/lib/python*/site-packages/nvidia*; do
+    ln -sf "$pkg" /opt/vllm-venv/lib/python*/site-packages/
+done
+VIRTUAL_ENV=/opt/vllm-venv uv pip install --cache-dir "$UV_CACHE_DIR" -e '.[vllm]'
+uv pip install -e '.[s3,clients,hf]' -c /tmp/cuda-constraints.txt
+uv pip install 'antlr4-python3-runtime' -c /tmp/cuda-constraints.txt
 
 cd /workspace

--- a/scripts/eval/install_olmo_eval.sh
+++ b/scripts/eval/install_olmo_eval.sh
@@ -15,7 +15,6 @@ git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/allenai/olmo-eval-i
 cd /opt/olmo-eval-internal
 git checkout "$ref"
 
-uv pip install --cache-dir "$cache_dir" -e '.[vllm]'
-uv pip install --cache-dir "$cache_dir" --upgrade 'transformers>=5.4.0' 'numpy<2.3'
+uv pip install --cache-dir "$cache_dir" -e '.[vllm]' 'transformers>=5.4.0' 'numpy<2.3'
 
 cd /workspace

--- a/scripts/eval/install_olmo_eval.sh
+++ b/scripts/eval/install_olmo_eval.sh
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-# Install olmo-eval-internal at the given git ref, plus a couple of pinned
-# dependency upgrades the base image needs.
-#
-# Usage: install_olmo_eval.sh <git-ref>
-#
-# Env vars: GITHUB_TOKEN must be set (used to clone the private repo).
+# Usage: install_olmo_eval.sh <git-ref>  (requires $GITHUB_TOKEN)
 set -euo pipefail
 
 ref="${1:?missing git ref}"

--- a/scripts/eval/install_olmo_eval.sh
+++ b/scripts/eval/install_olmo_eval.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Install olmo-eval-internal at the given git ref, plus a couple of pinned
+# dependency upgrades the base image needs.
+#
+# Usage: install_olmo_eval.sh <git-ref>
+#
+# Env vars: GITHUB_TOKEN must be set (used to clone the private repo).
+set -euo pipefail
+
+ref="${1:?missing git ref}"
+
+cache_dir=/weka/oe-eval-default/olmo-eval-pypi-cache
+
+git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/allenai/olmo-eval-internal.git" /opt/olmo-eval-internal
+cd /opt/olmo-eval-internal
+git checkout "$ref"
+
+uv pip install --cache-dir "$cache_dir" -e '.[vllm]'
+uv pip install --cache-dir "$cache_dir" --upgrade 'transformers>=5.4.0' 'numpy<2.3'
+
+cd /workspace

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -36,9 +36,30 @@ MAX_EXPERIMENT_NAME_LEN = 128
 EXPERIMENT_NAME_SAFE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
 
 DEFAULT_OLMO_EVAL_REF = "main"
+DEFAULT_BEAKER_IMAGE = "ai2/oe-data/olmo-eval-latest"
+OLMO_EVAL_REPO = "allenai/olmo-eval-internal"
 GIT_REF_SAFE_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 INSTALL_SCRIPT_PATH = pathlib.Path(__file__).parent / "eval" / "install_olmo_eval.sh"
 INSTALL_HEREDOC_TAG = "OPEN_INSTRUCT_INSTALL_EOF"
+
+
+def resolve_olmo_eval_ref(ref: str) -> str:
+    """Resolve a branch/tag to a 40-char SHA so submissions are reproducible."""
+    if not GIT_REF_SAFE_RE.match(ref):
+        raise ValueError(f"Invalid git ref {ref!r}; expected characters [A-Za-z0-9._/-].")
+    if GIT_SHA_RE.match(ref):
+        return ref
+    out = subprocess.run(
+        ["gh", "api", f"repos/{OLMO_EVAL_REPO}/commits/{ref}", "--jq", ".sha"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    sha = out.stdout.strip()
+    if not GIT_SHA_RE.match(sha):
+        raise RuntimeError(f"Could not resolve {ref!r} on {OLMO_EVAL_REPO} (got {sha!r}).")
+    return sha
 
 
 def build_install_block(ref: str) -> str:
@@ -80,7 +101,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--beaker_image",
         type=str,
-        default="ai2-tylerm/olmo-eval-cu1281-trc290-amd64",
+        default=DEFAULT_BEAKER_IMAGE,
         help="Beaker image with olmo-eval installed.",
     )
     parser.add_argument("--revision", type=str, default=None, help="HF revision (git sha/tag).")
@@ -198,6 +219,11 @@ def build_spec(args: argparse.Namespace, inner_cmd: list[str], dataset_id: str |
 def main() -> None:
     args = parse_args()
     launch_utils.validate_beaker_workspace(args.workspace)
+
+    resolved_ref = resolve_olmo_eval_ref(args.olmo_eval_ref)
+    if resolved_ref != args.olmo_eval_ref:
+        print(f"Resolved olmo_eval_ref {args.olmo_eval_ref!r} -> {resolved_ref}")
+    args.olmo_eval_ref = resolved_ref
 
     model_path, dataset_id = resolve_model_mount(args.location)
     inner_cmd = build_inner_cmd(args, model_path)

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -19,6 +19,7 @@ Example:
 """
 
 import argparse
+import pathlib
 import re
 import shlex
 import subprocess
@@ -36,21 +37,18 @@ EXPERIMENT_NAME_SAFE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
 
 DEFAULT_OLMO_EVAL_REF = "main"
 GIT_REF_SAFE_RE = re.compile(r"^[A-Za-z0-9._/-]+$")
+INSTALL_SCRIPT_PATH = pathlib.Path(__file__).parent / "eval" / "install_olmo_eval.sh"
+INSTALL_HEREDOC_TAG = "OPEN_INSTRUCT_INSTALL_EOF"
 
 
-def build_install_script(ref: str) -> str:
+def build_install_block(ref: str) -> str:
     if not GIT_REF_SAFE_RE.match(ref):
         raise ValueError(f"Invalid git ref {ref!r}; expected characters [A-Za-z0-9._/-].")
+    body = INSTALL_SCRIPT_PATH.read_text()
     return (
-        "set -euo pipefail && "
-        "git clone "
-        "https://x-access-token:${GITHUB_TOKEN}@github.com/allenai/olmo-eval-internal.git "
-        "/opt/olmo-eval-internal && "
-        f"cd /opt/olmo-eval-internal && git checkout {shlex.quote(ref)} && "
-        "uv pip install --cache-dir /weka/oe-eval-default/olmo-eval-pypi-cache -e '.[vllm]' && "
-        "uv pip install --cache-dir /weka/oe-eval-default/olmo-eval-pypi-cache "
-        "--upgrade 'transformers>=5.4.0' 'numpy<2.3' && "
-        "cd /workspace"
+        f"bash -s -- {shlex.quote(ref)} <<'{INSTALL_HEREDOC_TAG}'\n"
+        f"{body}"
+        f"{INSTALL_HEREDOC_TAG}"
     )
 
 
@@ -164,7 +162,11 @@ def build_spec(args: argparse.Namespace, inner_cmd: list[str], dataset_id: str |
     if dataset_id:
         datasets.append({"mountPath": "/model", "source": {"beaker": dataset_id}})
 
-    full_command = f"{build_install_script(args.olmo_eval_ref)} && {shlex.join(inner_cmd)}"
+    full_command = (
+        "set -euo pipefail\n"
+        f"{build_install_block(args.olmo_eval_ref)}\n"
+        f"{shlex.join(inner_cmd)}\n"
+    )
 
     return {
         "version": "v2",

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -63,8 +63,8 @@ def resolve_olmo_eval_ref(ref: str) -> str:
 
 
 def build_install_block(ref: str) -> str:
-    if not GIT_REF_SAFE_RE.match(ref):
-        raise ValueError(f"Invalid git ref {ref!r}; expected characters [A-Za-z0-9._/-].")
+    if not GIT_SHA_RE.match(ref):
+        raise ValueError(f"Expected a 40-char SHA (call resolve_olmo_eval_ref first); got {ref!r}.")
     body = INSTALL_SCRIPT_PATH.read_text()
     return (
         f"bash -s -- {shlex.quote(ref)} <<'{INSTALL_HEREDOC_TAG}'\n"

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -168,6 +168,16 @@ def build_inner_cmd(args: argparse.Namespace, model_path: str) -> list[str]:
     return cmd
 
 
+def get_git_info() -> tuple[str, str]:
+    branch = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], check=False, capture_output=True, text=True
+    ).stdout.strip() or "unknown"
+    commit = subprocess.run(
+        ["git", "rev-parse", "--short=12", "HEAD"], check=False, capture_output=True, text=True
+    ).stdout.strip() or "unknown"
+    return branch, commit
+
+
 def build_spec(args: argparse.Namespace, inner_cmd: list[str], dataset_id: str | None, experiment_name: str) -> dict:
     non_weka_clusters = [c for c in args.cluster if c not in launch_utils.WEKA_CLUSTERS]
     if non_weka_clusters:
@@ -186,12 +196,16 @@ def build_spec(args: argparse.Namespace, inner_cmd: list[str], dataset_id: str |
     full_command = (
         "set -euo pipefail\n"
         f"{build_install_block(args.olmo_eval_ref)}\n"
+        "export VLLM_PYTHON=/opt/vllm-venv/bin/python\n"
         f"{shlex.join(inner_cmd)}\n"
     )
 
+    git_branch, git_commit = get_git_info()
+    description = f"{experiment_name} (branch={git_branch}, commit={git_commit})"
+
     return {
         "version": "v2",
-        "description": experiment_name,
+        "description": description,
         "budget": args.budget,
         "retry": {"allowedTaskRetries": 2},
         "tasks": [

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -49,7 +49,7 @@ def build_install_script(ref: str) -> str:
         f"cd /opt/olmo-eval-internal && git checkout {shlex.quote(ref)} && "
         "uv pip install --cache-dir /weka/oe-eval-default/olmo-eval-pypi-cache -e '.[vllm]' && "
         "uv pip install --cache-dir /weka/oe-eval-default/olmo-eval-pypi-cache "
-        "--upgrade 'vllm[runai]>=0.19.0' 'transformers>=5.4.0' && "
+        "--upgrade 'transformers>=5.4.0' 'numpy<2.3' && "
         "cd /workspace"
     )
 
@@ -143,7 +143,7 @@ def build_inner_cmd(args: argparse.Namespace, model_path: str) -> list[str]:
             continue
         cmd += ["-t", task]
         if args.sampling_max_tokens is not None:
-            cmd += ["-o", f"max_tokens={args.sampling_max_tokens}"]
+            cmd += ["-o", f"sampling_params.max_tokens={args.sampling_max_tokens}"]
     cmd += ["--num-gpus", str(args.num_gpus)]
     cmd += ["--output-dir", "/results"]
     return cmd


### PR DESCRIPTION
## Summary

Three fixes to `scripts/submit_eval_jobs.py` so the script can submit working olmo-eval-internal jobs:

- **Drop the `vllm[runai]>=0.19.0` upgrade**: it was pulling cu13 wheels on top of the image's cu12.8 install, breaking the CUDA driver match (`CUDA driver too old, version 12080 found`). The image's bundled vLLM is sufficient.
- **Pin `numpy<2.3`** alongside the `transformers>=5.4.0` upgrade: transformers 5.4 pulls NumPy 2.4, which is incompatible with numba (`Numba needs NumPy 2.2 or less`). The transformers upgrade is needed for newer-model tokenizer support.
- **Fix `--sampling_max_tokens` override path**: was emitting `-o max_tokens=N` (rejected as `not a TaskConfig field`). Now emits `-o sampling_params.max_tokens=N` to match the nested field.

> Note: the `sampling_params.max_tokens` override only deep-merges correctly with the patch on `allenai/olmo-eval-internal` branch `finbarr/fix-sampling-params` (`prepare_task_items` was clobbering the entire `SamplingParams` dataclass with a dict). Until that lands on `main`, pass `--olmo_eval_ref finbarr/fix-sampling-params`.

## How to re-run the validation eval

```
uv run python scripts/submit_eval_jobs.py \
    --model_name qwen3_4b_base_dapo_20260422_083224 \
    --location 01KPTSPMHGEZVYCDNR0XBVJCGZ \
    --tasks aime_2025:pass_at_32 \
    --max_length 32768 \
    --sampling_max_tokens 16384 \
    --cluster ai2/jupiter ai2/saturn ai2/ceres ai2/neptune \
    --priority urgent \
    --preemptible \
    --workspace ai2/open-instruct-dev \
    --olmo_eval_ref finbarr/fix-sampling-params
```

Runs:

1. qwen3_4b_base_dapo aime_2025:pass_at_32 (max_tokens=16384) → pass_at_1:minerva_math_flex = 0.1104: [Beaker](https://beaker.org/ex/01KQAS9BSBYYFDRRH5D7WK1TPC)

## Test plan

- [x] End-to-end submission completes successfully (exit 0, ~9 min).
- [x] vLLM server starts (no CUDA-driver mismatch, no numba/NumPy conflict).
- [x] Tokenizer loads (transformers>=5.4.0 supports the model's tokenizer config).
- [x] `sampling_params.max_tokens` override is accepted by the CLI.

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)