### PR TITLE
Add time/per_group_wall_time metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max).
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).
@@ -54,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 
 ### Added
+- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max).
 - Replace `scripts/submit_eval_jobs.py` with a new olmo-eval-internal launcher (Beaker v2, no gantry); the previous script is preserved as `scripts/submit_eval_jobs_old.py` and emits a `DeprecationWarning` (https://github.com/allenai/open-instruct/pull/1638).
 - Add OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1579).
 - Add DR-TULU replication script for Qwen 3.5 4B with evolving rubrics, per-tool pool size overrides, `vllm_qwen3_xml` parser, and `<answer>` tag extraction in rubric scoring (https://github.com/allenai/open-instruct/pull/1609).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max).
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ All notable changes to this project will be documented in this file.
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 
 ### Added
-- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max).
+- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max) (https://github.com/allenai/open-instruct/pull/1656).
 - Replace `scripts/submit_eval_jobs.py` with a new olmo-eval-internal launcher (Beaker v2, no gantry); the previous script is preserved as `scripts/submit_eval_jobs_old.py` and emits a `DeprecationWarning` (https://github.com/allenai/open-instruct/pull/1638).
 - Add OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1579).
 - Add DR-TULU replication script for Qwen 3.5 4B with evolving rubrics, per-tool pool size overrides, `vllm_qwen3_xml` parser, and `<answer>` tag extraction in rubric scoring (https://github.com/allenai/open-instruct/pull/1609).

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -630,6 +630,11 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
             trainer_idle_wait_time = time.perf_counter() - wait_start_time
             batch_data.setdefault("metrics", {})["time/trainer_idle_waiting_for_inference"] = trainer_idle_wait_time
             self.training_step = step + 1
+            if len(batch_data["batch"]) == 0:
+                logger.warning(
+                    f"[Dataloader] Empty batch at step={step} (all groups filtered); skipping training step"
+                )
+                continue
             yield batch_data
 
 

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -630,11 +630,6 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
             trainer_idle_wait_time = time.perf_counter() - wait_start_time
             batch_data.setdefault("metrics", {})["time/trainer_idle_waiting_for_inference"] = trainer_idle_wait_time
             self.training_step = step + 1
-            if len(batch_data["batch"]) == 0:
-                logger.warning(
-                    f"[Dataloader] Empty batch at step={step} (all groups filtered); skipping training step"
-                )
-                continue
             yield batch_data
 
 

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -873,6 +873,7 @@ def make_batch_from_groups(
     total_prompt_tokens = 0
     total_response_tokens = 0
     max_generation_time = 0
+    per_group_generation_times: list[float] = []
 
     for group in groups:
         result = group.result
@@ -912,12 +913,18 @@ def make_batch_from_groups(
         total_prompt_tokens += result.token_statistics.num_prompt_tokens
         total_response_tokens += result.token_statistics.num_response_tokens
         max_generation_time = max(max_generation_time, result.token_statistics.generation_time)
+        per_group_generation_times.append(result.token_statistics.generation_time)
+
+    mean_per_group_wall_time = (
+        sum(per_group_generation_times) / len(per_group_generation_times) if per_group_generation_times else 0.0
+    )
 
     accumulated_stats = data_types.TokenStatistics(
         num_prompt_tokens=total_prompt_tokens,
         num_response_tokens=total_response_tokens,
         generation_time=max_generation_time,
         earliest_start_time=earliest_start_time,
+        mean_per_group_wall_time=mean_per_group_wall_time,
     )
 
     combined_request_info = data_types.RequestInfo(
@@ -1511,6 +1518,7 @@ class DataPreparationActor:
                 total_tokens = result.token_statistics.num_prompt_tokens + result.token_statistics.num_response_tokens
                 step_metrics["val/actor_tokens_per_second"] = total_tokens / result.token_statistics.generation_time
                 step_metrics["time/getting_response"] = result.token_statistics.generation_time
+                step_metrics["time/per_group_wall_time"] = result.token_statistics.mean_per_group_wall_time
 
             with self.lock:
                 self.prepared_data[step] = collated_data

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -630,11 +630,6 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
             trainer_idle_wait_time = time.perf_counter() - wait_start_time
             batch_data.setdefault("metrics", {})["time/trainer_idle_waiting_for_inference"] = trainer_idle_wait_time
             self.training_step = step + 1
-            if len(batch_data["batch"]) == 0:
-                logger.warning(
-                    f"[Dataloader] Empty batch at step={step} (all groups filtered); skipping training step"
-                )
-                continue
             yield batch_data
 
 
@@ -1323,7 +1318,8 @@ class DataPreparationActor:
                 ground_truth_overrides=self.ground_truth_overrides,
             )
 
-        for step in range(self.training_step, self.num_training_steps):
+        step = self.training_step
+        while step < self.num_training_steps:
             generation_idle_wait_start_time = time.perf_counter()
             while step - self._last_consumed_step > self.config.async_steps:
                 logger.info(
@@ -1363,21 +1359,9 @@ class DataPreparationActor:
                 return
 
             if result is None:
-                empty_data = [
-                    data_types.CollatedBatchData(
-                        query_responses=[],
-                        attention_masks=[],
-                        position_ids=[],
-                        advantages=[],
-                        response_masks=[],
-                        vllm_logprobs=[],
-                    )
-                    for _ in range(self.dp_world_size)
-                ]
-                with self.lock:
-                    self.prepared_data[step] = empty_data
-                    self.metrics[step] = {"time/generation_idle_waiting_for_trainer": generation_idle_wait_time}
-                    self.current_prepared_step = step
+                logger.warning(
+                    f"[DataPreparationActor] Step {step}: all groups filtered (zero-std rewards); resampling without advancing step counter"
+                )
                 continue
 
             assert batch is not None
@@ -1527,6 +1511,8 @@ class DataPreparationActor:
                 self.prepared_data[step] = collated_data
                 self.metrics[step] = step_metrics
                 self.current_prepared_step = step
+
+            step += 1
 
     def get_data(self, rank: int, step: int) -> dict:
         """Called by each rank's StreamingDataLoader. Blocks until data ready."""

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -630,6 +630,11 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
             trainer_idle_wait_time = time.perf_counter() - wait_start_time
             batch_data.setdefault("metrics", {})["time/trainer_idle_waiting_for_inference"] = trainer_idle_wait_time
             self.training_step = step + 1
+            if len(batch_data["batch"]) == 0:
+                logger.warning(
+                    f"[Dataloader] Empty batch at step={step} (all groups filtered); skipping training step"
+                )
+                continue
             yield batch_data
 
 
@@ -1318,8 +1323,7 @@ class DataPreparationActor:
                 ground_truth_overrides=self.ground_truth_overrides,
             )
 
-        step = self.training_step
-        while step < self.num_training_steps:
+        for step in range(self.training_step, self.num_training_steps):
             generation_idle_wait_start_time = time.perf_counter()
             while step - self._last_consumed_step > self.config.async_steps:
                 logger.info(
@@ -1359,9 +1363,21 @@ class DataPreparationActor:
                 return
 
             if result is None:
-                logger.warning(
-                    f"[DataPreparationActor] Step {step}: all groups filtered (zero-std rewards); resampling without advancing step counter"
-                )
+                empty_data = [
+                    data_types.CollatedBatchData(
+                        query_responses=[],
+                        attention_masks=[],
+                        position_ids=[],
+                        advantages=[],
+                        response_masks=[],
+                        vllm_logprobs=[],
+                    )
+                    for _ in range(self.dp_world_size)
+                ]
+                with self.lock:
+                    self.prepared_data[step] = empty_data
+                    self.metrics[step] = {"time/generation_idle_waiting_for_trainer": generation_idle_wait_time}
+                    self.current_prepared_step = step
                 continue
 
             assert batch is not None
@@ -1511,8 +1527,6 @@ class DataPreparationActor:
                 self.prepared_data[step] = collated_data
                 self.metrics[step] = step_metrics
                 self.current_prepared_step = step
-
-            step += 1
 
     def get_data(self, rank: int, step: int) -> dict:
         """Called by each rank's StreamingDataLoader. Blocks until data ready."""

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -873,7 +873,7 @@ def make_batch_from_groups(
     total_prompt_tokens = 0
     total_response_tokens = 0
     max_generation_time = 0
-    per_group_generation_times: list[float] = []
+    total_generation_time = 0.0
 
     for group in groups:
         result = group.result
@@ -913,11 +913,9 @@ def make_batch_from_groups(
         total_prompt_tokens += result.token_statistics.num_prompt_tokens
         total_response_tokens += result.token_statistics.num_response_tokens
         max_generation_time = max(max_generation_time, result.token_statistics.generation_time)
-        per_group_generation_times.append(result.token_statistics.generation_time)
+        total_generation_time += result.token_statistics.generation_time
 
-    mean_per_group_wall_time = (
-        sum(per_group_generation_times) / len(per_group_generation_times) if per_group_generation_times else 0.0
-    )
+    mean_per_group_wall_time = total_generation_time / len(groups)
 
     accumulated_stats = data_types.TokenStatistics(
         num_prompt_tokens=total_prompt_tokens,

--- a/open_instruct/data_types.py
+++ b/open_instruct/data_types.py
@@ -17,6 +17,7 @@ class TokenStatistics:
     num_response_tokens: int
     generation_time: float
     earliest_start_time: float | None = None
+    mean_per_group_wall_time: float | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Adds a new `time/per_group_wall_time` metric: the **mean** of per-group generation wall-clock times across the batch.
- Distinct from existing `time/getting_response`, which is the **max** of per-group times and gets dominated by tail-inflated groups when many requests are in flight (high `--num_async_steps`, many engines, etc.).
- Underlying timestamps are already captured (`metadata["start_time"]` in `add_request`; `current_time` in `finalize_completed_request`); per-group `generation_time` is already on `TokenStatistics`. This change just plumbs the mean through `make_batch_from_groups` and emits it as a new metric.

Applies to both `grpo_fast.py` and `grpo.py` since they share `DataPreparationActor`.

## Test plan
- [ ] `scripts/train/debug/single_gpu_grpo.sh` succeeds; `time/per_group_wall_time` appears in wandb.
- [ ] `scripts/train/qwen/qwen3_4b_dapo_math_oc.sh` (50 steps): inspect `time/per_group_wall_time` vs `time/getting_response`; mean should be <= max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)