### PR TITLE
Fix mutually exclusive filter checks for token lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `PreferenceDatasetProcessor.filter` dropping the rejected-sequence length check, so over-long rejected completions were no longer filtered (https://github.com/allenai/open-instruct/pull/1597).
 - Fix `Batch.__getitem__` handling of `active_tools` for int and list indexing (https://github.com/allenai/open-instruct/pull/1592).
 - Fix `RepeatPhraseChecker.check_following` to validate all matched phrases differ by exactly one word and return a proper boolean instead of `None` (https://github.com/allenai/open-instruct/pull/1044).
 - Fix incorrect hardcoded checkpoint state path for multi-GPU DeepSpeed resumption (https://github.com/allenai/open-instruct/pull/1589).

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -251,13 +251,10 @@ class PreferenceDatasetProcessor(DatasetProcessor):
                 len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
                 if self.config.max_prompt_token_length is not None
                 else (
-                    True and len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
+                    len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
+                    and len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length
                     if self.config.max_token_length is not None
-                    else (
-                        True and len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length
-                        if self.config.max_token_length is not None
-                        else True
-                    )
+                    else True
                 )
             )
 

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -247,16 +247,16 @@ class PreferenceDatasetProcessor(DatasetProcessor):
 
     def filter(self, dataset: Union[Dataset, DatasetDict]):
         def filter_fn(row):
-            return (
-                len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
-                if self.config.max_prompt_token_length is not None
-                else (
+            prompt_length_ok = True
+            if self.config.max_prompt_token_length is not None:
+                prompt_length_ok = len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
+            token_length_ok = True
+            if self.config.max_token_length is not None:
+                token_length_ok = (
                     len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
                     and len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length
-                    if self.config.max_token_length is not None
-                    else True
                 )
-            )
+            return prompt_length_ok and token_length_ok
 
         filtered_dataset = dataset.filter(
             filter_fn,

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -247,16 +247,10 @@ class PreferenceDatasetProcessor(DatasetProcessor):
 
     def filter(self, dataset: Union[Dataset, DatasetDict]):
         def filter_fn(row):
-            prompt_length_ok = True
-            if self.config.max_prompt_token_length is not None:
-                prompt_length_ok = len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
-            token_length_ok = True
-            if self.config.max_token_length is not None:
-                token_length_ok = (
-                    len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
-                    and len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length
-                )
-            return prompt_length_ok and token_length_ok
+            prompt_ok = len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length if self.config.max_prompt_token_length is not None else True
+            chosen_ok = len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length if self.config.max_token_length is not None else True
+            rejected_ok = len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length if self.config.max_token_length is not None else True
+            return prompt_ok and chosen_ok and rejected_ok
 
         filtered_dataset = dataset.filter(
             filter_fn,


### PR DESCRIPTION
Bug: prompt length check and sequence length checks were mutually exclusive. Root cause: when max_prompt_token_length and max_token_length were both defined, only the prompt length was validated. Fix: evaluated them independently with a flat AND condition so all constraints apply.