### PR TITLE
fix(ifeval): guard against ZeroDivisionError in IFEvalVerifier when instruction list is empty

### DIFF
--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -351,6 +351,8 @@ class IFEvalVerifier(VerifierFunction):
                 rewards.append(1.0)
             else:
                 rewards.append(0.0)
+        if not rewards:
+            return VerificationResult(score=0.0)
         return VerificationResult(score=sum(rewards) / len(rewards))
 
 


### PR DESCRIPTION
**Bug:** `IFEvalVerifier.__call__` divides by `len(rewards)` at the end, but `rewards` can be empty if `constraint_dict["instruction_id"]` is an empty list:

```python
instruction_keys = constraint_dict["instruction_id"]
args_list = constraint_dict["kwargs"]
rewards = []
...
for instruction_key, args in zip(instruction_keys, args_list):
    ...
    rewards.append(...)
return VerificationResult(score=sum(rewards) / len(rewards))  # ZeroDivisionError if empty
```

When `instruction_keys` is `[]`, `zip()` yields nothing, the loop body never executes, and `rewards` stays empty. Calling `sum([]) / len([])` raises `ZeroDivisionError`, crashing the batch's reward computation.

**Root cause:** Missing guard for the empty-instruction-list edge case. The existing guard (`if len(prediction) == 0 or len(answer) == 0`) only covers empty model outputs, not empty constraint lists.

**Fix:** Return `score=0.0` when `rewards` is empty (no instructions to check = no constraint satisfied):

```python
        if not rewards:
            return VerificationResult(score=0.0)
        return VerificationResult(score=sum(rewards) / len(rewards))
```