### PR TITLE
Fix validate_frequency_capital_words treating "around" as exact equality

### DIFF
--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -430,7 +430,7 @@ def validate_frequency_capital_words(text: str, N: int, quantifier: str) -> bool
     if quantifier == "at least":
         return len(words) >= N
     elif quantifier == "around":
-        return len(words) == N
+        return abs(len(words) - N) <= max(round(N * 0.1), 1)
     elif quantifier == "at most":
         return len(words) <= N
     else:


### PR DESCRIPTION
## Bug

`validate_frequency_capital_words` in `open_instruct/if_functions.py` treats the `\"around\"` quantifier as exact equality:

```python
elif quantifier == "around":
    return len(words) == N   # strict equality — wrong
```

This means a response with N±1 all-capital words always fails the constraint, contrary to the IFEval spec's intent for \"approximately N\".

## Root cause

Every other constraint function in the same file applies a tolerance band for `\"around\"`:
- `validate_word_constraint` — `abs(actual_count - N) <= max(round(N * 0.1), 1)` (±10 %, min 1)
- `verify_sentence_constraint` — `abs(actual_count - N) <= 1`

`validate_frequency_capital_words` was left with strict equality, making `\"around\"` indistinguishable from `\"exactly\"`.

## Fix

Apply the same ±10 % (minimum 1) tolerance used by `validate_word_constraint`, since both functions count word-level occurrences.