### PR TITLE
Fix validate_choice operand direction and 'around' tolerance in scripts/eval_constraints/if_functions.py

### DIFF
--- a/scripts/eval_constraints/if_functions.py
+++ b/scripts/eval_constraints/if_functions.py
@@ -369,7 +369,7 @@ def validate_title(text: str) -> bool:
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
     for option in options:
-        if text in option:
+        if option in text:
             return True
     return False
 
@@ -456,7 +456,7 @@ def validate_frequency_capital_words(text: str, N: int, quantifier: str) -> bool
     if quantifier == "at least":
         return len(words) >= N
     elif quantifier == "around":
-        return len(words) == N
+        return abs(len(words) - N) <= max(round(N * 0.1), 1)
     elif quantifier == "at most":
         return len(words) <= N
     else:


### PR DESCRIPTION
## Bug

`scripts/eval_constraints/if_functions.py` has two correctness bugs that mirror those already fixed in `open_instruct/if_functions.py` by #1646. The `scripts/eval_constraints/` copy was not updated by that PR.

### Bug 1 — `validate_choice`: operand direction reversed (line 372)

```python
# Before (broken):
if text in option:   # checks whether the full response is a substring of a short option string — almost always False

# After (correct):
if option in text:   # checks whether the option appears anywhere in the response
```

Root cause: `in` is not commutative for substrings. `text in option` asks "is the entire response a substring of the option?", which is true only when the response is shorter than the option and literally contained within it — essentially never in practice.

### Bug 2 — `validate_frequency_capital_words`: `"around"` quantifier uses exact equality instead of tolerance (line 459)

```python
# Before (broken):
return len(words) == N   # no tolerance — treats "around 5" identically to "exactly 5"

# After (correct):
return abs(len(words) - N) <= max(round(N * 0.1), 1)   # ±10% tolerance, matching validate_word_constraint
```

Root cause: The `"around"` case was written as a strict equality check. Every other `around` constraint in this file (e.g. `validate_word_constraint`) uses a ±10% tolerance band; this function was inconsistent.

## Why the fix is correct

Both fixes are identical to the changes already merged/proposed for `open_instruct/if_functions.py` in #1646. The two files are supposed to be in sync — `scripts/eval_constraints/` is the eval-time copy of the same constraint-verification logic.