### PR TITLE
Fix PreferenceDatasetProcessor filter length checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.
 - Replace olmo-core's `save_hf_model` path with a direct `convert_state_to_hf` + HF `save_pretrained` flow; verify HF export works at startup in `dpo.py`/`grpo.py` (https://github.com/allenai/open-instruct/pull/1671).
 
 ### Fixed
+- Fix `PreferenceDatasetProcessor.filter` applying prompt and sequence length checks independently so both `max_prompt_token_length` and `max_token_length` are enforced together.
 - Pass packed-sequence `doc_lens`/`max_doc_lens` to OLMo-core models in `forward_for_logprobs` (instead of relying on `attention_mask`), so OLMo-core GRPO uses correct intra-document attention; bumps olmo-core to a commit that accepts these kwargs (https://github.com/allenai/open-instruct/pull/1670).
 - Fix gpt-4o / gpt-4o-standard output pricing (was 10× too low) and restate `open_instruct/judge_utils.py` rates as dollars per 1M tokens (renamed `PRICE_PER_TOKEN` → `PRICE_PER_MILLION_TOKENS`); update the cost calculation in `open_instruct/ground_truth_utils.py` accordingly (supersedes #1618) (https://github.com/allenai/open-instruct/pull/1686).
 - Use processed vLLM logprobs in GRPO rollouts so sampled-token logprobs include sampling transforms like temperature (https://github.com/allenai/open-instruct/pull/1678).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ All notable changes to this project will be documented in this file.
 - Replace olmo-core's `save_hf_model` path with a direct `convert_state_to_hf` + HF `save_pretrained` flow; verify HF export works at startup in `dpo.py`/`grpo.py` (https://github.com/allenai/open-instruct/pull/1671).
 
 ### Fixed
-- Fix `PreferenceDatasetProcessor.filter` applying prompt and sequence length checks independently so both `max_prompt_token_length` and `max_token_length` are enforced together.
+- Fix `PreferenceDatasetProcessor.filter` applying prompt and sequence length checks independently so both `max_prompt_token_length` and `max_token_length` are enforced together (https://github.com/allenai/open-instruct/pull/1710).
 - Pass packed-sequence `doc_lens`/`max_doc_lens` to OLMo-core models in `forward_for_logprobs` (instead of relying on `attention_mask`), so OLMo-core GRPO uses correct intra-document attention; bumps olmo-core to a commit that accepts these kwargs (https://github.com/allenai/open-instruct/pull/1670).
 - Fix gpt-4o / gpt-4o-standard output pricing (was 10× too low) and restate `open_instruct/judge_utils.py` rates as dollars per 1M tokens (renamed `PRICE_PER_TOKEN` → `PRICE_PER_MILLION_TOKENS`); update the cost calculation in `open_instruct/ground_truth_utils.py` accordingly (supersedes #1618) (https://github.com/allenai/open-instruct/pull/1686).
 - Use processed vLLM logprobs in GRPO rollouts so sampled-token logprobs include sampling transforms like temperature (https://github.com/allenai/open-instruct/pull/1678).

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -247,16 +247,10 @@ class PreferenceDatasetProcessor(DatasetProcessor):
 
     def filter(self, dataset: Union[Dataset, DatasetDict]):
         def filter_fn(row):
-            return (
-                len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
-                if self.config.max_prompt_token_length is not None
-                else (
-                    len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
-                    and len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length
-                    if self.config.max_token_length is not None
-                    else True
-                )
-            )
+            prompt_ok = len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length if self.config.max_prompt_token_length is not None else True
+            chosen_ok = len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length if self.config.max_token_length is not None else True
+            rejected_ok = len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length if self.config.max_token_length is not None else True
+            return prompt_ok and chosen_ok and rejected_ok
 
         filtered_dataset = dataset.filter(
             filter_fn,


### PR DESCRIPTION
## Bug
When both `max_prompt_token_length` and `max_token_length` are set, `PreferenceDatasetProcessor.filter` only checks prompt length and skips chosen/rejected length limits.

## Root cause
The nested ternary makes prompt and sequence checks mutually exclusive instead of applying all configured limits.

## Why this fix is correct
Evaluate each limit independently and combine with AND, matching the pattern already used by `SFTDatasetProcessor.filter`.

Made with [Cursor](https://cursor.com)