### PR TITLE
Add Trackio rollout trace logging

### DIFF
--- a/docs/algorithms/grpo.md
+++ b/docs/algorithms/grpo.md
@@ -76,10 +76,30 @@ Both `grpo.py` and `grpo_fast.py` share the same config classes and accept the s
 | **Saving** | `--output_dir` | Output directory for checkpoints | `output` |
 | | `--save_freq` | Save every N train steps | `200` |
 | | `--with_tracking` | Track experiment with Weights and Biases | `False` |
+| **Trace Logging** | `--trackio_project` | Trackio project name for rollout traces | `None` |
+| | `--trackio_space_id` | Optional Hugging Face Space for Trackio logging | `None` |
+| | `--trackio_max_traces_per_step` | Maximum Trackio rollout traces per training step | `32` |
 
 For details on how GRPO's HSDP sharding works, see [OLMo-core Sharding and Parallelism](olmo_core_sharding.md).
 
 ---
+
+### Trackio Rollout Traces
+
+Open-Instruct can log GRPO rollouts as Trackio traces from the same data preparation path that writes JSONL rollout records. Set `--trackio_project` to enable this. Each trace contains the prompt, generated response, reward, advantage, finish reason, dataset, prompt index, sample index, and tool request metadata when present.
+
+```bash
+python -m open_instruct.grpo_fast \
+  ... \
+  --trackio_project open-instruct-rollouts \
+  --trackio_max_traces_per_step 32
+```
+
+To view local traces:
+
+```bash
+trackio show --project open-instruct-rollouts
+```
 
 
 

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -1337,6 +1337,14 @@ class DataPreparationActor:
         logger.info(f"[DataPreparationActor] Started preparation loop from training_step={self.training_step}")
 
     def _data_preparation_loop(self):
+        try:
+            self._run_data_preparation_loop()
+        finally:
+            if self.trackio_rollout_logger is not None:
+                self.trackio_rollout_logger.close()
+                self.trackio_rollout_logger = None
+
+    def _run_data_preparation_loop(self):
         logger.info("[DataPreparationActor] Starting _data_preparation_loop")
 
         if self.config.save_traces and self.config.rollouts_save_path and not self.metadata_saved:
@@ -1405,8 +1413,6 @@ class DataPreparationActor:
             )
 
             if isinstance(result, data_types.ShutdownSentinel):
-                if self.trackio_rollout_logger is not None:
-                    self.trackio_rollout_logger.close()
                 return
 
             if result is None:
@@ -1568,9 +1574,6 @@ class DataPreparationActor:
                 self.metrics[self.training_step] = step_metrics
                 self.current_prepared_step = self.training_step
             self.training_step += 1
-
-        if self.trackio_rollout_logger is not None:
-            self.trackio_rollout_logger.close()
 
     def get_data(self, rank: int, step: int) -> dict:
         """Called by each rank's StreamingDataLoader. Blocks until data ready."""

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -45,7 +45,13 @@ from open_instruct.dataset_transformation import (
 )
 from open_instruct.environments.tools.utils import EnvStatistics
 from open_instruct.model_utils import Batch
-from open_instruct.rl_utils import PackedSequences, pack_sequences, save_rollout_metadata, save_rollouts_to_disk
+from open_instruct.rl_utils import (
+    PackedSequences,
+    TrackioRolloutLogger,
+    pack_sequences,
+    save_rollout_metadata,
+    save_rollouts_to_disk,
+)
 from open_instruct.rubrics import RubricManager
 from open_instruct.utils import combine_reward_metrics
 
@@ -490,6 +496,12 @@ class StreamingDataLoaderConfig:
     # Rollout saving
     save_traces: bool = False
     rollouts_save_path: str = "/weka/oe-adapt-default/allennlp/deletable_rollouts/"
+    trackio_project: str | None = None
+    """Trackio project name for logging rollout traces. Leave unset to disable Trackio trace logging."""
+    trackio_space_id: str | None = None
+    """Optional Hugging Face Space ID for remote Trackio logging."""
+    trackio_max_traces_per_step: int = 32
+    """Maximum rollout traces to log to Trackio per training step. Set to 0 or a negative value to disable."""
 
     # Computed at post_init
     max_possible_score: float = 1.0
