### PR TITLE
Skip Beaker /output copy when output_dir is on /weka/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Skip the `--try_auto_save_to_beaker` `/output` copy when `--output_dir` lives under `/weka/`; the artifact is already on shared storage so the copy just wastes time and disk (https://github.com/allenai/open-instruct/pull/1667).
 - Restore 🤡 to resample warnings and use `self.training_step` in `DataPreparationActor.run` (https://github.com/allenai/open-instruct/pull/1663).
 - Add a unified `use_rho_correction` interface (clamp + mask, per-token or sequence-level) for the train/infer engine mismatch in GRPO loss; replaces `truncated_importance_sampling_ratio_cap` and the IcePop flags (https://github.com/allenai/open-instruct/pull/1650).
 - Resample on filtered batches in `DataPreparationActor` instead of emitting empty `CollatedBatchData`, unifying the `grpo.py` and `grpo_fast.py` consumer paths and removing the now-dead empty-batch checks in `grpo_fast.py` (https://github.com/allenai/open-instruct/pull/1660).

--- a/open_instruct/dpo.py
+++ b/open_instruct/dpo.py
@@ -106,6 +106,7 @@ def _handle_post_training(
         and beaker_config is not None
         and len(beaker_config.beaker_dataset_id_urls) > 0
         and output_path != beaker_output_path
+        and not args.output_dir.startswith("/weka/")
     ):
         shutil.copytree(hf_model_path, "/output", dirs_exist_ok=True)
 

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -729,6 +729,7 @@ def main(args: dpo_utils.DPOExperimentConfig, tc: TokenizerConfig):
         and beaker_config is not None
         and len(beaker_config.beaker_dataset_id_urls) > 0
         and args.output_dir.rstrip("/") != "/output"
+        and not args.output_dir.startswith("/weka/")
     ):
         shutil.copytree(args.output_dir, "/output", dirs_exist_ok=True)
 

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -1004,6 +1004,7 @@ def main(args: FlatArguments, tc: TokenizerConfig):
         and is_beaker_job()
         and len(maybe_get_beaker_config().beaker_dataset_id_urls) > 0
         and args.output_dir.rstrip("/") != "/output"
+        and not args.output_dir.startswith("/weka/")
     ):
         shutil.copytree(args.output_dir, "/output", dirs_exist_ok=True)
 

--- a/open_instruct/grpo.py
+++ b/open_instruct/grpo.py
@@ -80,6 +80,7 @@ def save_and_cleanup(
         and beaker_config is not None
         and len(beaker_config.beaker_dataset_id_urls) > 0
         and args.output_dir.rstrip("/") != "/output"
+        and not args.output_dir.startswith("/weka/")
         and os.path.isdir(args.output_dir)
     ):
         shutil.copytree(args.output_dir, "/output", dirs_exist_ok=True)

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -2508,6 +2508,7 @@ def main(
         and is_beaker_job()
         and len(beaker_config.beaker_dataset_id_urls) > 0
         and args.output_dir.rstrip("/") != "/output"
+        and not args.output_dir.startswith("/weka/")
         and os.path.isdir(args.output_dir)
     ):
         shutil.copytree(args.output_dir, "/output", dirs_exist_ok=True)


### PR DESCRIPTION
Add `not args.output_dir.startswith("/weka/")` to the `try_auto_save_to_beaker` guard in `dpo.py`, `dpo_tune_cache.py`, `finetune.py`, `grpo.py`, and `grpo_fast.py`. When `--output_dir` is on weka, the artifact is already on shared storage.