### PR TITLE
Use processed vLLM logprobs for GRPO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Use processed vLLM logprobs in GRPO rollouts so sampled-token logprobs include sampling transforms like temperature (https://github.com/allenai/open-instruct/pull/1677).
 - Fix hardcoded project version (https://github.com/allenai/open-instruct/pull/1636) by using setuptools scm's automatic versioning.
 - Fix CUDA illegal-memory-access in FSDP2 weight sync to vLLM by also unsharding the root FSDPModule (root-level params like model.norm and lm_head were producing local-shard buffers with global stride) (https://github.com/allenai/open-instruct/pull/1649).
 - Fix weight sync on resume by initializing vLLM weight sync before the training loop and warming up the learner with a dummy forward so DeepSpeed Stage 3 params materialize before the first broadcast; accept IPC `update_info` dict in `LLMRayActor.update_weights`; replace toothless weight-sync tests with a real divergent-weight broadcast test (https://github.com/allenai/open-instruct/pull/1627).

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -423,6 +423,9 @@ class VLLMConfig:
     vllm_gpu_memory_utilization: float = 0.9
     vllm_enable_prefix_caching: bool = False
     vllm_top_p: float = 1.0
+    vllm_logprobs_mode: Literal["raw_logits", "raw_logprobs", "processed_logits", "processed_logprobs"] = (
+        "processed_logprobs"
+    )
 
 
 @dataclass

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -1415,6 +1415,7 @@ def create_model_and_optimizer(
         train_dataset=train_dataset,
         eval_dataset=eval_dataset,
         vllm_attention_backend=vllm_config.vllm_attention_backend,
+        vllm_logprobs_mode=vllm_config.vllm_logprobs_mode,
     )
     logger.info("======== ✅ vLLM engines and actor_manager initialized =========")
 

--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -26,7 +26,7 @@ import time
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from concurrent import futures
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
 import aiohttp
 import backoff
@@ -1216,7 +1216,9 @@ def create_vllm_engines(
     eval_dataset=None,
     trust_remote_code: bool = False,
     vllm_attention_backend: str | None = None,
-    vllm_logprobs_mode: str = "processed_logprobs",
+    vllm_logprobs_mode: Literal["raw_logits", "raw_logprobs", "processed_logits", "processed_logprobs"] = (
+        "processed_logprobs"
+    ),
 ) -> list[ray.actor.ActorHandle]:
     vllm_engines = []
     # Use "mp" (multiprocessing) for TP > 1 when running inside a Ray actor.

--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -1216,6 +1216,7 @@ def create_vllm_engines(
     eval_dataset=None,
     trust_remote_code: bool = False,
     vllm_attention_backend: str | None = None,
+    vllm_logprobs_mode: str = "processed_logprobs",
 ) -> list[ray.actor.ActorHandle]:
     vllm_engines = []
     # Use "mp" (multiprocessing) for TP > 1 when running inside a Ray actor.
@@ -1282,6 +1283,7 @@ def create_vllm_engines(
                 enable_prefix_caching=enable_prefix_caching,
                 max_model_len=max_model_len,
                 gpu_memory_utilization=vllm_gpu_memory_utilization,
+                logprobs_mode=vllm_logprobs_mode,
                 bundle_indices=bundle_indices,
                 num_gpus=0.2 if use_hybrid_engine else 1,
                 noset_visible_devices=ray_noset_visible_devices(),


### PR DESCRIPTION
## Summary
- Add a GRPO vLLM config knob for logprobs mode and default it to processed logprobs.
- Pass the configured mode through to vLLM engine creation so rollout logprobs are comparable to learner logprobs after sampling transforms.