### PR TITLE
fix: guard against empty choices and null message in LLM responses

### DIFF
--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -723,7 +723,7 @@ class LMJudgeVerifier(VerifierFunction):
             return reasoning, score
 
         try:
-            if not completion.choices or completion.choices[0].message is None:
+            if not completion.choices or completion.choices[0].message is None or completion.choices[0].message.content is None:
                 raise ValueError("LLM returned empty or filtered response")
             # remove anything between <think> and </think> including the tags using regex
             pattern = r"<think>\s*.*?\s*</think>\s*"

--- a/open_instruct/ground_truth_utils.py
+++ b/open_instruct/ground_truth_utils.py
@@ -723,6 +723,8 @@ class LMJudgeVerifier(VerifierFunction):
             return reasoning, score
 
         try:
+            if not completion.choices or completion.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response")
             # remove anything between <think> and </think> including the tags using regex
             pattern = r"<think>\s*.*?\s*</think>\s*"
             content = re.sub(pattern, "", completion.choices[0].message.content, flags=re.DOTALL)

--- a/open_instruct/rejection_sampling/synthetic_preference_dataset.py
+++ b/open_instruct/rejection_sampling/synthetic_preference_dataset.py
@@ -144,6 +144,8 @@ def main(args: Args):
             for i in range(MAX_TRIES):
                 try:
                     response = await acompletion(model=model, messages=messages)
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     r = response.choices[0].message.content
                     comparison = r.split("Comparison:")[1].split("Preferred:")[0].strip()
                     preferred = r.split("Preferred:")[1].strip()

--- a/open_instruct/rejection_sampling/synthetic_preference_dataset.py
+++ b/open_instruct/rejection_sampling/synthetic_preference_dataset.py
@@ -144,7 +144,7 @@ def main(args: Args):
             for i in range(MAX_TRIES):
                 try:
                     response = await acompletion(model=model, messages=messages)
-                    if not response.choices or response.choices[0].message is None:
+                    if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
                         raise ValueError("LLM returned empty or filtered response")
                     r = response.choices[0].message.content
                     comparison = r.split("Comparison:")[1].split("Preferred:")[0].strip()

--- a/open_instruct/rubrics/run_utils.py
+++ b/open_instruct/rubrics/run_utils.py
@@ -116,6 +116,8 @@ def run_litellm(model_name: str, user_prompt: str, system_prompt: str | None = N
         # if we get an error, return an empty string
         return ""
 
+    if not response.choices or response.choices[0].message is None:
+        return ""
     return response.choices[0].message.content
 
 
@@ -204,4 +206,6 @@ async def run_litellm_async(
         logger.warning(f"Error in run_litellm_async: {e}")
         return ""
 
+    if not response.choices or response.choices[0].message is None:
+        return ""
     return response.choices[0].message.content

--- a/open_instruct/rubrics/run_utils.py
+++ b/open_instruct/rubrics/run_utils.py
@@ -116,7 +116,7 @@ def run_litellm(model_name: str, user_prompt: str, system_prompt: str | None = N
         # if we get an error, return an empty string
         return ""
 
-    if not response.choices or response.choices[0].message is None:
+    if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
         return ""
     return response.choices[0].message.content
 
@@ -206,6 +206,6 @@ async def run_litellm_async(
         logger.warning(f"Error in run_litellm_async: {e}")
         return ""
 
-    if not response.choices or response.choices[0].message is None:
+    if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
         return ""
     return response.choices[0].message.content

--- a/scripts/data/rlvr_code/sft_to_rlvr_azure.py
+++ b/scripts/data/rlvr_code/sft_to_rlvr_azure.py
@@ -146,7 +146,7 @@ async def get_completion(prompt, id, semaphore):
                     ],
                     max_tokens=8192,
                 )
-                if not response.choices or response.choices[0].message is None:
+                if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
                     raise ValueError("LLM returned empty or filtered response")
                 response_content = response.choices[0].message.content
                 if response_content and response.usage:

--- a/scripts/data/rlvr_code/sft_to_rlvr_azure.py
+++ b/scripts/data/rlvr_code/sft_to_rlvr_azure.py
@@ -146,8 +146,10 @@ async def get_completion(prompt, id, semaphore):
                     ],
                     max_tokens=8192,
                 )
