### PR TITLE
Fix validate_choice false positives on substring matching using regex word boundaries

### DIFF
--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -360,9 +360,9 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
-    # substring matching yields false positives (e.g. option "A" matches "Apple"); if this
-    # is a problem, switch to a regex, e.g. re.search(rf"(?<!\w){re.escape(str(option))}(?!\w)", text).
-    return any(option in text for option in options)
+    # Use word boundary regex to avoid false positives (e.g. option "A" matching "Apple")
+    import re
+    return any(bool(re.search(rf"(?<!\w){re.escape(str(option))}(?!\w)", text)) for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -361,8 +361,7 @@ def validate_title(text: str) -> bool:
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
     # Use word boundary regex to avoid false positives (e.g. option "A" matching "Apple")
-    import re
-    return any(bool(re.search(rf"(?<!\w){re.escape(str(option))}(?!\w)", text)) for option in options)
+    return any(re.search(rf"(?<!\w){re.escape(str(option))}(?!\w)", text) for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -18,6 +18,7 @@ class TestValidateChoice(unittest.TestCase):
             ("option_appears", "I choose red", ["red", "blue"], True),
             ("no_option_present", "I choose green", ["red", "blue"], False),
             ("exact_match", "red", ["red", "blue"], True),
+            ("substring_false_positive", "I love Apple", ["A"], False),
         ]
     )
     def test_validate_choice(self, _name, text, options, expected):


### PR DESCRIPTION
**Bug:** `validate_choice` uses simple substring matching (`any(option in text for option in options)`), which incorrectly flags substring matches as correct. For example, if the option is `"A"` and the text is `"I love Apple"`, it returns `True`.

**Root cause:** Lacking word boundary enforcement during the substring search.

**Why fix is correct:** Enforcing word boundaries with a regex `(?<!\w){re.escape(str(option))}(?!\w)` ensures that the option is matched as a standalone word/choice, matching the intended behavior of IFEval.