### PR TITLE
Fix validate_choice false positives and operand order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 - Add deprecation warning to `finetune.py` pointing users to the OLMo-core SFT implementation (https://github.com/allenai/open-instruct/pull/1574).
 
 ### Fixed
+- Fix `validate_choice` false positives and operand order by using a case-insensitive regex search with word boundaries.
 - Fix hardcoded project version (https://github.com/allenai/open-instruct/pull/1636) by using setuptools scm's automatic versioning.
 - Fix CUDA illegal-memory-access in FSDP2 weight sync to vLLM by also unsharding the root FSDPModule (root-level params like model.norm and lm_head were producing local-shard buffers with global stride) (https://github.com/allenai/open-instruct/pull/1649).
 - Fix weight sync on resume by initializing vLLM weight sync before the training loop and warming up the learner with a dummy forward so DeepSpeed Stage 3 params materialize before the first broadcast; accept IPC `update_info` dict in `LLMRayActor.update_weights`; replace toothless weight-sync tests with a real divergent-weight broadcast test (https://github.com/allenai/open-instruct/pull/1627).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -360,7 +360,7 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
-    return any(text in option for option in options)
+    return any(re.search(r"\b" + re.escape(option.lower()) + r"\b", text.lower()) for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted

--- a/scripts/eval_constraints/if_functions.py
+++ b/scripts/eval_constraints/if_functions.py
@@ -368,10 +368,7 @@ def validate_title(text: str) -> bool:
 
 # Choose: From Answer with one of the following options: {options}
 def validate_choice(text: str, options: list) -> bool:
-    for option in options:
-        if text in option:
-            return True
-    return False
+    return any(re.search(r"\b" + re.escape(option.lower()) + r"\b", text.lower()) for option in options)
 
 
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted


### PR DESCRIPTION
Bug: The `validate_choice` function incorrectly checks if the text is in the option rather than if the option is in the text, and is case-sensitive, leading to false negatives on capitalization differences and false positives on substring matches.
Root Cause: The `in` operator was used with operands reversed (`text in option`), and no casing transformations or word boundary constraints were applied.
Why fix is correct: Using a case-insensitive regex search with word boundaries (`\b`) accurately checks if any option exists as a distinct word within the generated text, matching the expected behavior of the constraint.