### PR TITLE
Update Beaker budget from ai2/oe-adapt to ai2/oe-omai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Update Beaker budget from `ai2/oe-adapt` to `ai2/oe-omai` across launch scripts and beaker configs to fix experiment launch failures from the retired budget (https://github.com/allenai/open-instruct/pull/1660).
 - Log every filtered prompt in `accumulate_inference_batches` at INFO level with the zero/solved/nonzero breakdown, and add `batch/filtered_prompts_pct` to wandb so policy collapse / convergence is visible without spelunking debug logs (https://github.com/allenai/open-instruct/pull/1657).
 - Aggregate prompt/response lengths across all DP ranks (deduplicating SP groups) when computing GRPO step token counts and utilization metrics, instead of using only rank 0 (https://github.com/allenai/open-instruct/pull/1659).
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Update Beaker budget from `ai2/oe-adapt` to `ai2/oe-omai` across launch scripts and beaker configs to fix experiment launch failures from the retired budget (https://github.com/allenai/open-instruct/pull/1660).
+- Update Beaker budget from `ai2/oe-adapt` to `ai2/oe-omai` across launch scripts and beaker configs to fix experiment launch failures from the retired budget (https://github.com/allenai/open-instruct/pull/1662).
 - Log every filtered prompt in `accumulate_inference_batches` at INFO level with the zero/solved/nonzero breakdown, and add `batch/filtered_prompts_pct` to wandb so policy collapse / convergence is visible without spelunking debug logs (https://github.com/allenai/open-instruct/pull/1657).
 - Aggregate prompt/response lengths across all DP ranks (deduplicating SP groups) when computing GRPO step token counts and utilization metrics, instead of using only rank 0 (https://github.com/allenai/open-instruct/pull/1659).
 - Split `accumulate_inference_batches` into `process_single_result` and `combine_processed_results` for clarity (https://github.com/allenai/open-instruct/pull/1614).

--- a/configs/beaker_configs/default_dpo.yaml
+++ b/configs/beaker_configs/default_dpo.yaml
@@ -1,6 +1,6 @@
 version: v2
 description: open-instruct-finetune
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 tasks:
   - name: open-instruct-finetune
     image:

--- a/configs/beaker_configs/default_dpo_multinode.yaml
+++ b/configs/beaker_configs/default_dpo_multinode.yaml
@@ -1,6 +1,6 @@
 version: v2
 description: open-instruct-finetune-multinode
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 tasks:
   - name: open-instruct-finetune-multinode
     replicas: 4

--- a/configs/beaker_configs/default_dpo_multinode_olmo2_1124.yaml
+++ b/configs/beaker_configs/default_dpo_multinode_olmo2_1124.yaml
@@ -1,6 +1,6 @@
 version: v2
 description: open-instruct-finetune-multinode
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 tasks:
   - name: open-instruct-finetune-multinode
     replicas: 4

--- a/configs/beaker_configs/default_dpo_multinode_olmo2_1124_augusta.yaml
+++ b/configs/beaker_configs/default_dpo_multinode_olmo2_1124_augusta.yaml
@@ -1,6 +1,6 @@
 version: v2
 description: open-instruct-finetune-multinode
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 tasks:
   - name: open-instruct-finetune-multinode
     replicas: 4

--- a/configs/beaker_configs/default_eval.yaml
+++ b/configs/beaker_configs/default_eval.yaml
@@ -1,6 +1,6 @@
 version: v2
 description: open-instruct-eval-default
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 retry:
   allowedTaskRetries: 2
 tasks:

--- a/configs/beaker_configs/default_finetune.yaml
+++ b/configs/beaker_configs/default_finetune.yaml
@@ -1,6 +1,6 @@
 version: v2
 description: open-instruct-finetune
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 tasks:
   - name: open-instruct-finetune
     image:

--- a/configs/beaker_configs/default_finetune_multinode.yaml
+++ b/configs/beaker_configs/default_finetune_multinode.yaml
@@ -1,6 +1,6 @@
 version: v2
 description: open-instruct-finetune-multinode
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 tasks:
   - name: open-instruct-finetune-multinode
     replicas: 4

--- a/configs/beaker_configs/default_finetune_multinode_olmo2_1124.yaml
+++ b/configs/beaker_configs/default_finetune_multinode_olmo2_1124.yaml
@@ -1,6 +1,6 @@
 version: v2
 description: open-instruct-finetune-multinode
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 tasks:
   - name: open-instruct-finetune-multinode
     replicas: 4

--- a/configs/beaker_configs/default_finetune_multinode_olmo2_1124_augusta.yaml
+++ b/configs/beaker_configs/default_finetune_multinode_olmo2_1124_augusta.yaml
@@ -1,6 +1,6 @@
 version: v2
 description: open-instruct-finetune-multinode
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 tasks:
   - name: open-instruct-finetune-multinode
     replicas: 4

--- a/configs/judge_configs/general_verifier_judge.yaml
+++ b/configs/judge_configs/general_verifier_judge.yaml
@@ -1,5 +1,5 @@
 version: v2
-budget: ai2/oe-adapt
+budget: ai2/oe-omai
 description: "VLLM Server for general verifier"
 tasks:
   - name: "vllm-job"

--- a/scripts/benchmarking/launch_benchmark_single_gpu.sh
+++ b/scripts/benchmarking/launch_benchmark_single_gpu.sh
@@ -60,7 +60,7 @@ for model_name_or_path in "$@"; do
         --num_nodes 1 \
         --max_retries 0 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --gpus 1 \
         --secret HF_TOKEN=finbarrt_HF_TOKEN \
         --task_name open_instruct-benchmark_generators -- source configs/beaker_configs/ray_node_setup.sh \&\& python -m open_instruct.benchmark_generators \

--- a/scripts/benchmarking/launch_benchmark_single_node.sh
+++ b/scripts/benchmarking/launch_benchmark_single_node.sh
@@ -55,7 +55,7 @@ for model_name_or_path in "$@"; do
         --max_retries 0 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
         --env NCCL_CUMEM_ENABLE=0 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --gpus 8 \
         --secret HF_TOKEN=finbarrt_HF_TOKEN \
         --task_name open_instruct-benchmark_generators -- source configs/beaker_configs/ray_node_setup.sh \&\& python -m open_instruct.benchmark_generators \

--- a/scripts/benchmarking/launch_dpo_cache_benchmark.sh
+++ b/scripts/benchmarking/launch_dpo_cache_benchmark.sh
@@ -12,7 +12,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --no_auto_dataset_cache \
     --env OLMO_SHARED_FS=1 \
     --env "REFERENCE_LOGPROBS_CACHE_PATH=/tmp/benchmark_cache_\$(date +%s)" \

--- a/scripts/benchmarking/olmo3_infra.sh
+++ b/scripts/benchmarking/olmo3_infra.sh
@@ -31,7 +31,7 @@ for split_var in mixin_it_up; do
         --env HOSTED_VLLM_API_BASE=http://saturn-cs-aus-240.reviz.ai2.in:8001/v1 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
         --env LITELLM_LOG="ERROR" \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name ${exp_name} \
         --beta 0.0 \

--- a/scripts/data/rlvr_code/verify_qwq.py
+++ b/scripts/data/rlvr_code/verify_qwq.py
@@ -8,7 +8,7 @@ python mason.py \
     --priority high \
     --description "filtering correct python qwq generations" \
     --max_retries 0 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 0 -- source configs/beaker_configs/code_api_setup.sh \\&\\& python scripts/data/rlvr_code/verify_qwq.py
 """
 

--- a/scripts/eval/faster_oe_eval_mmlu.sh
+++ b/scripts/eval/faster_oe_eval_mmlu.sh
@@ -223,7 +223,7 @@ for TASK in "${all_mmlu_tasks[@]}"; do
         python oe-eval-internal/oe_eval/launch.py \
             --model "$MODEL_NAME" \
             --beaker-workspace "ai2/tulu-3-results" \
-            --beaker-budget ai2/oe-adapt \
+            --beaker-budget ai2/oe-omai \
             --task "$TASK" \
             $MODEL_TYPE \
             --batch-size "$BATCH_SIZE" \
@@ -240,7 +240,7 @@ for TASK in "${all_mmlu_tasks[@]}"; do
         python oe-eval-internal/oe_eval/launch.py \
         --model "$MODEL_NAME" \
         --beaker-workspace "ai2/tulu-3-results" \
-        --beaker-budget ai2/oe-adapt \
+        --beaker-budget ai2/oe-omai \
         --task "$TASK" \
         $MODEL_TYPE \
         --batch-size "$BATCH_SIZE" \

--- a/scripts/eval/oe-eval.sh
+++ b/scripts/eval/oe-eval.sh
@@ -353,7 +353,7 @@ for TASK in "${TASKS[@]}"; do
         python oe-eval-internal/oe_eval/launch.py \
             --model "$MODEL_NAME" \
             --beaker-workspace "$BEAKER_WORKSPACE" \
-            --beaker-budget ai2/oe-adapt \
+            --beaker-budget ai2/oe-omai \
             --beaker-timeout 48h \
             --task "$TASK" \
             $MODEL_TYPE \
@@ -375,7 +375,7 @@ for TASK in "${TASKS[@]}"; do
         python oe-eval-internal/oe_eval/launch.py \
         --model "$MODEL_NAME" \
         --beaker-workspace "$BEAKER_WORKSPACE" \
-        --beaker-budget ai2/oe-adapt \
+        --beaker-budget ai2/oe-omai \
         --beaker-timeout 48h \
         --task "$TASK" \
         $MODEL_TYPE \

--- a/scripts/merge/direct_merge.sh
+++ b/scripts/merge/direct_merge.sh
@@ -48,7 +48,7 @@ SCRIPT_B64=$(base64 < open_instruct/merge_models.py | tr -d '\n')
 
 uv run python mason.py \
     --cluster ai2/jupiter \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --workspace ai2/olmo-instruct \
     --image "$IMAGE" \
     --pure_docker_mode \

--- a/scripts/merge/mergekit_merge.sh
+++ b/scripts/merge/mergekit_merge.sh
@@ -61,7 +61,7 @@ INSTALL_CMD="uv pip install mergekit"
 
 uv run python mason.py \
     --cluster ai2/jupiter \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --workspace ai2/olmo-instruct \
     --image "$IMAGE" \
     --pure_docker_mode \

--- a/scripts/submit_eval_jobs.py
+++ b/scripts/submit_eval_jobs.py
@@ -78,7 +78,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--priority", type=str, default="normal")
     parser.add_argument("--preemptible", action="store_true")
     parser.add_argument("--workspace", type=str, default="ai2/tulu-3-results")
-    parser.add_argument("--budget", type=str, default="ai2/oe-adapt")
+    parser.add_argument("--budget", type=str, default="ai2/oe-omai")
     parser.add_argument(
         "--beaker_image",
         type=str,

--- a/scripts/test/run_gpu_pytest.sh
+++ b/scripts/test/run_gpu_pytest.sh
@@ -23,7 +23,7 @@ uv run python mason.py \
        --preemptible \
        --num_nodes 1 \
        --max_retries 0 \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --no-host-networking \
        --gpus 1 \
        --env GIT_COMMIT="$(git rev-parse --short HEAD)" \

--- a/scripts/train/debug/dpo/7b_instruct_dpo_olmo_core.sh
+++ b/scripts/train/debug/dpo/7b_instruct_dpo_olmo_core.sh
@@ -14,7 +14,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --no_auto_dataset_cache \
     --artifact_ttl 1d \
     --env OLMO_SHARED_FS=1 \

--- a/scripts/train/debug/dpo/checkpoint_integration_test.sh
+++ b/scripts/train/debug/dpo/checkpoint_integration_test.sh
@@ -63,7 +63,7 @@ run1_output=$(uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --no_auto_dataset_cache \
     --artifact_ttl 1d \
     --gpus 8 -- accelerate launch \
@@ -98,7 +98,7 @@ run2_output=$(uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --no_auto_dataset_cache \
     --artifact_ttl 1d \
     --gpus 8 -- accelerate launch \

--- a/scripts/train/debug/dpo/multi_node.sh
+++ b/scripts/train/debug/dpo/multi_node.sh
@@ -14,7 +14,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --no_auto_dataset_cache \
     --artifact_ttl 1d \
     --env OLMO_SHARED_FS=1 \

--- a/scripts/train/debug/dpo/multi_node_cache.sh
+++ b/scripts/train/debug/dpo/multi_node_cache.sh
@@ -10,7 +10,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --no_auto_dataset_cache \
     --artifact_ttl 1d \
     --gpus 8 -- accelerate launch \

--- a/scripts/train/debug/dpo/multi_node_hybrid.sh
+++ b/scripts/train/debug/dpo/multi_node_hybrid.sh
@@ -24,7 +24,7 @@ uv run python mason.py \
     --env TORCH_DIST_INIT_BARRIER=1 \
     --env TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1800 \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \

--- a/scripts/train/debug/dpo/single_gpu.sh
+++ b/scripts/train/debug/dpo/single_gpu.sh
@@ -11,7 +11,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 1 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --no_auto_dataset_cache \
     --artifact_ttl 1d \
     --no-host-networking \

--- a/scripts/train/debug/dpo_integration_test.sh
+++ b/scripts/train/debug/dpo_integration_test.sh
@@ -13,7 +13,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 1 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --artifact_ttl 1d \
     --gpus 1 -- accelerate launch \
     --mixed_precision bf16 \

--- a/scripts/train/debug/envs/guess_number_beaker.sh
+++ b/scripts/train/debug/envs/guess_number_beaker.sh
@@ -20,7 +20,7 @@ uv run python mason.py \
        --env VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
        --env VLLM_DISABLE_COMPILE_CACHE=1 \
        --env VLLM_USE_V1=1 \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --gpus 1 \
        --no_auto_dataset_cache \
        --artifact_ttl 1d \

--- a/scripts/train/debug/envs/sandbox_lm_8gpu.sh
+++ b/scripts/train/debug/envs/sandbox_lm_8gpu.sh
@@ -26,7 +26,7 @@ uv run python mason.py \
        --env VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
        --env VLLM_DISABLE_COMPILE_CACHE=1 \
        --env VLLM_USE_V1=1 \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --mount_docker_socket \
        --gpus 8 \
        --no_auto_dataset_cache \

--- a/scripts/train/debug/envs/wordle_8gpu.sh
+++ b/scripts/train/debug/envs/wordle_8gpu.sh
@@ -21,7 +21,7 @@ uv run python mason.py \
        --env VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
        --env VLLM_DISABLE_COMPILE_CACHE=1 \
        --env VLLM_USE_V1=1 \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --gpus 8 \
        --no_auto_dataset_cache \
        --artifact_ttl 1d \

--- a/scripts/train/debug/envs/wordle_sandbox_lm_8gpu.sh
+++ b/scripts/train/debug/envs/wordle_sandbox_lm_8gpu.sh
@@ -22,7 +22,7 @@ uv run python mason.py \
        --env VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
        --env VLLM_DISABLE_COMPILE_CACHE=1 \
        --env VLLM_USE_V1=1 \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --mount_docker_socket \
        --gpus 8 \
        --no_auto_dataset_cache \

--- a/scripts/train/debug/finetune.sh
+++ b/scripts/train/debug/finetune.sh
@@ -36,7 +36,7 @@ if [ -n "$1" ]; then
         --pure_docker_mode \
         --preemptible \
         --num_nodes 1 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --gpus 1 \
         --non_resumable \
         --artifact_ttl 1d \

--- a/scripts/train/debug/full_integration_test.sh
+++ b/scripts/train/debug/full_integration_test.sh
@@ -27,7 +27,7 @@ for split_var in split_int_mix_3; do
         --env HOSTED_VLLM_API_BASE=http://saturn-cs-aus-253.reviz.ai2.in:8001/v1 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
         --env LITELLM_LOG="ERROR" \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --artifact_ttl 1d \
         --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name ${exp_name} \

--- a/scripts/train/debug/grpo_integration_test.sh
+++ b/scripts/train/debug/grpo_integration_test.sh
@@ -18,7 +18,7 @@ uv run python mason.py \
        --num_nodes 1 \
        --max_retries 0 \
        --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --no-host-networking \
        --gpus 1 \
        --no_auto_dataset_cache \

--- a/scripts/train/debug/large_test_script.sh
+++ b/scripts/train/debug/large_test_script.sh
@@ -16,7 +16,7 @@ uv run python mason.py \
         --timeout 1h \
         --max_retries 0 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --no_auto_dataset_cache \
         --artifact_ttl 1d \
         --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\&python open_instruct/grpo_fast.py \

--- a/scripts/train/debug/large_test_script_hybrid.sh
+++ b/scripts/train/debug/large_test_script_hybrid.sh
@@ -15,7 +15,7 @@ uv run python mason.py \
         --max_retries 0 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
         --env VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --no_auto_dataset_cache \
         --artifact_ttl 1d \
         --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\&python open_instruct/grpo_fast.py \

--- a/scripts/train/debug/multi_node_grpo.sh
+++ b/scripts/train/debug/multi_node_grpo.sh
@@ -16,7 +16,7 @@ uv run python mason.py \
         --timeout 1h \
         --max_retries 0 \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --artifact_ttl 1d \
         --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\&python open_instruct/grpo.py \
         --exp_name ${exp_name} \

--- a/scripts/train/debug/oc_sft.sh
+++ b/scripts/train/debug/oc_sft.sh
@@ -13,7 +13,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 1 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 1 \
     --non_resumable \
     --no-host-networking \

--- a/scripts/train/debug/oc_sft_cache.sh
+++ b/scripts/train/debug/oc_sft_cache.sh
@@ -13,7 +13,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 1 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 0 \
     --non_resumable \
     --no-host-networking \

--- a/scripts/train/debug/oc_sft_multinode.sh
+++ b/scripts/train/debug/oc_sft_multinode.sh
@@ -13,7 +13,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 \
     --non_resumable \
     --no_auto_dataset_cache \

--- a/scripts/train/debug/oc_sft_olmo3_7b_full.sh
+++ b/scripts/train/debug/oc_sft_olmo3_7b_full.sh
@@ -23,7 +23,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 4 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 \
     --non_resumable \
     --no_auto_dataset_cache \

--- a/scripts/train/debug/qwen35_4b_dapo_math.sh
+++ b/scripts/train/debug/qwen35_4b_dapo_math.sh
@@ -23,7 +23,7 @@ uv run mason.py \
     --preemptible \
     --num_nodes 1 \
     --gpus 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --artifact_ttl 1d \
     -- \
 source configs/beaker_configs/ray_node_setup.sh \

--- a/scripts/train/debug/sft_integration_test.sh
+++ b/scripts/train/debug/sft_integration_test.sh
@@ -36,7 +36,7 @@ if [ -n "$1" ]; then
         --pure_docker_mode \
         --preemptible \
         --num_nodes 1 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --gpus 1 \
         --non_resumable \
         --no_auto_dataset_cache \

--- a/scripts/train/debug/sft_multinode_test.sh
+++ b/scripts/train/debug/sft_multinode_test.sh
@@ -17,7 +17,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 \
     --non_resumable \
     --artifact_ttl 1d \

--- a/scripts/train/debug/single_gpu_grpo.sh
+++ b/scripts/train/debug/single_gpu_grpo.sh
@@ -18,7 +18,7 @@ uv run python mason.py \
        --max_retries 0 \
        --timeout 15m \
        --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --gpus 1 \
        --no_auto_dataset_cache \
        --artifact_ttl 1d \

--- a/scripts/train/debug/single_gpu_on_beaker.sh
+++ b/scripts/train/debug/single_gpu_on_beaker.sh
@@ -19,7 +19,7 @@ uv run python mason.py \
        --max_retries 0 \
        --timeout 15m \
        --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --gpus 1 \
        --no_auto_dataset_cache \
        --artifact_ttl 1d \

--- a/scripts/train/debug/tool_grpo.sh
+++ b/scripts/train/debug/tool_grpo.sh
@@ -24,7 +24,7 @@ uv run python mason.py \
        --timeout 45m \
        --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
        --env GIT_COMMIT="$(git rev-parse --short HEAD)" \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --no-host-networking \
        --artifact_ttl 1d \
        --gpus 1 \

--- a/scripts/train/debug/tools/olmo_3_parser_multigpu.sh
+++ b/scripts/train/debug/tools/olmo_3_parser_multigpu.sh
@@ -25,7 +25,7 @@ uv run python mason.py \
        --timeout 1h \
        --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
        --env GIT_COMMIT="$(git rev-parse --short HEAD)" \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --secret SERPER_API_KEY=${BEAKER_USER}_SERPER_API_KEY \
        --secret JINA_API_KEY=${BEAKER_USER}_JINA_API_KEY \
        --gpus 8 \

--- a/scripts/train/debug/tools/tool_regression_beaker.sh
+++ b/scripts/train/debug/tools/tool_regression_beaker.sh
@@ -22,7 +22,7 @@ uv run python mason.py \
        --env VLLM_USE_V1=1 \
        --env 'SERPER_API_KEY=secret:hamishivi_SERPER_API_KEY' \
        --env 'JINA_API_KEY=secret:hamishivi_JINA_API_KEY' \
-       --budget ai2/oe-adapt \
+       --budget ai2/oe-omai \
        --gpus 1 \
        --no_auto_dataset_cache \
        --artifact_ttl 1d \

--- a/scripts/train/dr-tulu/dr_tulu_qwen35.sh
+++ b/scripts/train/dr-tulu/dr_tulu_qwen35.sh
@@ -28,7 +28,7 @@ uv run mason.py \
     --preemptible \
     --num_nodes 2 \
     --gpus 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --no_auto_dataset_cache \
     --env RUBRIC_JUDGE_MODEL=gpt-4.1 \
     --env RUBRIC_GENERATION_MODEL=gpt-4.1 \

--- a/scripts/train/olmo-hybrid/7b_instruct_dpo.sh
+++ b/scripts/train/olmo-hybrid/7b_instruct_dpo.sh
@@ -31,7 +31,7 @@ uv run python mason.py \
     --env TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1800 \
     --env TRITON_PRINT_AUTOTUNING=1 \
     --num_nodes 4 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \

--- a/scripts/train/olmo-hybrid/7b_instruct_dpo_sweep.sh
+++ b/scripts/train/olmo-hybrid/7b_instruct_dpo_sweep.sh
@@ -63,7 +63,7 @@ for MODEL_PATH in "${SFT_MODELS[@]}"; do
             --env TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1800 \
             --env TRITON_PRINT_AUTOTUNING=1 \
             --num_nodes 4 \
-            --budget ai2/oe-adapt \
+            --budget ai2/oe-omai \
             --gpus 8 -- accelerate launch \
             --mixed_precision bf16 \
             --num_processes 8 \

--- a/scripts/train/olmo-hybrid/7b_instruct_sft.sh
+++ b/scripts/train/olmo-hybrid/7b_instruct_sft.sh
@@ -17,6 +17,6 @@ uv run python src/scripts/train/sft/Olmo-3-Hybrid-7B-SFT.py launch \
     --init_seed=42 \
     --launch.num_gpus=8 \
     --num_nodes=8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --workspace ai2/olmo-instruct \
     --dataset_path /weka/oe-adapt-default/nathanl/dataset/olmo3-32b-instruct-sft-1114

--- a/scripts/train/olmo-hybrid/7b_think_sft.sh
+++ b/scripts/train/olmo-hybrid/7b_think_sft.sh
@@ -15,6 +15,6 @@ uv run python src/scripts/train/sft/Olmo-3-Hybrid-7B-SFT.py launch \
     --seq_len=32768 \
     --launch.num_gpus=8 \
     --num_nodes=8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --workspace ai2/olmo-instruct \
     --dataset_path /weka/oe-training-default/ai2-llm/jacobm/data/sft/rl-sft-32k/olmo-hybrid-sft-triple-tools

--- a/scripts/train/olmo-hybrid/7b_think_sft_tokenization.sh
+++ b/scripts/train/olmo-hybrid/7b_think_sft_tokenization.sh
@@ -20,7 +20,7 @@ tokenizer_path=/weka/oe-adapt-default/saumyam/open-instruct/dolma2-tokenizer-olm
 
 uv run python mason.py \
   --cluster ai2/jupiter \
-  --budget ai2/oe-adapt \
+  --budget ai2/oe-omai \
   --workspace ai2/open-instruct-dev \
   --image "$BEAKER_IMAGE" \
   --pure_docker_mode \

--- a/scripts/train/olmo-hybrid/convert_instruct_sft_sweep.sh
+++ b/scripts/train/olmo-hybrid/convert_instruct_sft_sweep.sh
@@ -15,7 +15,7 @@ for LR in "${LRS[@]}"; do
 
     echo "Converting ${RUN_NAME}..."
 
-    gantry run --cluster ai2/saturn-cirrascale --timeout 0 -y --budget ai2/oe-adapt --workspace ai2/olmo-instruct \
+    gantry run --cluster ai2/saturn-cirrascale --timeout 0 -y --budget ai2/oe-omai --workspace ai2/olmo-instruct \
         --beaker-image "${BEAKER_IMAGE}" \
         --install "/opt/conda/bin/pip install -e '.[fla,transformers]'" \
         --weka=oe-adapt-default:/weka/oe-adapt-default \

--- a/scripts/train/olmo-hybrid/convert_think_sft.sh
+++ b/scripts/train/olmo-hybrid/convert_think_sft.sh
@@ -2,7 +2,7 @@
 # Convert Think SFT OLMo-core checkpoint to HuggingFace format.
 # This runs in OLMo-core, not open-instruct.
 
-gantry run --cluster ai2/saturn-cirrascale --timeout -1 -y --budget ai2/oe-adapt --workspace ai2/olmo-instruct \
+gantry run --cluster ai2/saturn-cirrascale --timeout -1 -y --budget ai2/oe-omai --workspace ai2/olmo-instruct \
     --beaker-image tylerr/olmo-core-tch291cu128-2025-11-25 \
     --install "/opt/conda/bin/pip install -e '.[fla,transformers]'" \
     --weka=oe-adapt-default:/weka/oe-adapt-default \

--- a/scripts/train/olmo2/dpo_13b.sh
+++ b/scripts/train/olmo2/dpo_13b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 4 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \

--- a/scripts/train/olmo2/dpo_7b.sh
+++ b/scripts/train/olmo2/dpo_7b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 4 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \

--- a/scripts/train/olmo2/finetune_13b.sh
+++ b/scripts/train/olmo2/finetune_13b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \

--- a/scripts/train/olmo2/finetune_32b.sh
+++ b/scripts/train/olmo2/finetune_32b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \

--- a/scripts/train/olmo2/finetune_7b.sh
+++ b/scripts/train/olmo2/finetune_7b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \

--- a/scripts/train/olmo2/grpo_fast_13b_zero.sh
+++ b/scripts/train/olmo2/grpo_fast_13b_zero.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name olmo2_13b_grpo_fast_zero \
     --beta 0.0 \

--- a/scripts/train/olmo2/grpo_fast_32b.sh
+++ b/scripts/train/olmo2/grpo_fast_32b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name olmo2_32b_grpo_fast_zero \
     --beta 0.0 \

--- a/scripts/train/olmo2/grpo_fast_32b_tulu.sh
+++ b/scripts/train/olmo2/grpo_fast_32b_tulu.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name olmo2_32b_grpo_fast_zero \
     --beta 0.0 \

--- a/scripts/train/olmo2/grpo_fast_7b_zero.sh
+++ b/scripts/train/olmo2/grpo_fast_7b_zero.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name olmo2_7b_grpo_fast_zero \
     --beta 0.0 \

--- a/scripts/train/olmo3/32b_instruct_dpo.sh
+++ b/scripts/train/olmo3/32b_instruct_dpo.sh
@@ -29,7 +29,7 @@ uv run python mason.py \
     --preemptible \
     --image $BEAKER_IMAGE --pure_docker_mode \
     --num_nodes $NUM_NODES \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 64 \

--- a/scripts/train/olmo3/32b_instruct_rl.sh
+++ b/scripts/train/olmo3/32b_instruct_rl.sh
@@ -11,7 +11,7 @@ export DATASET_MIXER_EVAL_LIST="hamishivi/omega-combined 4 allenai/IF_multi_cons
 export OE_EVAL_TASKS="gpqa:0shot_cot::qwen3-instruct,codex_humanevalplus:0-shot-chat::tulu-thinker_deepseek,alpaca_eval_v3::hamish_zs_reasoning_deepseek,ifeval::hamish_zs_reasoning_deepseek,agi_eval_english:0shot_cot::hamish_zs_reasoning_deepseek,omega_500:0-shot-chat_deepseek,minerva_math_500::hamish_zs_reasoning_deepseek,livecodebench_codegeneration::tulu-thinker_deepseek_no_think_tags_lite,aime:zs_cot_r1::pass_at_32_2024_deepseek,aime:zs_cot_r1::pass_at_32_2025_deepseek,zebralogic::hamish_zs_reasoning_deepseek,bbh:cot::hamish_zs_reasoning_deepseek_v2,mmlu:cot::hamish_zs_reasoning_deepseek,popqa::hamish_zs_reasoning_deepseek,mbppplus:0-shot-chat::tulu-thinker_deepseek"
 
 uv run python mason.py \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --cluster ai2/jupiter-cirrascale-2 \
     --image $BEAKER_IMAGE \
     --pure_docker_mode \

--- a/scripts/train/olmo3/32b_instruct_sft.sh
+++ b/scripts/train/olmo3/32b_instruct_sft.sh
@@ -17,7 +17,7 @@ python src/scripts/train/sft/OLMo-sft.py train \
     --num_nodes=8 \
     --global_batch_size=4194304 \
     --model_name=olmo3-32b \
-    --budget=ai2/oe-adapt \
+    --budget=ai2/oe-omai \
     --workspace=ai2/olmo-instruct \
     --dataset_path=gs://ai2-llm/jacobm/data/sft/rl-sft-32k/olmo3-32b-instruct-sft-1114 \
     --launch.priority=urgent

--- a/scripts/train/olmo3/32b_think_dpo.sh
+++ b/scripts/train/olmo3/32b_think_dpo.sh
@@ -20,7 +20,7 @@ do
         --env NCCL_TUNER_CONFIG_PATH=/var/lib/tcpxo/lib64/a3plus_tuner_config_ll128.textproto \
         --env NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE=/var/lib/tcpxo/lib64/a3plus_guest_config_ll128.textproto \
         --num_nodes $NUM_NODES \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --no_auto_dataset_cache \
         --gpus 8 -- source /var/lib/tcpxo/lib64/nccl-env-profile.sh \&\& accelerate launch \
         --mixed_precision bf16 \

--- a/scripts/train/olmo3/32b_think_rl.sh
+++ b/scripts/train/olmo3/32b_think_rl.sh
@@ -8,7 +8,7 @@ export model_path=/weka/oe-adapt-default/hamishi/model_checkpoints/olmo3-merge-3
 
 
 uv run python mason.py \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --cluster ai2/jupiter \
     --image $BEAKER_IMAGE \
     --pure_docker_mode \

--- a/scripts/train/olmo3/32b_think_sft.sh
+++ b/scripts/train/olmo3/32b_think_sft.sh
@@ -21,7 +21,7 @@ python src/scripts/train/sft/OLMo-sft.py train \
     --launch.use_hostname_constraints=True \
     --launch.num_execution_units=1 \
     --model_name=olmo3-32b \
-    --budget=ai2/oe-adapt \
+    --budget=ai2/oe-omai \
     --workspace=ai2/olmo-instruct \
     --dataset_path=gs://ai2-llm/jacobm/data/sft/rl-sft-32k/olmo3-32b-thinking-sft \
     --launch.priority=urgent

--- a/scripts/train/olmo3/7b_instruct_dpo.sh
+++ b/scripts/train/olmo3/7b_instruct_dpo.sh
@@ -18,7 +18,7 @@ do
         --env NCCL_TUNER_CONFIG_PATH=/var/lib/tcpxo/lib64/a3plus_tuner_config_ll128.textproto \
         --env NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE=/var/lib/tcpxo/lib64/a3plus_guest_config_ll128.textproto \
         --num_nodes 4 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --gpus 8 -- source /var/lib/tcpxo/lib64/nccl-env-profile.sh \&\& accelerate launch \
         --mixed_precision bf16 \
         --num_processes 8 \

--- a/scripts/train/olmo3/7b_instruct_dpo_olmocore.sh
+++ b/scripts/train/olmo3/7b_instruct_dpo_olmocore.sh
@@ -24,7 +24,7 @@ do
         --env NCCL_IB_TIMEOUT=23 \
         --env NCCL_IB_RETRY_CNT=7 \
         --num_nodes 4 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --gpus 8 -- torchrun \
         --nnodes=4 \
         --node_rank=\$BEAKER_REPLICA_RANK \

--- a/scripts/train/olmo3/7b_instruct_hybrid_dpo.sh
+++ b/scripts/train/olmo3/7b_instruct_hybrid_dpo.sh
@@ -28,7 +28,7 @@ do
             --env TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1800 \
 	    --env TRITON_PRINT_AUTOTUNING=1 \
             --num_nodes 4 \
-            --budget ai2/oe-adapt \
+            --budget ai2/oe-omai \
             --gpus 8 -- accelerate launch \
             --mixed_precision bf16 \
             --num_processes 8 \

--- a/scripts/train/olmo3/7b_instruct_hybrid_rl.sh
+++ b/scripts/train/olmo3/7b_instruct_hybrid_rl.sh
@@ -44,7 +44,7 @@ uv run --no-sync python mason.py \
         --env TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1800 \
         --env TRITON_PRINT_AUTOTUNING=1 \
         --gpus ${NUM_GPUS} \
-        --budget ai2/oe-adapt -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
+        --budget ai2/oe-omai -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name ${EXP_NAME} \
         --beta 0.0 \
         --num_samples_per_prompt_rollout 8 \

--- a/scripts/train/olmo3/7b_instruct_rl.sh
+++ b/scripts/train/olmo3/7b_instruct_rl.sh
@@ -37,7 +37,7 @@ uv run python mason.py \
         --env HOSTED_VLLM_API_BASE=$hosted_vllm \
         --gs_model_name $gs_model_name \
         --gpus ${NUM_GPUS} \
-        --budget ai2/oe-adapt -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
+        --budget ai2/oe-omai -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
         --exp_name ${EXP_NAME} \
         --beta 0.0 \
         --num_samples_per_prompt_rollout 8 \

--- a/scripts/train/olmo3/7b_instruct_sft.sh
+++ b/scripts/train/olmo3/7b_instruct_sft.sh
@@ -17,7 +17,7 @@ python src/scripts/train/sft/OLMo-sft.py train \
     --num_nodes=4 \
     --global_batch_size=1048576 \
     --model_name=olmo3-7b \
-    --budget=ai2/oe-adapt \
+    --budget=ai2/oe-omai \
     --workspace=ai2/olmo-instruct \
     --dataset_path=gs://ai2-llm/jacobm/data/sft/rl-sft-32k/olmo3-32b-instruct-sft-1114 \
     --launch.priority=urgent

--- a/scripts/train/olmo3/7b_rlzero_code.sh
+++ b/scripts/train/olmo3/7b_rlzero_code.sh
@@ -27,7 +27,7 @@ python mason.py \
     --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     --env VLLM_ATTENTION_BACKEND="FLASH_ATTN" \
     --gpus 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     -- source configs/beaker_configs/ray_node_setup.sh \
 \&\& uv run open_instruct/grpo_fast.py \
     --exp_name ${EXP_NAME} \

--- a/scripts/train/olmo3/7b_rlzero_general.sh
+++ b/scripts/train/olmo3/7b_rlzero_general.sh
@@ -29,7 +29,7 @@ python mason.py \
     --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     --env VLLM_ATTENTION_BACKEND="FLASH_ATTN" \
     --gpus 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     -- \
 source configs/beaker_configs/ray_node_setup.sh \&\& \
 python open_instruct/grpo_fast.py \

--- a/scripts/train/olmo3/7b_rlzero_instruction_following.sh
+++ b/scripts/train/olmo3/7b_rlzero_instruction_following.sh
@@ -27,7 +27,7 @@ python mason.py \
     --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     --env VLLM_ATTENTION_BACKEND="FLASH_ATTN" \
     --gpus 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     -- source configs/beaker_configs/ray_node_setup.sh \
 \&\& uv run open_instruct/grpo_fast.py \
     --exp_name ${EXP_NAME} \

--- a/scripts/train/olmo3/7b_rlzero_math.sh
+++ b/scripts/train/olmo3/7b_rlzero_math.sh
@@ -31,7 +31,7 @@ uv run mason.py \
     --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     --env VLLM_ATTENTION_BACKEND="FLASH_ATTN" \
     --gpus 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     -- source configs/beaker_configs/ray_node_setup.sh \
 \&\& uv run open_instruct/grpo_fast.py \
     --exp_name ${EXP_NAME} \

--- a/scripts/train/olmo3/7b_rlzero_mix.sh
+++ b/scripts/train/olmo3/7b_rlzero_mix.sh
@@ -27,7 +27,7 @@ python mason.py \
     --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     --env VLLM_ATTENTION_BACKEND="FLASH_ATTN" \
     --gpus 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     -- source configs/beaker_configs/ray_node_setup.sh \
 \&\& uv run open_instruct/grpo_fast.py \
     --exp_name ${EXP_NAME} \

--- a/scripts/train/olmo3/7b_think_dpo.sh
+++ b/scripts/train/olmo3/7b_think_dpo.sh
@@ -10,7 +10,7 @@ uv run python mason.py \
     --image $BEAKER_IMAGE --pure_docker_mode \
     --preemptible \
     --num_nodes 4 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --no_auto_dataset_cache \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \

--- a/scripts/train/olmo3/7b_think_rl.sh
+++ b/scripts/train/olmo3/7b_think_rl.sh
@@ -2,7 +2,7 @@
 BEAKER_IMAGE=${1:-nathanl/open_instruct_auto}
 
 python mason.py \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --cluster ai2/jupiter \
     --image hamishivi/open_instruct_testing_1110 \
     --pure_docker_mode \

--- a/scripts/train/olmo3/7b_think_rl_no_pipeline.sh
+++ b/scripts/train/olmo3/7b_think_rl_no_pipeline.sh
@@ -3,7 +3,7 @@ BEAKER_IMAGE=${1:-nathanl/open_instruct_auto}
 
 # our released olmo3 thinker model actually doesnt use pipelinerl, but using it should do just as well.
 python mason.py \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --cluster ai2/jupiter \
     --image hamishivi/open_instruct_testing_1110 \
     --pure_docker_mode \

--- a/scripts/train/olmo3/7b_think_sft.sh
+++ b/scripts/train/olmo3/7b_think_sft.sh
@@ -18,7 +18,7 @@ python src/scripts/train/sft/OLMo2-7B-sft.py train \
     --num_nodes=8 \
     --global_batch_size=1048576 \
     --model_name=olmo2.5-7b-yarn-fullonly \
-    --budget=ai2/oe-adapt \
+    --budget=ai2/oe-omai \
     --workspace=ai2/olmo-instruct \
     --dataset_path=/weka/oe-training-default/ai2-llm/jacobm/data/sft/rl-sft-32k/reasoning-mix-decontam-v2-special-tokens-v3-think-FIX \
     --launch.priority=urgent

--- a/scripts/train/qwen/finetune_7b.sh
+++ b/scripts/train/qwen/finetune_7b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \

--- a/scripts/train/qwen/grpo_fast_32b.sh
+++ b/scripts/train/qwen/grpo_fast_32b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_32b_grpo_fast_zero \
     --beta 0.0 \

--- a/scripts/train/qwen/grpo_fast_3b_single_node.sh
+++ b/scripts/train/qwen/grpo_fast_3b_single_node.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 1 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_3b_grpo_fast_zero \
     --beta 0.0 \

--- a/scripts/train/qwen/grpo_fast_7b.sh
+++ b/scripts/train/qwen/grpo_fast_7b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_7b_grpo_fast_zero \
     --beta 0.0 \

--- a/scripts/train/qwen/grpo_fast_7b_code.sh
+++ b/scripts/train/qwen/grpo_fast_7b_code.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 4 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_7b_grpo_fast_zero_orz \
     --beta 0.0 \

--- a/scripts/train/qwen/grpo_fast_7b_orz.sh
+++ b/scripts/train/qwen/grpo_fast_7b_orz.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 4 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name qwen2.5_7b_grpo_fast_zero_orz \
     --beta 0.0 \

--- a/scripts/train/qwen/qwen3_4b_dapo_math.sh
+++ b/scripts/train/qwen/qwen3_4b_dapo_math.sh
@@ -23,7 +23,7 @@ uv run mason.py \
     --num_nodes 1 \
     --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     --gpus $NUM_GPUS \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     -- \
 uv run open_instruct/grpo_fast.py \
     --run_name "${RUN_NAME}" \

--- a/scripts/train/qwen/qwen3_4b_dapo_math_32k.sh
+++ b/scripts/train/qwen/qwen3_4b_dapo_math_32k.sh
@@ -28,7 +28,7 @@ uv run mason.py \
     --env VLLM_ATTENTION_BACKEND="FLASH_ATTN" \
     --no_auto_dataset_cache \
     --gpus 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     -- \
 source configs/beaker_configs/ray_node_setup.sh \
 \&\& uv run open_instruct/grpo_fast.py \

--- a/scripts/train/qwen/qwen3_4b_dapo_math_oc.sh
+++ b/scripts/train/qwen/qwen3_4b_dapo_math_oc.sh
@@ -28,7 +28,7 @@ uv run mason.py \
     --num_nodes 1 \
     --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     --gpus $NUM_GPUS \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     -- \
 uv run open_instruct/grpo.py \
     --run_name "${RUN_NAME}" \

--- a/scripts/train/rlvr/grpo_qwen_fast_2.5_7B_best.sh
+++ b/scripts/train/rlvr/grpo_qwen_fast_2.5_7B_best.sh
@@ -7,7 +7,7 @@ python mason.py \
     --preemptible \
     --num_nodes 2 \
     --max_retries 0 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name 0302_qwen2.5_7B_math_grpo_fast1_1317 \
     --beta 0.0 \

--- a/scripts/train/rlvr/judge_general_verifier.sh
+++ b/scripts/train/rlvr/judge_general_verifier.sh
@@ -20,7 +20,7 @@ python mason.py \
         --max_retries 0 \
         --env HOSTED_VLLM_API_BASE=${JUDGE_BASE_URL} \
         --env VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
-        --budget ai2/oe-adapt \
+        --budget ai2/oe-omai \
         --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
             --exp_name 0906rl_judge_test_${RANDOM} \
             --dataset_mixer_list hamishivi/WebInstruct-verified-general-verifier-judge 1.0 \

--- a/scripts/train/rlvr/valpy_if_grpo_fast.sh
+++ b/scripts/train/rlvr/valpy_if_grpo_fast.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image valpy/open_instruct_dev_multi --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name valpy_if_multi_tulu3.1_8b_grpo \
     --beta 0.01 \

--- a/scripts/train/tulu3/dpo_8b.sh
+++ b/scripts/train/tulu3/dpo_8b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 4 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \

--- a/scripts/train/tulu3/finetune_8b.sh
+++ b/scripts/train/tulu3/finetune_8b.sh
@@ -12,7 +12,7 @@ uv run python mason.py \
     --pure_docker_mode \
     --preemptible \
     --num_nodes 8 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 \
     -- \
     accelerate launch \

--- a/scripts/train/tulu3/grpo_fast_8b.sh
+++ b/scripts/train/tulu3/grpo_fast_8b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name tulu3.1_8b_grpo_fast \
     --beta 0.01 \

--- a/scripts/train/tulu3/grpo_fast_8b_code_dpo.sh
+++ b/scripts/train/tulu3/grpo_fast_8b_code_dpo.sh
@@ -11,7 +11,7 @@ python mason.py \
     --preemptible \
     --num_nodes 2 \
     --description "${description}" \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name $exp_name \
     --beta 0.01 \

--- a/scripts/train/tulu3/grpo_fast_8b_code_sft.sh
+++ b/scripts/train/tulu3/grpo_fast_8b_code_sft.sh
@@ -11,7 +11,7 @@ python mason.py \
     --preemptible \
     --num_nodes 4 \
     --description "${description}" \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& source configs/beaker_configs/code_api_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name $exp_name \
     --beta 0.01 \

--- a/scripts/train/tulu3/grpo_fast_8b_single_node.sh
+++ b/scripts/train/tulu3/grpo_fast_8b_single_node.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 1 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
     --exp_name tulu3.1_8b_grpo_fast \
     --beta 0.01 \

--- a/scripts/train/tulu3/ppo_8b.sh
+++ b/scripts/train/tulu3/ppo_8b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --priority high \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/ppo_vllm_thread_ray_gtrl.py \
     --exp_name tulu3_8b_ppo \
     --beta 0.05 \

--- a/scripts/train/tulu3/reward_modeling_8b.sh
+++ b/scripts/train/tulu3/reward_modeling_8b.sh
@@ -6,7 +6,7 @@ python mason.py \
     --image nathanl/open_instruct_auto --pure_docker_mode \
     --preemptible \
     --num_nodes 2 \
-    --budget ai2/oe-adapt \
+    --budget ai2/oe-omai \
     --gpus 8 -- accelerate launch \
     --mixed_precision bf16 \
     --num_processes 8 \


### PR DESCRIPTION
## Summary
- The `ai2/oe-adapt` budget is retired, causing the Beaker Experiment Launch CI to fail when launching experiments.
- Replace `--budget ai2/oe-adapt` (and `--budget=ai2/oe-adapt`, `budget: ai2/oe-adapt` in YAML, default value in `submit_eval_jobs.py`) with `ai2/oe-omai` across launch scripts and beaker configs.
- Workspace names like `ai2/oe-adapt-code` and weka paths like `/weka/oe-adapt-default/...` are unrelated and left alone.

## Test plan
- [ ] Beaker Experiment Launch CI succeeds on this branch.

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)