### PR TITLE
Fix validate_choice to be case-insensitive and use word boundaries

### DIFF
--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -360,7 +360,7 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
-    return any(text in option for option in options)
+    return any(re.search(r"\b" + re.escape(option.lower()) + r"\b", text.lower()) for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted

--- a/scripts/eval_constraints/if_functions.py
+++ b/scripts/eval_constraints/if_functions.py
@@ -368,10 +368,7 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
-    for option in options:
-        if text in option:
-            return True
-    return False
+    return any(re.search(r"\b" + re.escape(option.lower()) + r"\b", text.lower()) for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted


### PR DESCRIPTION
Bug: `validate_choice` checks if the output text is inside the option instead of vice-versa, and it can cause false positives (e.g. matching 'A' in 'Apple') or false negatives due to case differences.
Root cause: The function used a simple `text in option` substring match instead of checking for word boundaries.
Why fix is correct: Replaces the simple `in` operator with a case-insensitive regex search using word boundaries (`\b`) on the options, ensuring accurate validation of model outputs.