@@ -1303,6 +1315,7 @@ class DataPreparationActor:
         self.training_step = 0
         self.total_samples_written = 0
         self.metadata_saved = False
+        self.trackio_rollout_logger: TrackioRolloutLogger | None = None
         self._executor: ThreadPoolExecutor | None = None
         self._prep_future = None
 
@@ -1329,6 +1342,18 @@ class DataPreparationActor:
         if self.config.save_traces and self.config.rollouts_save_path and not self.metadata_saved:
             save_rollout_metadata(self.config.rollouts_save_path, self.run_name, self.model_name)
             self.metadata_saved = True
+        if (
+            self.config.trackio_project
+            and self.config.trackio_max_traces_per_step > 0
+            and self.trackio_rollout_logger is None
+        ):
+            self.trackio_rollout_logger = TrackioRolloutLogger(
+                project=self.config.trackio_project,
+                run_name=self.run_name,
+                tokenizer=self.tokenizer,
+                space_id=self.config.trackio_space_id,
+                max_traces_per_step=self.config.trackio_max_traces_per_step,
+            )
 
         num_initial_prompts = self.config.async_steps * self.global_batch_size
         logger.info(f"[DataPreparationActor] Pushing {num_initial_prompts} initial prompts to param_prompt_Q")
@@ -1380,6 +1405,8 @@ class DataPreparationActor:
             )
 
             if isinstance(result, data_types.ShutdownSentinel):
+                if self.trackio_rollout_logger is not None:
+                    self.trackio_rollout_logger.close()
                 return
 
             if result is None:
@@ -1437,6 +1464,15 @@ class DataPreparationActor:
                     self.total_samples_written,
                 )
                 self.total_samples_written += len(batch.queries)
