### PR TITLE
Fix combine_dataset asserting splits count before list-to-dict conversion

### DIFF
--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -617,7 +617,6 @@ def combine_dataset(
             Whether to keep ids for training that are added during mixing.
             Used primarily in mix_data.py for saving, or the saved dataset has IDs already.
     """
-    assert len(splits) == len(dataset_mixer), "Number of splits must match the number of datasets."
     if isinstance(dataset_mixer, list):
         assert len(dataset_mixer) % 2 == 0, f"Data mixer list length is not even: {dataset_mixer}"
         mixer_dict = {}
@@ -628,6 +627,7 @@ def combine_dataset(
             mixer_dict[dataset_mixer[i]] = value
             i += 2
         dataset_mixer = mixer_dict
+    assert len(splits) == len(dataset_mixer), "Number of splits must match the number of datasets."
 
     if any(frac_or_samples < 0 for frac_or_samples in dataset_mixer.values()):
         raise ValueError("Dataset fractions / lengths cannot be negative.")


### PR DESCRIPTION
## Bug

`combine_dataset` accepts `dataset_mixer` as either a `dict` or a `list`. The list form interleaves dataset names and weights, e.g. `['d1', '0.5', 'd2', '0.5']` (4 elements for 2 datasets).

The assertion that validates the number of splits runs **before** the list is converted to a dict:

```python
assert len(splits) == len(dataset_mixer), "Number of splits must match the number of datasets."
if isinstance(dataset_mixer, list):
    ...
    dataset_mixer = mixer_dict  # 2-entry dict for the 4-element list above
```

For a list with 2 datasets (4 elements) and `splits = ['train', 'test']` (correctly sized), this evaluates as `2 == 4` and raises `AssertionError`, making the function unusable with list input. The call site in `open_instruct/rejection_sampling/generation.py` passes `args.dataset_mixer_list` (always a list) and would always hit this.

## Root cause

The assertion uses `len(dataset_mixer)` on the raw list (element count) instead of on the converted dict (dataset count).

## Fix

Move the assertion to run after the list→dict conversion so `len(dataset_mixer)` reflects the actual number of datasets.