### PR TITLE
Fix validate_choice operand direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `validate_choice` operand direction to correctly check if any option is present within the response text, and make the matching case-insensitive (https://github.com/allenai/open-instruct/pull/1615).
 - Fix hardcoded project version (https://github.com/allenai/open-instruct/pull/1636) by using setuptools scm's automatic versioning.
 - Fix CUDA illegal-memory-access in FSDP2 weight sync to vLLM by also unsharding the root FSDPModule (root-level params like model.norm and lm_head were producing local-shard buffers with global stride) (https://github.com/allenai/open-instruct/pull/1649).
 - Fix weight sync on resume by initializing vLLM weight sync before the training loop and warming up the learner with a dummy forward so DeepSpeed Stage 3 params materialize before the first broadcast; accept IPC `update_info` dict in `LLMRayActor.update_weights`; replace toothless weight-sync tests with a real divergent-weight broadcast test (https://github.com/allenai/open-instruct/pull/1627).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -360,7 +360,7 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
-    return any(text in option for option in options)
+    return any(option in text for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -360,7 +360,8 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
-    return any(option.lower() in text.lower() for option in options)
+    text_lower = text.lower()
+    return any(option.lower() in text_lower for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -360,7 +360,7 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
-    return any(option in text for option in options)
+    return any(option.lower() in text.lower() for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted

--- a/scripts/eval_constraints/if_functions.py
+++ b/scripts/eval_constraints/if_functions.py
@@ -369,7 +369,7 @@ def validate_title(text: str) -> bool:
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
     for option in options:
-        if option in text:
+        if option.lower() in text.lower():
             return True
     return False
 

--- a/scripts/eval_constraints/if_functions.py
+++ b/scripts/eval_constraints/if_functions.py
@@ -368,8 +368,9 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
+    text_lower = text.lower()
     for option in options:
-        if option.lower() in text.lower():
+        if option.lower() in text_lower:
             return True
     return False
 

--- a/scripts/eval_constraints/if_functions.py
+++ b/scripts/eval_constraints/if_functions.py
@@ -369,7 +369,7 @@ def validate_title(text: str) -> bool:
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
     for option in options:
-        if text in option:
+        if option in text:
             return True
     return False
 


### PR DESCRIPTION
## Bug
`validate_choice` is backwards. When evaluating options like `['yes', 'no']` against a response like `"The answer is yes"`, the validation function returns `False`.

## Root cause
The operand check is `any(text in option for option in options)` (and a similar `text in option` loop in the scripts variant). This checks if the response `"The answer is yes"` is a substring of the option `"yes"`, which is backwards.

## Why fix is correct
Swapping the check to `option in text` checks if the option is a substring of the response, restoring the correct membership logic and matching the other `validate_*` functions in the module.