### PR TITLE
Test combine_dataset with list and dict mixers against local fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Add parameterized `combine_dataset` tests in `open_instruct/test_utils.py` covering both list and dict mixer forms against local jsonl fixtures (no network), including split-count mismatch coverage that would have caught the bug fixed in #1674.
 - Make `mason.py` `--output_dir` / `--checkpoint_state_dir` overrides idempotent via `replace_or_append_flag`, add `open_instruct/grpo.py` to `OPEN_INSTRUCT_COMMANDS` / `OPEN_INSTRUCT_RESUMABLES`, and wire OLMo-core checkpoint save/resume into `grpo.py` (`CheckpointerCallback` + `DataPreparationActorCheckpointCallback` + `LoadStrategy.if_available`) so resumable Beaker jobs actually resume (https://github.com/allenai/open-instruct/pull/1666).
 - Make `--budget` optional in `mason.py` (falls back to the workspace's default budget) and drop the explicit `--budget` flag from launch scripts where it already matched the workspace default (https://github.com/allenai/open-instruct/pull/1673).
 - Restore 🤡 to resample warnings and use `self.training_step` in `DataPreparationActor.run` (https://github.com/allenai/open-instruct/pull/1663).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
-- Add parameterized `combine_dataset` tests in `open_instruct/test_utils.py` covering both list and dict mixer forms against local jsonl fixtures (no network), including split-count mismatch coverage that would have caught the bug fixed in #1674.
+- Add parameterized `combine_dataset` tests in `open_instruct/test_utils.py` against local jsonl fixtures (no network), covering varied fractional/sample-count weight combinations and split-count mismatch (would have caught the bug fixed in #1674). Extract the interleaved-list→dict parsing into a shared `utils.parse_dataset_mixer_list` helper (with its own parameterized unit tests) and tighten `combine_dataset` / `get_datasets` to accept dict-only `dataset_mixer`; the one external list-form caller (`rejection_sampling/generation.py`) now converts at the call site.
 - Make `mason.py` `--output_dir` / `--checkpoint_state_dir` overrides idempotent via `replace_or_append_flag`, add `open_instruct/grpo.py` to `OPEN_INSTRUCT_COMMANDS` / `OPEN_INSTRUCT_RESUMABLES`, and wire OLMo-core checkpoint save/resume into `grpo.py` (`CheckpointerCallback` + `DataPreparationActorCheckpointCallback` + `LoadStrategy.if_available`) so resumable Beaker jobs actually resume (https://github.com/allenai/open-instruct/pull/1666).
 - Make `--budget` optional in `mason.py` (falls back to the workspace's default budget) and drop the explicit `--budget` flag from launch scripts where it already matched the workspace default (https://github.com/allenai/open-instruct/pull/1673).
 - Restore 🤡 to resample warnings and use `self.training_step` in `DataPreparationActor.run` (https://github.com/allenai/open-instruct/pull/1663).

--- a/open_instruct/rejection_sampling/generation.py
+++ b/open_instruct/rejection_sampling/generation.py
@@ -31,7 +31,7 @@ from vllm import LLM, SamplingParams
 
 from open_instruct.dataset_processor import INPUT_IDS_PROMPT_KEY, DatasetConfig, SFTDatasetProcessor
 from open_instruct.rejection_sampling.api_generate import LLMGenerationConfig, LLMProcessor  # Import your classes
-from open_instruct.utils import ArgumentParserPlus, combine_dataset
+from open_instruct.utils import ArgumentParserPlus, combine_dataset, parse_dataset_mixer_list
 
 api = HfApi()
 # we don't use `multiprocessing.cpu_count()` because typically we only have 12 CPUs
@@ -132,7 +132,9 @@ def format_conversation(messages: list) -> str:
 
 def main(args: Args, dataset_config: DatasetConfig, gen_args: GenerationArgs):
     dataset = combine_dataset(
-        args.dataset_mixer_list, splits=args.dataset_splits, columns_to_keep=[dataset_config.sft_messages_key]
+        parse_dataset_mixer_list(args.dataset_mixer_list),
+        splits=args.dataset_splits,
+        columns_to_keep=[dataset_config.sft_messages_key],
     )
     if args.dataset_end_idx is None:
         args.dataset_end_idx = len(dataset)

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -134,19 +134,45 @@ class CombineDatasetTest(unittest.TestCase):
     RLVR_PATH = str(pathlib.Path(__file__).parent / "test_data" / "rlvr_sample.jsonl")
 
     @parameterized.expand(
-        [("dict_form", {SFT_PATH: 1.0, RLVR_PATH: 1.0}), ("list_form", [SFT_PATH, "1.0", RLVR_PATH, "1.0"])]
+        [
+            ("full_fractions", {SFT_PATH: 1.0, RLVR_PATH: 1.0}, 200),
+            ("half_fractions", {SFT_PATH: 0.5, RLVR_PATH: 0.5}, 100),
+            ("asymmetric_fractions", {SFT_PATH: 0.7, RLVR_PATH: 0.3}, 100),
+            ("zero_and_full", {SFT_PATH: 0.0, RLVR_PATH: 1.0}, 100),
+            ("int_sample_counts", {SFT_PATH: 25, RLVR_PATH: 50}, 75),
+            ("mixed_fraction_and_count", {SFT_PATH: 0.4, RLVR_PATH: 10}, 50),
+        ]
     )
-    def test_combine_dataset_list_and_dict_equivalent(self, _name, mixer):
+    def test_combine_dataset_dict_form(self, _name, mixer, expected_len):
         ds = utils.combine_dataset(mixer, splits=["train", "train"], columns_to_keep=["messages"])
-        self.assertEqual(len(ds), 200)
+        self.assertEqual(len(ds), expected_len)
         self.assertIn("messages", ds.column_names)
 
-    @parameterized.expand(
-        [("dict_form", {SFT_PATH: 1.0, RLVR_PATH: 1.0}), ("list_form", [SFT_PATH, "1.0", RLVR_PATH, "1.0"])]
-    )
-    def test_combine_dataset_split_mismatch_raises(self, _name, mixer):
+    def test_combine_dataset_split_mismatch_raises(self):
+        mixer = {self.SFT_PATH: 1.0, self.RLVR_PATH: 1.0}
         with self.assertRaises(AssertionError):
             utils.combine_dataset(mixer, splits=["train"], columns_to_keep=["messages"])
+
+
+class ParseDatasetMixerListTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("float_weights", ["a", "0.5", "b", "0.25"], {"a": 0.5, "b": 0.25}),
+            ("int_weights", ["a", "100", "b", "200"], {"a": 100, "b": 200}),
+            ("mixed_weights", ["a", "1.0", "b", "3"], {"a": 1.0, "b": 3}),
+            ("single_entry", ["only", "0.7"], {"only": 0.7}),
+        ]
+    )
+    def test_parse_valid(self, _name, mixer_list, expected):
+        self.assertEqual(utils.parse_dataset_mixer_list(mixer_list), expected)
+
+    def test_odd_length_raises(self):
+        with self.assertRaises(AssertionError):
+            utils.parse_dataset_mixer_list(["a", "1.0", "b"])
+
+    def test_non_string_key_raises(self):
+        with self.assertRaises(AssertionError):
+            utils.parse_dataset_mixer_list([123, "1.0"])
 
 
 def setup_beaker_mocks(mock_beaker_from_env, mock_is_beaker_job, initial_description):

--- a/open_instruct/test_utils.py
+++ b/open_instruct/test_utils.py
@@ -127,6 +127,28 @@ class GetDatasetsTest(unittest.TestCase):
         self.assertTrue(parser.parse("0001-01-01T00:00:00Z"))
 
 
+class CombineDatasetTest(unittest.TestCase):
+    """Exercises combine_dataset end-to-end against local jsonl fixtures (no network)."""
+
+    SFT_PATH = str(pathlib.Path(__file__).parent / "test_data" / "sft_sample.jsonl")
+    RLVR_PATH = str(pathlib.Path(__file__).parent / "test_data" / "rlvr_sample.jsonl")
+
+    @parameterized.expand(
+        [("dict_form", {SFT_PATH: 1.0, RLVR_PATH: 1.0}), ("list_form", [SFT_PATH, "1.0", RLVR_PATH, "1.0"])]
+    )
+    def test_combine_dataset_list_and_dict_equivalent(self, _name, mixer):
+        ds = utils.combine_dataset(mixer, splits=["train", "train"], columns_to_keep=["messages"])
+        self.assertEqual(len(ds), 200)
+        self.assertIn("messages", ds.column_names)
+
+    @parameterized.expand(
+        [("dict_form", {SFT_PATH: 1.0, RLVR_PATH: 1.0}), ("list_form", [SFT_PATH, "1.0", RLVR_PATH, "1.0"])]
+    )
+    def test_combine_dataset_split_mismatch_raises(self, _name, mixer):
+        with self.assertRaises(AssertionError):
+            utils.combine_dataset(mixer, splits=["train"], columns_to_keep=["messages"])
+
+
 def setup_beaker_mocks(mock_beaker_from_env, mock_is_beaker_job, initial_description):
     """Shared mock setup for beaker tests."""
     mock_is_beaker_job.return_value = True

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -361,8 +361,21 @@ def convert_rejection_samples_to_messages(example):
     return example
 
 
+def parse_dataset_mixer_list(mixer_list: list) -> dict:
+    """Convert an interleaved `[name, weight, name, weight, ...]` list into a `{name: weight}` dict."""
+    assert len(mixer_list) % 2 == 0, f"Data mixer list length is not even: {mixer_list}"
+    mixer_dict = {}
+    i = 0
+    while i < len(mixer_list) - 1:
+        assert isinstance(mixer_list[i], str), f"Invalid type in data mixer: {mixer_list}"
+        value = float(mixer_list[i + 1]) if "." in mixer_list[i + 1] else int(mixer_list[i + 1])
+        mixer_dict[mixer_list[i]] = value
+        i += 2
+    return mixer_dict
+
+
 def get_datasets(
-    dataset_mixer: dict | list,
+    dataset_mixer: dict,
     splits: list[str] | None = None,
     configs: list[str] | None = None,
     columns_to_keep: list[str] | None = None,
@@ -376,10 +389,8 @@ def get_datasets(
     Loads and mixes datasets according to proportions specified in `dataset_mixer`.
 
     Args:
-        dataset_mixer (`list` or `dict`):
-            Dictionary or list containing the dataset names and their training proportions.
-            By default, all test proportions are 1. Lists are formatted as
-            `key1 value1 key2 value2 ...` If a list is passed in, it will be converted to a dictionary.
+        dataset_mixer (`dict`):
+            Dictionary mapping dataset names to their training proportions.
         splits (Optional[List[str]], *optional*, defaults to `None`):
             Dataset splits to load and mix. Assumes the splits exist in
             all datasets and have a `train_` or `test_` prefix.
@@ -401,17 +412,6 @@ def get_datasets(
         add_source_col (`bool`, *optional*, defaults to `False`):
             Whether to add a column to the dataset that indicates the source of the data explicitly.
     """
-    if isinstance(dataset_mixer, list):
-        assert len(dataset_mixer) % 2 == 0, f"Data mixer list length is not even: {dataset_mixer}"
-        mixer_dict = {}
-        i = 0
-        while i < len(dataset_mixer) - 1:
-            assert isinstance(dataset_mixer[i], str), f"Invalid type in data mixer: {dataset_mixer}"
-            value = float(dataset_mixer[i + 1]) if "." in dataset_mixer[i + 1] else int(dataset_mixer[i + 1])
-            mixer_dict[dataset_mixer[i]] = value
-            i += 2
-        dataset_mixer = mixer_dict
-
     splits = ["train", "test"] if splits is None else splits
     configs = configs if configs else [None] * len(dataset_mixer)
     columns_to_keep = [] if columns_to_keep is None else columns_to_keep
@@ -587,7 +587,7 @@ def get_datasets(
 
 
 def combine_dataset(
-    dataset_mixer: dict | list,
+    dataset_mixer: dict,
     splits: list[str],
     configs: list[str] | None = None,
     columns_to_keep: list[str] | None = None,
@@ -600,7 +600,7 @@ def combine_dataset(
 
     Args:
         dataset_mixer (`dict`):
-            Dictionary containing the dataset names and their training proportions.
+            Dictionary mapping dataset names to their training proportions.
         splits (Optional[List[str]], *optional*, defaults to `None`):
             Dataset splits to load and mix. Assumes the splits exist in
             all datasets and have a `train_` or `test_` prefix.
@@ -618,16 +618,6 @@ def combine_dataset(
             Used primarily in mix_data.py for saving, or the saved dataset has IDs already.
     """
     assert len(splits) == len(dataset_mixer), "Number of splits must match the number of datasets."
-    if isinstance(dataset_mixer, list):
-        assert len(dataset_mixer) % 2 == 0, f"Data mixer list length is not even: {dataset_mixer}"
-        mixer_dict = {}
-        i = 0
-        while i < len(dataset_mixer) - 1:
-            assert isinstance(dataset_mixer[i], str), f"Invalid type in data mixer: {dataset_mixer}"
-            value = float(dataset_mixer[i + 1]) if "." in dataset_mixer[i + 1] else int(dataset_mixer[i + 1])
-            mixer_dict[dataset_mixer[i]] = value
-            i += 2
-        dataset_mixer = mixer_dict
 
     if any(frac_or_samples < 0 for frac_or_samples in dataset_mixer.values()):
         raise ValueError("Dataset fractions / lengths cannot be negative.")


### PR DESCRIPTION
#1674 indicated a lack of coverage in our tests. This PR rectifies that, and refactors the code to have a single, `dict` path for the mixers, adding a function + tests to convert from the list format (only used by one caller) to the dict format, and adds a bunch of test coverage to the mixing code using the saved test data for the RLVR/SFT tests. 