### PR TITLE
Log filtered prompts at INFO + add batch/filtered_prompts_pct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Log every filtered prompt in `accumulate_inference_batches` at INFO level with the zero/solved/nonzero breakdown, and add `batch/filtered_prompts_pct` to wandb so policy collapse / convergence is visible without spelunking debug logs.
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Log every filtered prompt in `accumulate_inference_batches` at INFO level with the zero/solved/nonzero breakdown, and add `batch/filtered_prompts_pct` to wandb so policy collapse / convergence is visible without spelunking debug logs.
+- Log every filtered prompt in `accumulate_inference_batches` at INFO level with the zero/solved/nonzero breakdown, and add `batch/filtered_prompts_pct` to wandb so policy collapse / convergence is visible without spelunking debug logs (https://github.com/allenai/open-instruct/pull/1657).
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -649,6 +649,7 @@ class BatchStatistics:
     filtered_prompts_zero: int
     filtered_prompts_solved: int
     filtered_prompts_nonzero: int
+    filtered_prompts_pct: float
     percent_solved_mean: float
     percent_solved_hist: np.ndarray
     no_resampled_prompts: int
@@ -965,6 +966,9 @@ def make_batch_from_groups(
     combined_reward_metrics["num_steps_off_policy"] = float(training_step - model_steps_array.mean())
     percent_solved_mean = np.mean(all_percent_solved) if all_percent_solved else 0.0
 
+    total_prompts = len(groups)
+    total_seen = filtered_prompts + total_prompts
+    filtered_prompts_pct = filtered_prompts / total_seen if total_seen > 0 else 0.0
     batch_stats = BatchStatistics(
         prompt_lengths=prompt_lengths,
         response_lengths=response_lengths,
@@ -972,10 +976,11 @@ def make_batch_from_groups(
         filtered_prompts_zero=filtered_prompts_zero,
         filtered_prompts_solved=filtered_prompts_solved,
         filtered_prompts_nonzero=filtered_prompts_nonzero,
+        filtered_prompts_pct=filtered_prompts_pct,
         percent_solved_mean=percent_solved_mean,
         percent_solved_hist=np.array(all_percent_solved),
         no_resampled_prompts=no_resampled_prompts,
-        total_prompts=len(groups),
+        total_prompts=total_prompts,
     )
     return combined_result, batch, combined_reward_metrics, batch_stats
 
@@ -1078,8 +1083,11 @@ def accumulate_inference_batches(
                 filtered_prompt_solved += 1
             else:
                 filtered_prompt_nonzero += 1
-            logging.debug(
-                f"[Data Preparation Thread] Filtered prompt with reward std 0, total filtered {total_filtered_prompts}"
+            logger.info(
+                f"[accumulate_inference_batches] training_step={training_step} "
+                f"sampled={num_prompts_sampled}/{num_prompts} "
+                f"filtered={total_filtered_prompts} "
+                f"(all_zero={filtered_prompt_zero}, all_solved={filtered_prompt_solved}, nonzero_std0={filtered_prompt_nonzero})"
             )
             continue
 


### PR DESCRIPTION
## Summary

- Bump per-filter log in `accumulate_inference_batches` from DEBUG to INFO with `training_step`, `sampled/num_prompts`, and the zero/solved/nonzero breakdown so the active-sampling failure modes are obvious from logs alone.
- Add `batch/filtered_prompts_pct = filtered / (filtered + kept)` to `BatchStatistics`, automatically surfaced as a wandb scalar.

## Why

Hit a stuck `qwen3_4b_dapo_math` run (Beaker `01KQT9S2CR2FF6VA8XSG6CMPRN`, wandb `ai2-llm/rl-difficulty-curriculum/fo5n0g8i`) where a grad-norm spike (~11) at step 712 collapsed the policy. Post-collapse, ~99% of rollouts scored 0, so `--active_sampling` filtered hundreds of prompts per step trying to find non-zero variance. From logs the only visible signal was `Got result 1/8` repeating for hours — the filter counters were DEBUG-only, and the `filtered_prompts_zero` vs `filtered_prompts_solved` split (the thing that actually distinguishes "model failing everything" from "model converged") was buried in wandb summary.

`filtered_prompts_pct` makes the regime change obvious in wandb: ~0 when healthy, → 1 when stuck.

## Test plan

- [ ] `make style && make quality` (passes locally).
- [ ] Smoke-launch a small GRPO run and confirm `batch/filtered_prompts_pct` appears in wandb.

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)