### PR TITLE
Emit bool response_masks from DataPreparationActor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `grpo.py` token-count inflation by emitting bool `response_masks` from `DataPreparationActor` (instead of int64 doc-id-valued masks) and dropping per-consumer `.bool()` coercions in `grpo_fast.py`, `grpo_utils.py`, and `olmo_core_train_modules.py`. Previously the OLMo-core path summed the doc-id-valued mask in `calculate_token_counts`, inflating `loss_denominator` by ~60× (https://github.com/allenai/open-instruct/pull/1668).
 - Fix hardcoded project version (https://github.com/allenai/open-instruct/pull/1636) by using setuptools scm's automatic versioning.
 - Fix CUDA illegal-memory-access in FSDP2 weight sync to vLLM by also unsharding the root FSDPModule (root-level params like model.norm and lm_head were producing local-shard buffers with global stride) (https://github.com/allenai/open-instruct/pull/1649).
 - Fix weight sync on resume by initializing vLLM weight sync before the training loop and warming up the learner with a dummy forward so DeepSpeed Stage 3 params materialize before the first broadcast; accept IPC `update_info` dict in `LLMRayActor.update_weights`; replace toothless weight-sync tests with a real divergent-weight broadcast test (https://github.com/allenai/open-instruct/pull/1627).

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -610,7 +610,7 @@ class StreamingDataLoader(data_loader.DataLoaderBase):
         dummy_qr = torch.tensor([[self.tokenizer.pad_token_id, self.tokenizer.eos_token_id]], dtype=torch.long)
         dummy_attention = torch.tensor([[1, 1]], dtype=torch.long)
         dummy_position_ids = torch.arange(dummy_qr.shape[-1], dtype=torch.long).unsqueeze(0)
-        dummy_response_mask = torch.tensor([[0, 1]], dtype=torch.long)
+        dummy_response_mask = torch.tensor([[False, True]], dtype=torch.bool)
         dummy_advantage = torch.tensor([[0.0, 1.0]], dtype=torch.float)
 
         batch = data_types.CollatedBatchData(
@@ -1339,17 +1339,18 @@ class DataPreparationActor:
                 ground_truth_overrides=self.ground_truth_overrides,
             )
 
-        while self.training_step < self.num_training_steps:
+        step = self.training_step
+        while step < self.num_training_steps:
             generation_idle_wait_start_time = time.perf_counter()
-            while self.training_step - self._last_consumed_step > self.config.async_steps:
+            while step - self._last_consumed_step > self.config.async_steps:
                 logger.info(
-                    f"[DataPreparationActor] Step {self.training_step}: waiting for step {self._last_consumed_step + self.config.async_steps} to be consumed. Consider increasing training compute."
+                    f"[DataPreparationActor] Step {step}: waiting for step {self._last_consumed_step + self.config.async_steps} to be consumed. Consider increasing training compute."
                 )
                 time.sleep(0.1)
             generation_idle_wait_time = time.perf_counter() - generation_idle_wait_start_time
 
             logger.info(
-                f"[DataPreparationActor] Step {self.training_step}: calling accumulate_inference_batches for {self.global_batch_size} prompts"
+                f"[DataPreparationActor] Step {step}: calling accumulate_inference_batches for {self.global_batch_size} prompts"
             )
             result, batch, reward_metrics, batch_stats = accumulate_inference_batches(
                 self.inference_results_Q,
@@ -1365,14 +1366,14 @@ class DataPreparationActor:
                 no_resampling_pass_rate=self.config.no_resampling_pass_rate,
                 iter_dataloader=self.iter_dataloader,
                 param_prompt_Q=self.param_prompt_Q,
-                training_step=self.training_step,
+                training_step=step,
                 verbose=self.verbose,
                 max_possible_score=self.config.max_possible_score,
                 base_env_config=self.base_env_config,
                 ground_truth_overrides=self.ground_truth_overrides,
             )
             logger.info(
-                f"[DataPreparationActor] Step {self.training_step}: accumulate_inference_batches returned, result type: {type(result).__name__}"
+                f"[DataPreparationActor] Step {step}: accumulate_inference_batches returned, result type: {type(result).__name__}"
             )
 
             if isinstance(result, data_types.ShutdownSentinel):
@@ -1380,7 +1381,7 @@ class DataPreparationActor:
 
             if result is None:
                 logger.warning(
-                    f"[DataPreparationActor] 🤡 Step {self.training_step}: all groups filtered (zero-std rewards); "
+                    f"[DataPreparationActor] Step {step}: all groups filtered (zero-std rewards); "
                     "resampling without advancing step counter"
                 )
                 continue
@@ -1392,7 +1393,7 @@ class DataPreparationActor:
 
             if len(result.responses) == 0:
                 logger.warning(
-                    f"[DataPreparationActor] 🤡 Step {self.training_step}: no trainable responses after truncation filter; "
+                    f"[DataPreparationActor] Step {step}: no trainable responses after truncation filter; "
                     "resampling without advancing step counter"
                 )
                 continue
@@ -1402,7 +1403,7 @@ class DataPreparationActor:
                     decoded_responses=batch.decoded_responses,
                     ground_truths=batch.ground_truths,
                     indices=batch.indices,
-                    step=self.training_step,
+                    step=step,
                 )
                 reward_metrics.update(rubric_metrics)
                 self.ground_truth_overrides.update(new_overrides)
@@ -1425,7 +1426,7 @@ class DataPreparationActor:
                 save_rollouts_to_disk(
                     self.config.rollouts_save_path,
                     self.run_name,
-                    self.training_step,
+                    step,
                     batch,
                     result,
                     advantages,
@@ -1451,6 +1452,11 @@ class DataPreparationActor:
                 for packed_mask in packed_sequences.response_masks
             ]
             packed_sequences.advantages = packed_advantages
+            # `pack_sequences` returns int64 doc-id-valued masks (0 for query/pad, i+1 for tokens of
+            # sample i) because the gather above uses them as integer indices into `lookup_advantages`.
+            # Now that the gather is done, downcast to bool so all downstream consumers see a single
+            # contract.
+            packed_sequences.response_masks = [mask.bool() for mask in packed_sequences.response_masks]
 
             collated_data = prepare_collated_data_for_workers(
                 packed_sequences, self.dp_world_size, self.per_device_train_batch_size, self.tokenizer.pad_token_id
@@ -1516,10 +1522,10 @@ class DataPreparationActor:
             step_metrics["time/getting_response"] = result.token_statistics.generation_time
 
             with self.lock:
-                self.prepared_data[self.training_step] = collated_data
-                self.metrics[self.training_step] = step_metrics
-                self.current_prepared_step = self.training_step
-            self.training_step += 1
+                self.prepared_data[step] = collated_data
+                self.metrics[step] = step_metrics
+                self.current_prepared_step = step
+            step += 1
 
     def get_data(self, rank: int, step: int) -> dict:
         """Called by each rank's StreamingDataLoader. Blocks until data ready."""

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -1339,18 +1339,17 @@ class DataPreparationActor:
                 ground_truth_overrides=self.ground_truth_overrides,
             )
 
-        step = self.training_step
-        while step < self.num_training_steps:
+        while self.training_step < self.num_training_steps:
             generation_idle_wait_start_time = time.perf_counter()
-            while step - self._last_consumed_step > self.config.async_steps:
+            while self.training_step - self._last_consumed_step > self.config.async_steps:
                 logger.info(
-                    f"[DataPreparationActor] Step {step}: waiting for step {self._last_consumed_step + self.config.async_steps} to be consumed. Consider increasing training compute."
+                    f"[DataPreparationActor] Step {self.training_step}: waiting for step {self._last_consumed_step + self.config.async_steps} to be consumed. Consider increasing training compute."
                 )
                 time.sleep(0.1)
             generation_idle_wait_time = time.perf_counter() - generation_idle_wait_start_time
 
             logger.info(
-                f"[DataPreparationActor] Step {step}: calling accumulate_inference_batches for {self.global_batch_size} prompts"
+                f"[DataPreparationActor] Step {self.training_step}: calling accumulate_inference_batches for {self.global_batch_size} prompts"
             )
             result, batch, reward_metrics, batch_stats = accumulate_inference_batches(
                 self.inference_results_Q,
@@ -1366,14 +1365,14 @@ class DataPreparationActor:
                 no_resampling_pass_rate=self.config.no_resampling_pass_rate,
                 iter_dataloader=self.iter_dataloader,
                 param_prompt_Q=self.param_prompt_Q,
-                training_step=step,
+                training_step=self.training_step,
                 verbose=self.verbose,
                 max_possible_score=self.config.max_possible_score,
                 base_env_config=self.base_env_config,
                 ground_truth_overrides=self.ground_truth_overrides,
             )
             logger.info(
-                f"[DataPreparationActor] Step {step}: accumulate_inference_batches returned, result type: {type(result).__name__}"
+                f"[DataPreparationActor] Step {self.training_step}: accumulate_inference_batches returned, result type: {type(result).__name__}"
             )
 
             if isinstance(result, data_types.ShutdownSentinel):
@@ -1381,7 +1380,7 @@ class DataPreparationActor:
 
             if result is None:
                 logger.warning(
-                    f"[DataPreparationActor] Step {step}: all groups filtered (zero-std rewards); "
+                    f"[DataPreparationActor] Step {self.training_step}: all groups filtered (zero-std rewards); "
                     "resampling without advancing step counter"
                 )
                 continue
@@ -1393,7 +1392,7 @@ class DataPreparationActor:
 
             if len(result.responses) == 0:
                 logger.warning(
-                    f"[DataPreparationActor] Step {step}: no trainable responses after truncation filter; "
+                    f"[DataPreparationActor] Step {self.training_step}: no trainable responses after truncation filter; "
                     "resampling without advancing step counter"
                 )
                 continue
@@ -1403,7 +1402,7 @@ class DataPreparationActor:
                     decoded_responses=batch.decoded_responses,
                     ground_truths=batch.ground_truths,
                     indices=batch.indices,
-                    step=step,
+                    step=self.training_step,
                 )
                 reward_metrics.update(rubric_metrics)
                 self.ground_truth_overrides.update(new_overrides)
@@ -1426,7 +1425,7 @@ class DataPreparationActor:
                 save_rollouts_to_disk(
                     self.config.rollouts_save_path,
                     self.run_name,
-                    step,
+                    self.training_step,
                     batch,
                     result,
                     advantages,
@@ -1522,10 +1521,10 @@ class DataPreparationActor:
             step_metrics["time/getting_response"] = result.token_statistics.generation_time
 
             with self.lock:
-                self.prepared_data[step] = collated_data
-                self.metrics[step] = step_metrics
-                self.current_prepared_step = step
-            step += 1
+                self.prepared_data[self.training_step] = collated_data
+                self.metrics[self.training_step] = step_metrics
+                self.current_prepared_step = self.training_step
+            self.training_step += 1
 
     def get_data(self, rank: int, step: int) -> dict:
         """Called by each rank's StreamingDataLoader. Blocks until data ready."""

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -1380,7 +1380,7 @@ class DataPreparationActor:
 
             if result is None:
                 logger.warning(
-                    f"[DataPreparationActor] Step {self.training_step}: all groups filtered (zero-std rewards); "
+                    f"[DataPreparationActor] 🤡 Step {self.training_step}: all groups filtered (zero-std rewards); "
                     "resampling without advancing step counter"
                 )
                 continue
@@ -1392,7 +1392,7 @@ class DataPreparationActor:
 
             if len(result.responses) == 0:
                 logger.warning(
-                    f"[DataPreparationActor] Step {self.training_step}: no trainable responses after truncation filter; "
+                    f"[DataPreparationActor] 🤡 Step {self.training_step}: no trainable responses after truncation filter; "
                     "resampling without advancing step counter"
                 )
                 continue

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -618,7 +618,6 @@ class PolicyTrainerRayProcess(RayProcess):
                 data_BT = self.splitter.split_collated_batch(data_BT)
 
         data_BT = data_BT.to(self.device)
-        data_BT.response_masks = [mask.bool() for mask in data_BT.response_masks]
         num_samples = len(data_BT)
         accumulation_steps = max(math.ceil(num_samples / self.num_mini_batches - 0.5), 1)
         leftover = num_samples % accumulation_steps
@@ -651,7 +650,7 @@ class PolicyTrainerRayProcess(RayProcess):
                     for i in range(len(data_BT.query_responses)):
                         if self.args.use_vllm_logprobs:
                             old_logprobs_BT[i] = grpo_utils.mask_logprobs(
-                                data_BT.vllm_logprobs[i][:, 1:], data_BT.response_masks[i][:, 1:].bool()
+                                data_BT.vllm_logprobs[i][:, 1:], data_BT.response_masks[i][:, 1:]
                             )
                         else:
                             old_logprobs_BT[i] = local_old_logprobs_BT[i]

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -565,7 +565,7 @@ def compute_logprobs(
                     )
 
                     response_mask_BT = data_BT.response_masks[i]
-                    single_logprobs = mask_logprobs(single_logprobs, response_mask_BT[:, 1:].bool())
+                    single_logprobs = mask_logprobs(single_logprobs, response_mask_BT[:, 1:])
                     logprobs_BT.append(single_logprobs)
                 continue
 
@@ -581,7 +581,7 @@ def compute_logprobs(
 
             for i, logprob_BT in zip(batch_indices, split_logprobs):
                 response_mask_BT = data_BT.response_masks[i]
-                logprob_BT = mask_logprobs(logprob_BT, response_mask_BT[:, 1:].bool())
+                logprob_BT = mask_logprobs(logprob_BT, response_mask_BT[:, 1:])
                 logprobs_BT.append(logprob_BT)
 
     return logprobs_BT

--- a/open_instruct/olmo_core_train_modules.py
+++ b/open_instruct/olmo_core_train_modules.py
@@ -416,7 +416,7 @@ class GRPOTrainModule(TransformerTrainModule):
                 for i in range(num_samples):
                     if self.grpo_config.use_vllm_logprobs:
                         old_logprobs_BT[i] = grpo_utils.mask_logprobs(
-                            data_BT.vllm_logprobs[i][:, 1:], data_BT.response_masks[i][:, 1:].bool()
+                            data_BT.vllm_logprobs[i][:, 1:], data_BT.response_masks[i][:, 1:]
                         )
                     else:
                         assert local_old_logprobs_BT is not None
@@ -460,7 +460,7 @@ class GRPOTrainModule(TransformerTrainModule):
                     return_entropy=self.grpo_config.record_entropy,
                 )
 
-                response_mask = data_BT.response_masks[sample_idx][:, 1:].bool()
+                response_mask = data_BT.response_masks[sample_idx][:, 1:]
                 new_logprobs = grpo_utils.mask_logprobs(new_logprobs, response_mask)
 
                 vllm_logprobs = grpo_utils.mask_logprobs(data_BT.vllm_logprobs[sample_idx][:, 1:], response_mask)

--- a/open_instruct/test_grpo_fast.py
+++ b/open_instruct/test_grpo_fast.py
@@ -146,7 +146,7 @@ class TestGrpoFastBase(unittest.TestCase):
         return rl_utils.PackedSequences(
             query_responses=[torch.full((length,), i, dtype=torch.long) for i, length in enumerate(lengths)],
             attention_masks=[torch.ones(length, dtype=torch.long) for length in lengths],
-            response_masks=[torch.ones(length, dtype=torch.long) for length in lengths],
+            response_masks=[torch.ones(length, dtype=torch.bool) for length in lengths],
             original_responses=[[i] * seq_length for i in range(batch_size)],
             advantages=[torch.randn(length) for length in lengths],
             position_ids=[torch.arange(length, dtype=torch.long) for length in lengths],

--- a/open_instruct/test_olmo_core_train_modules.py
+++ b/open_instruct/test_olmo_core_train_modules.py
@@ -31,8 +31,8 @@ def _make_batch_data(
         attention_masks.append(torch.ones(batch_size, seq_len, dtype=torch.long))
         position_ids.append(torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1))
         advantages.append(torch.randn(batch_size, seq_len))
-        response_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
-        response_mask[:, :2] = 0
+        response_mask = torch.ones(batch_size, seq_len, dtype=torch.bool)
+        response_mask[:, :2] = False
         response_masks.append(response_mask)
         vllm_logprobs.append(torch.randn(batch_size, seq_len - 1))
 


### PR DESCRIPTION
`pack_sequences` returns int64 doc-id-valued `response_masks` (0 for query/pad, `i+1` for tokens of sample `i`) because the gather in `DataPreparationActor` uses them as integer indices into `lookup_advantages`. After that gather is done, the masks are still doc-id-valued, but every downstream consumer needs a 0/1 bool mask, so each call site was sprinkled with `.bool()` coercions.

In `grpo.py`'s OLMo-core path, `calculate_token_counts` summed the masks before any consumer coerced them, inflating `loss_denominator` ~60× and crushing `grad_norm`.

This PR moves the cast to its source and drops a bunch of unneeded casts. 