### PR TITLE
Fix sentence terminator and whitespace handling in verify_sentence_constraint

### DIFF
--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -231,7 +231,8 @@ def verify_sentence_constraint(text: str, N: int, quantifier: str) -> bool:
         bool: True if the text contains the expected number of sentences, False otherwise
     """
     # Split the text into sentences
-    sentences = re.split(r"(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?|!)\s", text)
+    sentences = re.split(r"(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?|!)\s+", text)
+    sentences = [s for s in sentences if s.strip()]
 
     # Count the number of sentences
     actual_count = len(sentences)

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -232,7 +232,7 @@ def verify_sentence_constraint(text: str, N: int, quantifier: str) -> bool:
     """
     # Split the text into sentences
     sentences = re.split(r"(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?|!)\s+", text)
-    sentences = [s for s in sentences if s.strip()]
+    sentences = [s.strip() for s in sentences if s.strip()]
 
     # Count the number of sentences
     actual_count = len(sentences)

--- a/scripts/eval_constraints/if_functions.py
+++ b/scripts/eval_constraints/if_functions.py
@@ -231,7 +231,8 @@ def verify_sentence_constraint(text: str, N: int, quantifier: str) -> bool:
         bool: True if the text contains the expected number of sentences, False otherwise
     """
     # Split the text into sentences
-    sentences = re.split(r"(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?)\s", text)
+    sentences = re.split(r"(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?|!)\s+", text)
+    sentences = [s for s in sentences if s.strip()]
 
     # Count the number of sentences
     actual_count = len(sentences)

--- a/scripts/eval_constraints/if_functions.py
+++ b/scripts/eval_constraints/if_functions.py
@@ -232,7 +232,7 @@ def verify_sentence_constraint(text: str, N: int, quantifier: str) -> bool:
     """
     # Split the text into sentences
     sentences = re.split(r"(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?|!)\s+", text)
-    sentences = [s for s in sentences if s.strip()]
+    sentences = [s.strip() for s in sentences if s.strip()]
 
     # Count the number of sentences
     actual_count = len(sentences)


### PR DESCRIPTION
Bug: The sentence constraint logic was failing on trailing spaces or multiple spaces between sentences, resulting in incorrect sentence counts. Root cause: The regex split used \s which left empty strings when splitting on multiple spaces, and it didn't filter out empty strings resulting from trailing spaces. Why fix is correct: Used \s+ in the regex and added a list comprehension to filter out empty strings, ensuring only actual sentences are counted.