### PR TITLE
Resample filtered batches in DataPreparationActor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Resample on filtered batches in `DataPreparationActor` instead of emitting empty `CollatedBatchData`, unifying the `grpo.py` and `grpo_fast.py` consumer paths and removing the now-dead empty-batch checks in `grpo_fast.py`.
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max).
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).
@@ -54,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 
 ### Added
+- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max).
 - Replace `scripts/submit_eval_jobs.py` with a new olmo-eval-internal launcher (Beaker v2, no gantry); the previous script is preserved as `scripts/submit_eval_jobs_old.py` and emits a `DeprecationWarning` (https://github.com/allenai/open-instruct/pull/1638).
 - Add OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1579).
 - Add DR-TULU replication script for Qwen 3.5 4B with evolving rubrics, per-tool pool size overrides, `vllm_qwen3_xml` parser, and `<answer>` tag extraction in rubric scoring (https://github.com/allenai/open-instruct/pull/1609).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max).
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,6 @@ All notable changes to this project will be documented in this file.
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 
 ### Added
-- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max) (https://github.com/allenai/open-instruct/pull/1656).
 - Replace `scripts/submit_eval_jobs.py` with a new olmo-eval-internal launcher (Beaker v2, no gantry); the previous script is preserved as `scripts/submit_eval_jobs_old.py` and emits a `DeprecationWarning` (https://github.com/allenai/open-instruct/pull/1638).
 - Add OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1579).
 - Add DR-TULU replication script for Qwen 3.5 4B with evolving rubrics, per-tool pool size overrides, `vllm_qwen3_xml` parser, and `<answer>` tag extraction in rubric scoring (https://github.com/allenai/open-instruct/pull/1609).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ All notable changes to this project will be documented in this file.
 - Add `--no_auto_dataset_cache` to GRPO and SFT integration test scripts to avoid HuggingFace 504 timeouts on CI runner (https://github.com/allenai/open-instruct/pull/1571).
 
 ### Added
-- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max).
+- Add `time/per_group_wall_time` metric: mean of per-group generation wall-clock times across the batch, providing a cleaner per-group timing signal than `time/getting_response` (which is the max) (https://github.com/allenai/open-instruct/pull/1656).
 - Replace `scripts/submit_eval_jobs.py` with a new olmo-eval-internal launcher (Beaker v2, no gantry); the previous script is preserved as `scripts/submit_eval_jobs_old.py` and emits a `DeprecationWarning` (https://github.com/allenai/open-instruct/pull/1638).
 - Add OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1579).
 - Add DR-TULU replication script for Qwen 3.5 4B with evolving rubrics, per-tool pool size overrides, `vllm_qwen3_xml` parser, and `<answer>` tag extraction in rubric scoring (https://github.com/allenai/open-instruct/pull/1609).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Resample on filtered batches in `DataPreparationActor` instead of emitting empty `CollatedBatchData`, unifying the `grpo.py` and `grpo_fast.py` consumer paths and removing the now-dead empty-batch checks in `grpo_fast.py`.
+- Resample on filtered batches in `DataPreparationActor` instead of emitting empty `CollatedBatchData`, unifying the `grpo.py` and `grpo_fast.py` consumer paths and removing the now-dead empty-batch checks in `grpo_fast.py` (https://github.com/allenai/open-instruct/pull/1660).
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).
 - Match reference SFT run: `olmo_core_finetune.py` parity with pure olmo-core; default CP strategy switched to `ulysses` and ring-flash-attn dependency removed (https://github.com/allenai/open-instruct/pull/1620).
 - Address review feedback on #1620: derive vocab size from the run's tokenizer (no longer hardcoded to dolma2), validate complete numpy artifacts before reusing the SFT cache, fold seed/max_seq_length into the cache directory, fix HF-vs-olmo-core checkpoint detection for relative local paths, and log which checkpoint format was detected (https://github.com/allenai/open-instruct/pull/1620).

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -1418,6 +1418,13 @@ class DataPreparationActor:
                 result.finish_reasons = [result.finish_reasons[i] for i in stop_idxes]
                 result.logprobs = [result.logprobs[i] for i in stop_idxes]
 
+            if len(result.responses) == 0:
+                logger.warning(
+                    f"[DataPreparationActor] Step {step}: no trainable responses left after filtering; "
+                    "resampling without advancing step counter"
+                )
+                continue
+
             packed_sequences = pack_sequences(
                 queries=batch.queries,
                 responses=result.responses,
@@ -1440,67 +1447,64 @@ class DataPreparationActor:
                 packed_sequences, self.dp_world_size, self.per_device_train_batch_size, self.tokenizer.pad_token_id
             )
 
-            if len(result.responses) == 0:
-                step_metrics = {"time/generation_idle_waiting_for_trainer": generation_idle_wait_time}
-            else:
-                real_num_responses = len(result.responses)
-                expected_num_responses = self.config.num_samples_per_prompt_rollout * self.global_batch_size
-                unsolved_num_responses = (scores < self.config.max_possible_score).sum()
-                sequence_lengths = np.array([len(response) for response in result.responses])
-                sequence_length_solved = (
-                    np.array([])
-                    if np.all(scores == 0)
-                    else np.array(sequence_lengths[scores == self.config.max_possible_score])
-                )
-                sequence_length_unsolved = (
-                    np.array([])
-                    if np.all(scores == self.config.max_possible_score)
-                    else np.array(sequence_lengths[scores == 0])
-                )
-                stop_rate = sum(int(fr == "stop") for fr in result.finish_reasons) / len(result.finish_reasons)
+            real_num_responses = len(result.responses)
+            expected_num_responses = self.config.num_samples_per_prompt_rollout * self.global_batch_size
+            unsolved_num_responses = (scores < self.config.max_possible_score).sum()
+            sequence_lengths = np.array([len(response) for response in result.responses])
+            sequence_length_solved = (
+                np.array([])
+                if np.all(scores == 0)
+                else np.array(sequence_lengths[scores == self.config.max_possible_score])
+            )
+            sequence_length_unsolved = (
+                np.array([])
+                if np.all(scores == self.config.max_possible_score)
+                else np.array(sequence_lengths[scores == 0])
+            )
+            stop_rate = sum(int(fr == "stop") for fr in result.finish_reasons) / len(result.finish_reasons)
 
-                batch_metrics_dict = asdict(batch_stats)
-                batch_metrics_prefixed = {f"batch/{k}": v for k, v in batch_metrics_dict.items()}
+            batch_metrics_dict = asdict(batch_stats)
+            batch_metrics_prefixed = {f"batch/{k}": v for k, v in batch_metrics_dict.items()}
 
-                step_metrics = {
-                    "time/generation_idle_waiting_for_trainer": generation_idle_wait_time,
-                    "scores": scores.mean(),
-                    "real_batch_size_ratio": real_num_responses / expected_num_responses,
-                    "unsolved_batch_size_ratio": unsolved_num_responses / real_num_responses,
-                    "packed_ratio": len(packed_sequences.query_responses) / real_num_responses,
-                    "val/solve_rate_hist": batch_stats.percent_solved_hist,
-                    "val/total_reward_groups": real_num_responses / self.config.num_samples_per_prompt_rollout,
-                    "val/sequence_lengths": sequence_lengths.mean(),
-                    "val/sequence_lengths_min": sequence_lengths.min(),
-                    "val/sequence_lengths_max": sequence_lengths.max(),
-                    "val/sequence_lengths_unsolved": (
-                        0 if len(sequence_length_unsolved) == 0 else sequence_length_unsolved.mean()
-                    ),
-                    "val/sequence_lengths_solved": (
-                        0 if len(sequence_length_solved) == 0 else sequence_length_solved.mean()
-                    ),
-                    "val/sequence_lengths_unsolved_hist": sequence_length_unsolved,
-                    "val/sequence_lengths_solved_hist": sequence_length_solved,
-                    "val/stop_rate": stop_rate,
-                    "val/advantages_mean": advantages.mean(),
-                    "val/advantages_min": advantages.min(),
-                    "val/advantages_max": advantages.max(),
-                    "val/advantages_hist": advantages,
-                    **reward_metrics,
-                    **batch_metrics_prefixed,
-                }
+            step_metrics = {
+                "time/generation_idle_waiting_for_trainer": generation_idle_wait_time,
+                "scores": scores.mean(),
+                "real_batch_size_ratio": real_num_responses / expected_num_responses,
+                "unsolved_batch_size_ratio": unsolved_num_responses / real_num_responses,
+                "packed_ratio": len(packed_sequences.query_responses) / real_num_responses,
+                "val/solve_rate_hist": batch_stats.percent_solved_hist,
+                "val/total_reward_groups": real_num_responses / self.config.num_samples_per_prompt_rollout,
+                "val/sequence_lengths": sequence_lengths.mean(),
+                "val/sequence_lengths_min": sequence_lengths.min(),
+                "val/sequence_lengths_max": sequence_lengths.max(),
+                "val/sequence_lengths_unsolved": (
+                    0 if len(sequence_length_unsolved) == 0 else sequence_length_unsolved.mean()
+                ),
+                "val/sequence_lengths_solved": (
+                    0 if len(sequence_length_solved) == 0 else sequence_length_solved.mean()
+                ),
+                "val/sequence_lengths_unsolved_hist": sequence_length_unsolved,
+                "val/sequence_lengths_solved_hist": sequence_length_solved,
+                "val/stop_rate": stop_rate,
+                "val/advantages_mean": advantages.mean(),
+                "val/advantages_min": advantages.min(),
+                "val/advantages_max": advantages.max(),
+                "val/advantages_hist": advantages,
+                **reward_metrics,
+                **batch_metrics_prefixed,
+            }
 
-                tool_stats = EnvStatistics(tool_names=self.tool_names)
-                for rollout_stats in result.request_info.tool_call_stats:
-                    tool_stats.add_rollout(rollout_stats)
-                step_metrics.update(tool_stats.compute_metrics())
+            tool_stats = EnvStatistics(tool_names=self.tool_names)
+            for rollout_stats in result.request_info.tool_call_stats:
+                tool_stats.add_rollout(rollout_stats)
+            step_metrics.update(tool_stats.compute_metrics())
 
-                step_metrics.update(_aggregate_env_metrics(result.request_info.rollout_states))
+            step_metrics.update(_aggregate_env_metrics(result.request_info.rollout_states))
 
-                assert result.token_statistics is not None
-                total_tokens = result.token_statistics.num_prompt_tokens + result.token_statistics.num_response_tokens
-                step_metrics["val/actor_tokens_per_second"] = total_tokens / result.token_statistics.generation_time
-                step_metrics["time/getting_response"] = result.token_statistics.generation_time
+            assert result.token_statistics is not None
+            total_tokens = result.token_statistics.num_prompt_tokens + result.token_statistics.num_response_tokens
+            step_metrics["val/actor_tokens_per_second"] = total_tokens / result.token_statistics.generation_time
+            step_metrics["time/getting_response"] = result.token_statistics.generation_time
 
             with self.lock:
                 self.prepared_data[step] = collated_data

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -1353,10 +1353,24 @@ class DataPreparationActor:
             if isinstance(result, data_types.ShutdownSentinel):
                 return
 
-            if result is None:
+            if result is not None and self.config.mask_truncated_completions:
+                stop_idxes = [i for i, fr in enumerate(result.finish_reasons) if fr == "stop"]
+                num_truncated = len(result.finish_reasons) - len(stop_idxes)
+                if num_truncated > 0:
+                    logger.info(
+                        f"[DataPreparationActor] Filtered {num_truncated} responses that didn't finish with 'stop'. "
+                        f"Retention rate: {len(stop_idxes) / len(result.finish_reasons):.2%}"
+                    )
+                batch = batch[stop_idxes]
+                result.responses = [result.responses[i] for i in stop_idxes]
+                result.masks = [result.masks[i] for i in stop_idxes]
+                result.finish_reasons = [result.finish_reasons[i] for i in stop_idxes]
+                result.logprobs = [result.logprobs[i] for i in stop_idxes]
+
+            if result is None or len(result.responses) == 0:
                 logger.warning(
-                    f"[DataPreparationActor] Step {step}: all groups filtered "
-                    f"(zero-std rewards); resampling without advancing step counter"
+                    f"[DataPreparationActor] Step {step}: no trainable responses after filtering; "
+                    "resampling without advancing step counter"
                 )
                 continue
 
@@ -1399,31 +1413,6 @@ class DataPreparationActor:
                     self.total_samples_written,
                 )
                 self.total_samples_written += len(batch.queries)
-
-            if self.config.mask_truncated_completions:
-                stop_idxes = torch.tensor(
-                    [i for i in range(len(result.finish_reasons)) if result.finish_reasons[i] == "stop"]
-                )
-                num_truncated = len(result.finish_reasons) - len(stop_idxes)
-                if num_truncated > 0:
-                    logger.info(
-                        f"[DataPreparationActor] Filtered {num_truncated} responses that didn't finish with 'stop'. "
-                        f"Retention rate: {len(stop_idxes) / len(result.finish_reasons):.2%}"
-                    )
-                scores = scores[stop_idxes]
-                advantages = advantages[stop_idxes]
-                batch = batch[stop_idxes.tolist()]
-                result.responses = [result.responses[i] for i in stop_idxes]
-                result.masks = [result.masks[i] for i in stop_idxes]
-                result.finish_reasons = [result.finish_reasons[i] for i in stop_idxes]
-                result.logprobs = [result.logprobs[i] for i in stop_idxes]
-
-            if len(result.responses) == 0:
-                logger.warning(
-                    f"[DataPreparationActor] Step {step}: no trainable responses left after filtering; "
-                    "resampling without advancing step counter"
-                )
-                continue
 
             packed_sequences = pack_sequences(
                 queries=batch.queries,

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -873,7 +873,6 @@ def make_batch_from_groups(
     total_prompt_tokens = 0
     total_response_tokens = 0
     max_generation_time = 0
-    total_generation_time = 0.0
 
     for group in groups:
         result = group.result
@@ -913,16 +912,12 @@ def make_batch_from_groups(
         total_prompt_tokens += result.token_statistics.num_prompt_tokens
         total_response_tokens += result.token_statistics.num_response_tokens
         max_generation_time = max(max_generation_time, result.token_statistics.generation_time)
-        total_generation_time += result.token_statistics.generation_time
-
-    mean_per_group_wall_time = total_generation_time / len(groups)
 
     accumulated_stats = data_types.TokenStatistics(
         num_prompt_tokens=total_prompt_tokens,
         num_response_tokens=total_response_tokens,
         generation_time=max_generation_time,
         earliest_start_time=earliest_start_time,
-        mean_per_group_wall_time=mean_per_group_wall_time,
     )
 
     combined_request_info = data_types.RequestInfo(
@@ -1506,7 +1501,6 @@ class DataPreparationActor:
                 total_tokens = result.token_statistics.num_prompt_tokens + result.token_statistics.num_response_tokens
                 step_metrics["val/actor_tokens_per_second"] = total_tokens / result.token_statistics.generation_time
                 step_metrics["time/getting_response"] = result.token_statistics.generation_time
-                step_metrics["time/per_group_wall_time"] = result.token_statistics.mean_per_group_wall_time
 
             with self.lock:
                 self.prepared_data[step] = collated_data

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -630,6 +630,11 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
             trainer_idle_wait_time = time.perf_counter() - wait_start_time
             batch_data.setdefault("metrics", {})["time/trainer_idle_waiting_for_inference"] = trainer_idle_wait_time
             self.training_step = step + 1
+            if len(batch_data["batch"]) == 0:
+                logger.warning(
+                    f"[Dataloader] Empty batch at step={step} (all groups filtered); skipping training step"
+                )
+                continue
             yield batch_data
 
 

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -630,11 +630,6 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
             trainer_idle_wait_time = time.perf_counter() - wait_start_time
             batch_data.setdefault("metrics", {})["time/trainer_idle_waiting_for_inference"] = trainer_idle_wait_time
             self.training_step = step + 1
-            if len(batch_data["batch"]) == 0:
-                logger.warning(
-                    f"[Dataloader] Empty batch at step={step} (all groups filtered); skipping training step"
-                )
-                continue
             yield batch_data
 
 

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -873,6 +873,7 @@ def make_batch_from_groups(
     total_prompt_tokens = 0
     total_response_tokens = 0
     max_generation_time = 0
+    per_group_generation_times: list[float] = []
 
     for group in groups:
         result = group.result
@@ -912,12 +913,18 @@ def make_batch_from_groups(
         total_prompt_tokens += result.token_statistics.num_prompt_tokens
         total_response_tokens += result.token_statistics.num_response_tokens
         max_generation_time = max(max_generation_time, result.token_statistics.generation_time)
+        per_group_generation_times.append(result.token_statistics.generation_time)
+
+    mean_per_group_wall_time = (
+        sum(per_group_generation_times) / len(per_group_generation_times) if per_group_generation_times else 0.0
+    )
 
     accumulated_stats = data_types.TokenStatistics(
         num_prompt_tokens=total_prompt_tokens,
         num_response_tokens=total_response_tokens,
         generation_time=max_generation_time,
         earliest_start_time=earliest_start_time,
+        mean_per_group_wall_time=mean_per_group_wall_time,
     )
 
     combined_request_info = data_types.RequestInfo(
@@ -1511,6 +1518,7 @@ class DataPreparationActor:
                 total_tokens = result.token_statistics.num_prompt_tokens + result.token_statistics.num_response_tokens
                 step_metrics["val/actor_tokens_per_second"] = total_tokens / result.token_statistics.generation_time
                 step_metrics["time/getting_response"] = result.token_statistics.generation_time
+                step_metrics["time/per_group_wall_time"] = result.token_statistics.mean_per_group_wall_time
 
             with self.lock:
                 self.prepared_data[step] = collated_data

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -630,11 +630,6 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
             trainer_idle_wait_time = time.perf_counter() - wait_start_time
             batch_data.setdefault("metrics", {})["time/trainer_idle_waiting_for_inference"] = trainer_idle_wait_time
             self.training_step = step + 1
-            if len(batch_data["batch"]) == 0:
-                logger.warning(
-                    f"[Dataloader] Empty batch at step={step} (all groups filtered); skipping training step"
-                )
-                continue
             yield batch_data
 
 
@@ -1323,7 +1318,8 @@ class DataPreparationActor:
                 ground_truth_overrides=self.ground_truth_overrides,
             )
 
-        for step in range(self.training_step, self.num_training_steps):
+        step = self.training_step
+        while step < self.num_training_steps:
             generation_idle_wait_start_time = time.perf_counter()
             while step - self._last_consumed_step > self.config.async_steps:
                 logger.info(
@@ -1363,21 +1359,9 @@ class DataPreparationActor:
                 return
 
             if result is None:
-                empty_data = [
-                    data_types.CollatedBatchData(
-                        query_responses=[],
-                        attention_masks=[],
-                        position_ids=[],
-                        advantages=[],
-                        response_masks=[],
-                        vllm_logprobs=[],
-                    )
-                    for _ in range(self.dp_world_size)
-                ]
-                with self.lock:
-                    self.prepared_data[step] = empty_data
-                    self.metrics[step] = {"time/generation_idle_waiting_for_trainer": generation_idle_wait_time}
-                    self.current_prepared_step = step
+                logger.warning(
+                    f"[DataPreparationActor] Step {step}: all groups filtered (zero-std rewards); resampling without advancing step counter"
+                )
                 continue
 
             assert batch is not None
@@ -1527,6 +1511,8 @@ class DataPreparationActor:
                 self.prepared_data[step] = collated_data
                 self.metrics[step] = step_metrics
                 self.current_prepared_step = step
+
+            step += 1
 
     def get_data(self, rank: int, step: int) -> dict:
         """Called by each rank's StreamingDataLoader. Blocks until data ready."""

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -630,6 +630,11 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
             trainer_idle_wait_time = time.perf_counter() - wait_start_time
             batch_data.setdefault("metrics", {})["time/trainer_idle_waiting_for_inference"] = trainer_idle_wait_time
             self.training_step = step + 1
+            if len(batch_data["batch"]) == 0:
+                logger.warning(
+                    f"[Dataloader] Empty batch at step={step} (all groups filtered); skipping training step"
+                )
+                continue
             yield batch_data
 
 
@@ -1318,8 +1323,7 @@ class DataPreparationActor:
                 ground_truth_overrides=self.ground_truth_overrides,
             )
 
-        step = self.training_step
-        while step < self.num_training_steps:
+        for step in range(self.training_step, self.num_training_steps):
             generation_idle_wait_start_time = time.perf_counter()
             while step - self._last_consumed_step > self.config.async_steps:
                 logger.info(
@@ -1359,9 +1363,21 @@ class DataPreparationActor:
                 return
 
             if result is None:
-                logger.warning(
-                    f"[DataPreparationActor] Step {step}: all groups filtered (zero-std rewards); resampling without advancing step counter"
-                )
+                empty_data = [
+                    data_types.CollatedBatchData(
+                        query_responses=[],
+                        attention_masks=[],
+                        position_ids=[],
+                        advantages=[],
+                        response_masks=[],
+                        vllm_logprobs=[],
+                    )
+                    for _ in range(self.dp_world_size)
+                ]
+                with self.lock:
+                    self.prepared_data[step] = empty_data
+                    self.metrics[step] = {"time/generation_idle_waiting_for_trainer": generation_idle_wait_time}
+                    self.current_prepared_step = step
                 continue
 
             assert batch is not None
@@ -1511,8 +1527,6 @@ class DataPreparationActor:
                 self.prepared_data[step] = collated_data
                 self.metrics[step] = step_metrics
                 self.current_prepared_step = step
-
-            step += 1
 
     def get_data(self, rank: int, step: int) -> dict:
         """Called by each rank's StreamingDataLoader. Blocks until data ready."""

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -1318,7 +1318,8 @@ class DataPreparationActor:
                 ground_truth_overrides=self.ground_truth_overrides,
             )
 
-        for step in range(self.training_step, self.num_training_steps):
+        step = self.training_step
+        while step < self.num_training_steps:
             generation_idle_wait_start_time = time.perf_counter()
             while step - self._last_consumed_step > self.config.async_steps:
                 logger.info(
@@ -1358,21 +1359,10 @@ class DataPreparationActor:
                 return
 
             if result is None:
-                empty_data = [
-                    data_types.CollatedBatchData(
-                        query_responses=[],
-                        attention_masks=[],
-                        position_ids=[],
-                        advantages=[],
-                        response_masks=[],
-                        vllm_logprobs=[],
-                    )
-                    for _ in range(self.dp_world_size)
-                ]
-                with self.lock:
-                    self.prepared_data[step] = empty_data
-                    self.metrics[step] = {"time/generation_idle_waiting_for_trainer": generation_idle_wait_time}
-                    self.current_prepared_step = step
+                logger.warning(
+                    f"[DataPreparationActor] Step {step}: all groups filtered "
+                    f"(zero-std rewards); resampling without advancing step counter"
+                )
                 continue
 
             assert batch is not None
@@ -1522,6 +1512,7 @@ class DataPreparationActor:
                 self.prepared_data[step] = collated_data
                 self.metrics[step] = step_metrics
                 self.current_prepared_step = step
+            step += 1
 
     def get_data(self, rank: int, step: int) -> dict:
         """Called by each rank's StreamingDataLoader. Blocks until data ready."""

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -873,7 +873,7 @@ def make_batch_from_groups(
     total_prompt_tokens = 0
     total_response_tokens = 0
     max_generation_time = 0
-    per_group_generation_times: list[float] = []
+    total_generation_time = 0.0
 
     for group in groups:
         result = group.result
@@ -913,11 +913,9 @@ def make_batch_from_groups(
         total_prompt_tokens += result.token_statistics.num_prompt_tokens
         total_response_tokens += result.token_statistics.num_response_tokens
         max_generation_time = max(max_generation_time, result.token_statistics.generation_time)
-        per_group_generation_times.append(result.token_statistics.generation_time)
+        total_generation_time += result.token_statistics.generation_time
 
-    mean_per_group_wall_time = (
-        sum(per_group_generation_times) / len(per_group_generation_times) if per_group_generation_times else 0.0
-    )
+    mean_per_group_wall_time = total_generation_time / len(groups)
 
     accumulated_stats = data_types.TokenStatistics(
         num_prompt_tokens=total_prompt_tokens,

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -1115,6 +1115,24 @@ def accumulate_inference_batches(
     )
 
 
+def maybe_mask_truncated_completions(result: data_types.GenerationResult, batch: Batch, enabled: bool) -> Batch:
+    """If enabled, drop rollouts that didn't finish with 'stop' from result (in place) and batch."""
+    if not enabled:
+        return batch
+    stop_idxes = [i for i, fr in enumerate(result.finish_reasons) if fr == "stop"]
+    num_truncated = len(result.finish_reasons) - len(stop_idxes)
+    if num_truncated > 0:
+        logger.info(
+            f"[DataPreparationActor] Filtered {num_truncated} responses that didn't finish with 'stop'. "
+            f"Retention rate: {len(stop_idxes) / len(result.finish_reasons):.2%}"
+        )
+    result.responses = [result.responses[i] for i in stop_idxes]
+    result.masks = [result.masks[i] for i in stop_idxes]
+    result.finish_reasons = [result.finish_reasons[i] for i in stop_idxes]
+    result.logprobs = [result.logprobs[i] for i in stop_idxes]
+    return batch[stop_idxes]
+
+
 def prepare_collated_data_for_workers(
     packed_sequences: PackedSequences,
     dp_world_size: int,
@@ -1353,29 +1371,24 @@ class DataPreparationActor:
             if isinstance(result, data_types.ShutdownSentinel):
                 return
 
-            if result is not None and self.config.mask_truncated_completions:
-                stop_idxes = [i for i, fr in enumerate(result.finish_reasons) if fr == "stop"]
-                num_truncated = len(result.finish_reasons) - len(stop_idxes)
-                if num_truncated > 0:
-                    logger.info(
-                        f"[DataPreparationActor] Filtered {num_truncated} responses that didn't finish with 'stop'. "
-                        f"Retention rate: {len(stop_idxes) / len(result.finish_reasons):.2%}"
-                    )
-                batch = batch[stop_idxes]
-                result.responses = [result.responses[i] for i in stop_idxes]
-                result.masks = [result.masks[i] for i in stop_idxes]
-                result.finish_reasons = [result.finish_reasons[i] for i in stop_idxes]
-                result.logprobs = [result.logprobs[i] for i in stop_idxes]
-
-            if result is None or len(result.responses) == 0:
+            if result is None:
                 logger.warning(
-                    f"[DataPreparationActor] Step {step}: no trainable responses after filtering; "
+                    f"[DataPreparationActor] Step {step}: all groups filtered (zero-std rewards); "
                     "resampling without advancing step counter"
                 )
                 continue
 
             assert batch is not None
             assert batch_stats is not None
+
+            batch = maybe_mask_truncated_completions(result, batch, self.config.mask_truncated_completions)
+
+            if len(result.responses) == 0:
+                logger.warning(
+                    f"[DataPreparationActor] Step {step}: no trainable responses after truncation filter; "
+                    "resampling without advancing step counter"
+                )
+                continue
 
             if self.rubric_manager and batch.decoded_responses:
                 rubric_metrics, new_overrides = self.rubric_manager.run_step(

--- a/open_instruct/data_types.py
+++ b/open_instruct/data_types.py
@@ -17,7 +17,6 @@ class TokenStatistics:
     num_response_tokens: int
     generation_time: float
     earliest_start_time: float | None = None
-    mean_per_group_wall_time: float | None = None
 
 
 @dataclass

--- a/open_instruct/data_types.py
+++ b/open_instruct/data_types.py
@@ -17,6 +17,7 @@ class TokenStatistics:
     num_response_tokens: int
     generation_time: float
     earliest_start_time: float | None = None
+    mean_per_group_wall_time: float | None = None
 
 
 @dataclass

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -611,9 +611,6 @@ class PolicyTrainerRayProcess(RayProcess):
         """
         batch_data = next(self.dataloader)
         data_BT = batch_data["batch"]
-        if len(data_BT) == 0:
-            logger.warning("[Training] Empty batch received, skipping training step")
-            return [], {}
 
         # split batch for sequence parallelism. Do before moving data to GPU.
         if self.splitter is not None:
@@ -1569,9 +1566,6 @@ def one_training_step(
             desc=f"Running training step {training_step}",
         )
         metrics, array_metrics = zip(*results)
-        if all(len(m) == 0 for m in metrics):
-            logger.warning("[Main Thread] 🤡 After packing, there is not enough data to train")
-            return 0
         if (
             args.load_ref_policy
             and args.ref_policy_update_freq is not None


### PR DESCRIPTION
When `filter_zero_std_samples=True`, `accumulate_inference_batches` can return `result is None` if every group has zero-std rewards. The old code emitted an empty `CollatedBatchData` placeholder and advanced the step counter. `grpo_fast.py` tolerated this with explicit empty-batch checks, but `grpo.py` didn't.

In this PR, in `_data_preparation_loop`, convert the `for` loop to a `while` and `continue` (without advancing `step`) on `result is None`. Every batch handed to a consumer is now legit.
- Drop the (now-dead) empty-batch guards in `grpo_fast.py`. Both `grpo.py` and `grpo_fast.py` consume the same well-formed stream.


Runs:

- `single_gpu_grpo_async4.sh` (`--async_steps 4`): completes 6/6 steps, observe at least one resample warning, no `KeyError` on `batch/prompt_lengths`.
- `qwen3_4b_dapo_math_oc.sh` (4 vllm engines, `--async_steps 4`): runs past step 120 with no empty-batch crashes.
- `make style && make quality` — passes locally.