+
+            if self.trackio_rollout_logger is not None:
+                self.trackio_rollout_logger.log_rollouts(
+                    step=self.training_step,
+                    batch=batch,
+                    result=result,
+                    advantages=advantages,
+                    num_samples_per_prompt=self.config.num_samples_per_prompt_rollout,
+                )
 
             packed_sequences = pack_sequences(
                 queries=batch.queries,
@@ -1532,6 +1568,9 @@ class DataPreparationActor:
                 self.metrics[self.training_step] = step_metrics
                 self.current_prepared_step = self.training_step
             self.training_step += 1
+
+        if self.trackio_rollout_logger is not None:
+            self.trackio_rollout_logger.close()
 
     def get_data(self, rank: int, step: int) -> dict:
         """Called by each rank's StreamingDataLoader. Blocks until data ready."""

--- a/open_instruct/rl_utils.py
+++ b/open_instruct/rl_utils.py
@@ -1,5 +1,6 @@
 import contextlib
 import datetime
+import importlib
 import json
 import os
 import time
@@ -157,6 +158,77 @@ def save_rollouts_to_disk(
     _rollout_executor.submit(
         _save_rollouts, save_path, run_name, step, batch, result, advantages, num_samples_per_prompt, shard_idx
     )
+
+
+class TrackioRolloutLogger:
+    """Log rollout records as Trackio traces."""
+
+    def __init__(
+        self, *, project: str, run_name: str, tokenizer, space_id: str | None = None, max_traces_per_step: int = 32
+    ):
+        self.tokenizer = tokenizer
+        self.max_traces_per_step = max_traces_per_step
+        self.trackio = importlib.import_module("trackio")
+        self.trackio.init(project=project, name=run_name, space_id=space_id)
+
+    def log_rollouts(
+        self,
+        *,
+        step: int,
+        batch: model_utils.Batch,
+        result: data_types.GenerationResult,
+        advantages: np.ndarray,
+        num_samples_per_prompt: int,
+        split: str = "train",
+    ) -> None:
+        if self.max_traces_per_step <= 0:
+            return
+
+        assert batch.scores is not None, "batch.scores must not be None when logging Trackio traces"
+
+        traces = []
+        for i in range(min(len(batch.queries), self.max_traces_per_step)):
+            metadata = {
+                "split": split,
+                "step": step,
+                "sample_idx": i,
+                "prompt_idx": i // num_samples_per_prompt,
+                "reward": float(batch.scores[i]),
+                "advantage": float(advantages[i]),
+                "finish_reason": result.finish_reasons[i],
+                "dataset": batch.datasets[i],
+            }
+            if batch.indices is not None:
+                metadata["dataset_index"] = batch.indices[i]
+            if batch.model_steps:
+                metadata["model_step"] = batch.model_steps[i]
+            request_info = _get_request_info_for_sample(result.request_info, i)
+            if request_info is not None:
+                metadata["request_info"] = request_info
+
+            prompt = (
+                batch.raw_queries[i]
+                if batch.raw_queries is not None and batch.raw_queries[i] is not None
+                else self.tokenizer.decode(batch.queries[i], skip_special_tokens=False)
+            )
+            response = (
+                batch.decoded_responses[i]
+                if batch.decoded_responses is not None and batch.decoded_responses[i] is not None
+                else self.tokenizer.decode(result.responses[i], skip_special_tokens=False)
+            )
+
+            traces.append(
+                self.trackio.Trace(
+                    messages=[{"role": "user", "content": prompt}, {"role": "assistant", "content": response}],
+                    metadata=metadata,
+                )
+            )
+
+        if traces:
+            self.trackio.log({f"{split}/rollouts": traces}, step=step)
+
+    def close(self) -> None:
+        self.trackio.finish()
 
 
 @dataclass

--- a/open_instruct/rl_utils.py
+++ b/open_instruct/rl_utils.py
@@ -1,6 +1,5 @@
 import contextlib
 import datetime
-import importlib
 import json
 import os
 import time
@@ -10,6 +9,7 @@ from typing import Generic, TypeVar
 
 import numpy as np
 import torch
+import trackio
 
 from open_instruct import data_types, logger_utils, model_utils, utils
 
@@ -168,8 +168,7 @@ class TrackioRolloutLogger:
     ):
         self.tokenizer = tokenizer
         self.max_traces_per_step = max_traces_per_step
-        self.trackio = importlib.import_module("trackio")
-        self.trackio.init(project=project, name=run_name, space_id=space_id)
+        trackio.init(project=project, name=run_name, space_id=space_id)
 
     def log_rollouts(
         self,
@@ -184,10 +183,21 @@ class TrackioRolloutLogger:
         if self.max_traces_per_step <= 0:
             return
 
-        assert batch.scores is not None, "batch.scores must not be None when logging Trackio traces"
+        if batch.scores is None:
+            logger.warning("Skipping Trackio rollout traces because batch.scores is None")
+            return
 
         traces = []
-        for i in range(min(len(batch.queries), self.max_traces_per_step)):
+        num_traces = min(
+            len(batch.queries),
+            len(batch.scores),
+            len(batch.datasets),
+            len(result.responses),
+            len(result.finish_reasons),
+            len(advantages),
+            self.max_traces_per_step,
+        )
+        for i in range(num_traces):
             metadata = {
                 "split": split,
                 "step": step,
@@ -198,9 +208,9 @@ class TrackioRolloutLogger:
                 "finish_reason": result.finish_reasons[i],
                 "dataset": batch.datasets[i],
             }
-            if batch.indices is not None:
+            if batch.indices is not None and i < len(batch.indices):
                 metadata["dataset_index"] = batch.indices[i]
-            if batch.model_steps:
+            if batch.model_steps and i < len(batch.model_steps):
                 metadata["model_step"] = batch.model_steps[i]
             request_info = _get_request_info_for_sample(result.request_info, i)
             if request_info is not None:
@@ -208,27 +218,29 @@ class TrackioRolloutLogger:
 
             prompt = (
                 batch.raw_queries[i]
-                if batch.raw_queries is not None and batch.raw_queries[i] is not None
+                if batch.raw_queries is not None and i < len(batch.raw_queries) and batch.raw_queries[i] is not None
                 else self.tokenizer.decode(batch.queries[i], skip_special_tokens=False)
             )
             response = (
                 batch.decoded_responses[i]
-                if batch.decoded_responses is not None and batch.decoded_responses[i] is not None
+                if batch.decoded_responses is not None
+                and i < len(batch.decoded_responses)
+                and batch.decoded_responses[i] is not None
                 else self.tokenizer.decode(result.responses[i], skip_special_tokens=False)
             )
 
             traces.append(
-                self.trackio.Trace(
+                trackio.Trace(
                     messages=[{"role": "user", "content": prompt}, {"role": "assistant", "content": response}],
                     metadata=metadata,
                 )
             )
 
         if traces:
-            self.trackio.log({f"{split}/rollouts": traces}, step=step)
+            trackio.log({f"{split}/rollouts": traces}, step=step)
 
     def close(self) -> None:
-        self.trackio.finish()
+        trackio.finish()
 
 
 @dataclass

--- a/open_instruct/test_rl_utils.py
+++ b/open_instruct/test_rl_utils.py
@@ -2,13 +2,14 @@ import shutil
 import tempfile
 import time
 import unittest
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import torch
 import transformers
 from parameterized import parameterized
 
-from open_instruct import rl_utils
+from open_instruct import data_types, model_utils, rl_utils
 
 PACK_LENGTH = 40
 PROMPT_MAX_LEN = 20
@@ -335,6 +336,136 @@ class TestRLUtils(unittest.TestCase):
         # Verify no empty sequences
         for seq in packed_with_min.query_responses:
             self.assertGreater(len(seq), 0)
+
+    @patch("open_instruct.rl_utils.importlib.import_module")
+    def test_trackio_rollout_logger_logs_traces(self, mock_import_module):
+        """Test that rollout batches are logged as Trackio Trace records."""
+        mock_trackio = MagicMock()
+        mock_trackio.Trace.side_effect = lambda messages, metadata: {
+            "_type": "trackio.trace",
+            "messages": messages,
+            "metadata": metadata,
+        }
+        mock_import_module.return_value = mock_trackio
+
+        tokenizer = MagicMock()
+        tokenizer.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
+            str(token) for token in tokens
+        )
+        logger = rl_utils.TrackioRolloutLogger(
+            project="open-instruct-trackio-test",
+            run_name="test-run",
+            tokenizer=tokenizer,
+            space_id="user/space",
+            max_traces_per_step=2,
+        )
+
+        batch = model_utils.Batch(
+            queries=[[1, 2], [3, 4]],
+            ground_truths=[[5], [6]],
+            datasets=["math", "math"],
+            raw_queries=["What is 2 + 2?", "What is 3 + 3?"],
+            decoded_responses=["4", "6"],
+            indices=[10, 11],
+            scores=[1.0, 0.5],
+            model_steps=[7, 7],
+        )
+        result = data_types.GenerationResult(
+            responses=[[5], [6]],
+            finish_reasons=["stop", "length"],
+            masks=[[1], [1]],
+            request_info=data_types.RequestInfo(
+                num_calls=[0, 1],
+                timeouts=[0, 0],
+                tool_errors=["", ""],
+                tool_outputs=["", "tool output"],
+                tool_runtimes=[0.0, 0.2],
+                tool_calleds=[False, True],
+            ),
+            index=None,
+            prompt_id=None,
+        )
+
+        logger.log_rollouts(
+            step=3, batch=batch, result=result, advantages=np.array([0.25, -0.25]), num_samples_per_prompt=2
+        )
+
+        mock_trackio.init.assert_called_once_with(
+            project="open-instruct-trackio-test", name="test-run", space_id="user/space"
+        )
+        self.assertEqual(mock_trackio.Trace.call_count, 2)
+        first_trace = mock_trackio.Trace.call_args_list[0].kwargs
+        self.assertEqual(
+            first_trace["messages"],
+            [{"role": "user", "content": "What is 2 + 2?"}, {"role": "assistant", "content": "4"}],
+        )
+        self.assertEqual(
+            first_trace["metadata"],
+            {
+                "split": "train",
+                "step": 3,
+                "sample_idx": 0,
+                "prompt_idx": 0,
+                "reward": 1.0,
+                "advantage": 0.25,
+                "finish_reason": "stop",
+                "dataset": "math",
+                "dataset_index": 10,
+                "model_step": 7,
+                "request_info": {
+                    "num_calls": 0,
+                    "timeouts": 0,
+                    "tool_errors": "",
+                    "tool_outputs": "",
+                    "tool_runtimes": 0.0,
+                    "tool_calleds": False,
+                    "tool_call_stats": [],
+                    "rollout_state": {},
+                },
+            },
+        )
+        mock_trackio.log.assert_called_once()
+        self.assertEqual(mock_trackio.log.call_args.args[0]["train/rollouts"][0]["messages"], first_trace["messages"])
+        self.assertEqual(mock_trackio.log.call_args.kwargs, {"step": 3})
+
+    @patch("open_instruct.rl_utils.importlib.import_module")
+    def test_trackio_rollout_logger_respects_cap(self, mock_import_module):
+        """Test that Trackio rollout logging respects max_traces_per_step."""
+        mock_trackio = MagicMock()
+        mock_import_module.return_value = mock_trackio
+        logger = rl_utils.TrackioRolloutLogger(
+            project="open-instruct-trackio-test", run_name="test-run", tokenizer=MagicMock(), max_traces_per_step=1
+        )
+        batch = model_utils.Batch(
+            queries=[[1], [2]],
+            ground_truths=[[], []],
+            datasets=["math", "math"],
+            raw_queries=["q1", "q2"],
+            decoded_responses=["a1", "a2"],
+            indices=None,
+            scores=[1.0, 0.0],
+        )
+        result = data_types.GenerationResult(
+            responses=[[3], [4]],
+            finish_reasons=["stop", "stop"],
+            masks=[[1], [1]],
+            request_info=data_types.RequestInfo(
+                num_calls=[0, 0],
+                timeouts=[0, 0],
+                tool_errors=["", ""],
+                tool_outputs=["", ""],
+                tool_runtimes=[0.0, 0.0],
+                tool_calleds=[False, False],
+            ),
+            index=None,
+            prompt_id=None,
+        )
+
+        logger.log_rollouts(
+            step=0, batch=batch, result=result, advantages=np.array([1.0, 0.0]), num_samples_per_prompt=1
+        )
+
+        mock_trackio.Trace.assert_called_once()
 
 
 class TestMaskedMean(unittest.TestCase):

--- a/open_instruct/test_rl_utils.py
+++ b/open_instruct/test_rl_utils.py
@@ -337,16 +337,14 @@ class TestRLUtils(unittest.TestCase):
         for seq in packed_with_min.query_responses:
             self.assertGreater(len(seq), 0)
 
-    @patch("open_instruct.rl_utils.importlib.import_module")
-    def test_trackio_rollout_logger_logs_traces(self, mock_import_module):
+    @patch("open_instruct.rl_utils.trackio")
+    def test_trackio_rollout_logger_logs_traces(self, mock_trackio):
         """Test that rollout batches are logged as Trackio Trace records."""
-        mock_trackio = MagicMock()
         mock_trackio.Trace.side_effect = lambda messages, metadata: {
             "_type": "trackio.trace",
             "messages": messages,
             "metadata": metadata,
         }
-        mock_import_module.return_value = mock_trackio
 
         tokenizer = MagicMock()
         tokenizer.decode.side_effect = lambda tokens, skip_special_tokens=False: " ".join(
@@ -428,11 +426,9 @@ class TestRLUtils(unittest.TestCase):
         self.assertEqual(mock_trackio.log.call_args.args[0]["train/rollouts"][0]["messages"], first_trace["messages"])
         self.assertEqual(mock_trackio.log.call_args.kwargs, {"step": 3})
 
-    @patch("open_instruct.rl_utils.importlib.import_module")
-    def test_trackio_rollout_logger_respects_cap(self, mock_import_module):
+    @patch("open_instruct.rl_utils.trackio")
+    def test_trackio_rollout_logger_respects_cap(self, mock_trackio):
         """Test that Trackio rollout logging respects max_traces_per_step."""
-        mock_trackio = MagicMock()
-        mock_import_module.return_value = mock_trackio
         logger = rl_utils.TrackioRolloutLogger(
             project="open-instruct-trackio-test", run_name="test-run", tokenizer=MagicMock(), max_traces_per_step=1
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "setuptools>=75.6.0,<80.0.0",
     "tensorboard>=2.18.0",
     "torch>=2.10.0",
+    "trackio",
     "transformers>=5.4.0",
     "vllm>=0.19.1; platform_system != 'Darwin'",
     "wandb==0.23.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -288,6 +288,7 @@ frozenlist==1.8.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') 
 fsspec==2025.10.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via
     #   datasets
+    #   gradio-client
     #   huggingface-hub
     #   torch
 gguf==0.17.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')
@@ -324,6 +325,8 @@ googleapis-common-protos==1.72.0 ; (platform_machine == 'aarch64' and sys_platfo
     #   google-api-core
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
+gradio-client==2.5.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
+    # via trackio
 greenlet==3.3.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via
     #   patchright
@@ -342,7 +345,7 @@ h2==4.3.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (plat
     # via httpx
 hf-transfer==0.1.9 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via open-instruct
-hf-xet==1.4.2 ; (platform_machine == 'AMD64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')
+hf-xet==1.5.0 ; (platform_machine == 'AMD64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine == 'amd64' and sys_platform == 'darwin') or (platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')
     # via huggingface-hub
 hjson==3.1.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via deepspeed
@@ -350,7 +353,7 @@ hpack==4.1.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (p
     # via h2
 httpcore==1.0.9 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via httpx
-httptools==0.7.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')
+httptools==0.7.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via uvicorn
 httpx==0.28.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via
@@ -361,6 +364,7 @@ httpx==0.28.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (
     #   fastapi
     #   fastapi-cloud-cli
     #   fastmcp
+    #   gradio-client
     #   huggingface-hub
     #   litellm
     #   mcp
@@ -368,14 +372,16 @@ httpx==0.28.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (
     #   openai
 httpx-sse==0.4.3 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via mcp
-huggingface-hub==1.8.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
+huggingface-hub==1.16.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via
     #   accelerate
     #   cached-path
     #   datasets
+    #   gradio-client
     #   openenv-core
     #   peft
     #   tokenizers
+    #   trackio
     #   transformers
 humanize==4.15.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via crawl4ai
@@ -570,6 +576,7 @@ numpy==2.2.6 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (p
     #   shapely
     #   tensorboard
     #   torchvision
+    #   trackio
     #   transformers
     #   trimesh
     #   vllm
@@ -739,6 +746,8 @@ opentelemetry-semantic-conventions==0.60b1 ; (platform_machine == 'aarch64' and 
     #   opentelemetry-semantic-conventions-ai
 opentelemetry-semantic-conventions-ai==0.5.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')
     # via vllm
+orjson==3.11.9 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
+    # via trackio
 outlines-core==0.2.11 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')
     # via vllm
 packaging==25.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
@@ -752,6 +761,7 @@ packaging==25.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or
     #   deepspeed
     #   flash-attn-3
     #   flashinfer-python
+    #   gradio-client
     #   huggingface-hub
     #   lm-format-enforcer
     #   matplotlib
@@ -792,6 +802,7 @@ pillow==12.1.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or 
     #   pdfplumber
     #   tensorboard
     #   torchvision
+    #   trackio
     #   vllm
 platformdirs==4.5.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via
@@ -955,6 +966,7 @@ python-multipart==0.0.21 ; (platform_machine == 'aarch64' and sys_platform == 'l
     # via
     #   fastapi
     #   mcp
+    #   trackio
 pytz==2025.2 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via pandas
 pyyaml==6.0.3 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
@@ -1126,6 +1138,7 @@ starlette==0.50.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') 
     #   model-hosting-container-standards
     #   prometheus-fastapi-instrumentator
     #   sse-starlette
+    #   trackio
 supervisor==4.3.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')
     # via model-hosting-container-standards
 sympy==1.14.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
@@ -1229,6 +1242,8 @@ tqdm==4.67.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (p
     #   peft
     #   transformers
     #   vllm
+trackio==0.25.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
+    # via open-instruct
 transformers==5.4.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via
     #   compressed-tensors
@@ -1268,6 +1283,7 @@ typing-extensions==4.15.0 ; (platform_machine == 'aarch64' and sys_platform == '
     #   exceptiongroup
     #   fastapi
     #   flash-attn-4
+    #   gradio-client
     #   grpcio
     #   huggingface-hub
     #   mcp
@@ -1319,7 +1335,8 @@ uvicorn==0.40.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or
     #   mcp
     #   open-instruct
     #   openenv-core
-uvloop==0.22.1 ; (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')
+    #   trackio
+uvloop==0.22.1 ; (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_python_implementation != 'PyPy' and sys_platform == 'darwin')
     # via uvicorn
 virtualenv==20.36.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via
@@ -1331,7 +1348,7 @@ wandb==0.23.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (
     # via open-instruct
 watchdog==6.0.0 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via mkdocs
-watchfiles==1.1.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')
+watchfiles==1.1.1 ; (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'
     # via
     #   uvicorn
     #   vllm

--- a/uv.lock
+++ b/uv.lock
@@ -1493,6 +1493,22 @@ wheels = [
 ]
 
 [[package]]
+name = "gradio-client"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "httpx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "huggingface-hub", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "packaging", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/e6/6b6029f5fe2ad7f1211105d530e34d991014c2cae463f9223033031cfc4f/gradio_client-2.5.0.tar.gz", hash = "sha256:4cde99bad62149595c30c90876ca2e405e3a13687ecf895474f3412cb476673d", size = 59013, upload-time = "2026-04-20T23:16:21.518Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/81/0a861b8e1ff42960139c6cd4c7dd591292fa09ea1ae2d87677441cba4c00/gradio_client-2.5.0-py3-none-any.whl", hash = "sha256:d43e2179c29076292a76485ad7ed2e6eaa19d14ac58283bd7f5beabfe4ca958c", size = 59952, upload-time = "2026-04-20T23:16:20.186Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1559,16 +1575,16 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.4.2"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/09/08/23c84a26716382c89151b5b447b4beb19e3345f3a93d3b73009a71a57ad3/hf_xet-1.4.2.tar.gz", hash = "sha256:b7457b6b482d9e0743bd116363239b1fa904a5e65deede350fbc0c4ea67c71ea", size = 672357, upload-time = "2026-03-13T06:58:51.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/86/b40b83a2ff03ef05c4478d2672b1fc2b9683ff870e2b25f4f3af240f2e7b/hf_xet-1.4.2-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:71f02d6e4cdd07f344f6844845d78518cc7186bd2bc52d37c3b73dc26a3b0bc5", size = 3800339, upload-time = "2026-03-13T06:58:36.245Z" },
-    { url = "https://files.pythonhosted.org/packages/64/2e/af4475c32b4378b0e92a587adb1aa3ec53e3450fd3e5fe0372a874531c00/hf_xet-1.4.2-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9b38d876e94d4bdcf650778d6ebbaa791dd28de08db9736c43faff06ede1b5a", size = 3559664, upload-time = "2026-03-13T06:58:34.787Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/4c/781267da3188db679e601de18112021a5cb16506fe86b246e22c5401a9c4/hf_xet-1.4.2-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:77e8c180b7ef12d8a96739a4e1e558847002afe9ea63b6f6358b2271a8bdda1c", size = 4217422, upload-time = "2026-03-13T06:58:27.472Z" },
-    { url = "https://files.pythonhosted.org/packages/68/47/d6cf4a39ecf6c7705f887a46f6ef5c8455b44ad9eb0d391aa7e8a2ff7fea/hf_xet-1.4.2-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3b3c6a882016b94b6c210957502ff7877802d0dbda8ad142c8595db8b944271", size = 3992847, upload-time = "2026-03-13T06:58:25.989Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/ef/e80815061abff54697239803948abc665c6b1d237102c174f4f7a9a5ffc5/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9d9a634cc929cfbaf2e1a50c0e532ae8c78fa98618426769480c58501e8c8ac2", size = 4193843, upload-time = "2026-03-13T06:58:44.59Z" },
-    { url = "https://files.pythonhosted.org/packages/54/75/07f6aa680575d9646c4167db6407c41340cbe2357f5654c4e72a1b01ca14/hf_xet-1.4.2-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6b0932eb8b10317ea78b7da6bab172b17be03bbcd7809383d8d5abd6a2233e04", size = 4432751, upload-time = "2026-03-13T06:58:46.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
 ]
 
 [[package]]
@@ -1608,6 +1624,8 @@ version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
     { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
     { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
     { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
@@ -1645,7 +1663,7 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.8.0"
+version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
@@ -1658,9 +1676,9 @@ dependencies = [
     { name = "typer", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/2a/a847fd02261cd051da218baf99f90ee7c7040c109a01833db4f838f25256/huggingface_hub-1.8.0.tar.gz", hash = "sha256:c5627b2fd521e00caf8eff4ac965ba988ea75167fad7ee72e17f9b7183ec63f3", size = 735839, upload-time = "2026-03-25T16:01:28.152Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/ae/8a3a16ea4d202cb641b51d2681bdd3d482c1c592d7570b3fa264730829ce/huggingface_hub-1.8.0-py3-none-any.whl", hash = "sha256:d3eb5047bd4e33c987429de6020d4810d38a5bef95b3b40df9b17346b7f353f2", size = 625208, upload-time = "2026-03-25T16:01:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -2741,6 +2759,7 @@ dependencies = [
     { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
     { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "torch", version = "2.10.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "trackio", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "transformers", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "uvicorn", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "vllm", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -2815,6 +2834,7 @@ requires-dist = [
     { name = "torch", marker = "sys_platform != 'linux'", specifier = ">=2.10.0" },
     { name = "torch", marker = "platform_machine != 'aarch64' and sys_platform == 'linux'", specifier = ">=2.10.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torch", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'", specifier = ">=2.10.0", index = "https://download.pytorch.org/whl/cu130" },
+    { name = "trackio" },
     { name = "transformers", specifier = ">=5.4.0" },
     { name = "uvicorn", specifier = ">=0.20.0" },
     { name = "vllm", marker = "sys_platform != 'darwin'", specifier = ">=0.19.1" },
@@ -3129,6 +3149,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/0b/0ff2326417a9eed74ff6717629075246098dcbda067a62fd73095139babb/opentelemetry_semantic_conventions_ai-0.5.0.tar.gz", hash = "sha256:64c21c5ae0c971ee2ecab986d66e93bb50e616b52e18a1284e118a323a9e6869", size = 25202, upload-time = "2026-03-20T08:47:05.751Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/18/35fec29ed6e49bcbbe629b790cc0deb5bb58da9caceee29b39b54d3d7f47/opentelemetry_semantic_conventions_ai-0.5.0-py3-none-any.whl", hash = "sha256:8727f474f590138f5e4937945378878a5b2f4ea82bc24ffd93265ca9fbdc48a4", size = 9983, upload-time = "2026-03-20T08:47:06.843Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c7/375e83a76851b73b2e39f3bcf0e5a19e2b89bad13e5bca97d0b293d27f24/orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2", size = 141509, upload-time = "2026-05-06T15:10:09.595Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
 ]
 
 [[package]]
@@ -4585,6 +4619,24 @@ wheels = [
 ]
 
 [[package]]
+name = "trackio"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gradio-client", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "huggingface-hub", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "orjson", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "pillow", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "python-multipart", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "starlette", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "uvicorn", extra = ["standard"], marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9a/80caa250ef9e0e465db883958764c9b27a413c8b246349f60c237b820201/trackio-0.25.1-py3-none-any.whl", hash = "sha256:d019b79a8dfb14264db1055b7e9b2681984138b827dabd5ec01585c0bd24116d", size = 1653922, upload-time = "2026-04-26T02:13:41.814Z" },
+]
+
+[[package]]
 name = "transformers"
 version = "5.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4720,12 +4772,12 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "httptools", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "python-dotenv", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "pyyaml", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "uvloop", marker = "(platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
-    { name = "watchfiles", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "websockets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "httptools", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "python-dotenv", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "uvloop", marker = "(platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_python_implementation != 'PyPy' and sys_platform == 'darwin')" },
+    { name = "watchfiles", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "websockets", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
 ]
 
 [[package]]
@@ -4734,6 +4786,8 @@ version = "0.22.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
     { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
     { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
     { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
@@ -4877,10 +4931,12 @@ name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "anyio", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
     { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
     { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
     { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },


### PR DESCRIPTION
Hi folks! This PR adds trace logging via Trackio, the free, local-first experiment tracking library from Hugging Face 🤗

This PR follows Open-Instruct's existing rollout trace saving path, specifically I did this:

- added `StreamingDataLoaderConfig.trackio_project` support to enable Trackio rollout traces
- added logging GRPO rollout prompt/response pairs as `trackio.Trace` records from the data preparation actor
- included reward, advantage, finish reason, dataset, prompt/sample index, model step, and tool request metadata on each trace
- added `trackio_max_traces_per_step` to cap trace volume per training step, plus optional `trackio_space_id` for remote logging
- documented the Trackio rollout trace flags and added tests with mocked Trackio

I tested it end-to-end and here's what it looks like:

<img width="1503" height="718" alt="image" src="https://github.com/user-attachments/assets/ae8c641d-e39c-49be-978c-93207b0305de" />


AI assistance was used to prepare this PR.