+                if not response.choices or response.choices[0].message is None:
+                    raise ValueError("LLM returned empty or filtered response")
                 response_content = response.choices[0].message.content
-                if response.choices[0].message.content and response.usage:
+                if response_content and response.usage:
                     input_tokens = response.usage.prompt_tokens
                     output_tokens = response.usage.completion_tokens
 

--- a/scripts/data/rlvr_code/the_algorithms.py
+++ b/scripts/data/rlvr_code/the_algorithms.py
@@ -94,6 +94,8 @@ async def get_completion(prompt):
             ],
             max_tokens=8192,
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return {"original_prompt": prompt, "openai_response": response.choices[0].message.content, "success": True}
     except Exception as e:
         return {"original_prompt": prompt, "openai_response": str(e), "success": False}

--- a/scripts/data/rlvr_code/the_algorithms.py
+++ b/scripts/data/rlvr_code/the_algorithms.py
@@ -94,7 +94,7 @@ async def get_completion(prompt):
             ],
             max_tokens=8192,
         )
-        if not response.choices or response.choices[0].message is None:
+        if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
             raise ValueError("LLM returned empty or filtered response")
         return {"original_prompt": prompt, "openai_response": response.choices[0].message.content, "success": True}
     except Exception as e:

--- a/scripts/does_prompt_make_sense.py
+++ b/scripts/does_prompt_make_sense.py
@@ -67,6 +67,8 @@ def llm_judge(ljc: LLMJudgeConfig, df: pd.DataFrame):
                             {"role": "user", "content": text},
                         ],
                     )
+                    if not response.choices or response.choices[0].message is None:
+                        raise ValueError("LLM returned empty or filtered response")
                     r = response.choices[0].message.content
                 except Exception as e:
                     print(f"error in {i}: {e}")

--- a/scripts/does_prompt_make_sense.py
+++ b/scripts/does_prompt_make_sense.py
@@ -67,7 +67,7 @@ def llm_judge(ljc: LLMJudgeConfig, df: pd.DataFrame):
                             {"role": "user", "content": text},
                         ],
                     )
-                    if not response.choices or response.choices[0].message is None:
+                    if not response.choices or response.choices[0].message is None or response.choices[0].message.content is None:
                         raise ValueError("LLM returned empty or filtered response")
                     r = response.choices[0].message.content
                 except Exception as e:


### PR DESCRIPTION
## Summary

Six locations across five files access `response.choices[0].message.content` without first verifying that `choices` is non-empty and `message` is not `None`.

Two crash vectors that bypass existing try/except blocks:

- **IndexError** — API returns an empty `choices` list (quota exhaustion, network failure, provider-side filtering)
- **AttributeError** — `choices[0].message` is `None` (documented Gemini `PROHIBITED_CONTENT` behaviour: HTTP 200 response with null message object rather than an error status)

## Files changed

| File | Locations | Guard action |
|------|-----------|-------------|
| `open_instruct/rubrics/run_utils.py` | 2 | Return `""` (matches existing except-path behaviour) |
| `open_instruct/ground_truth_utils.py` | 1 | Raise `ValueError` → caught by `except Exception` → returns zero-values |
| `open_instruct/rejection_sampling/synthetic_preference_dataset.py` | 1 | Raise `ValueError` → caught by retry-loop `except Exception` |
| `scripts/does_prompt_make_sense.py` | 1 | Raise `ValueError` → caught by retry-loop `except Exception` |
| `scripts/data/rlvr_code/the_algorithms.py` | 1 | Raise `ValueError` → caught by outer `except` → returns error dict |
| `scripts/data/rlvr_code/sft_to_rlvr_azure.py` | 1 | Guard before access; also simplifies redundant double-access |

## Pattern

```python
# Before
r = response.choices[0].message.content

# After
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
r = response.choices[0].message.content
```

## References

- [OpenAI API docs — finish_reason content_filter](https://platform.openai.com/docs/guides/chat-completions)
- Detected by [pact](https://github.com/qizwiz/pact) static analysis (`llm_response_unguarded` rule)