### PR TITLE
feat: add MiniMax-M3 to judge price table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 
+### Added
+- Add `minimax-m3` to `PRICE_PER_MILLION_TOKENS` in `open_instruct/judge_utils.py` for cost tracking on the latest MiniMax flagship model.
+
 ### Changed
 - Expand type-checking coverage by replacing `# ty: ignore` directives with typed casts and fixing related type issues (https://github.com/allenai/open-instruct/pull/1688).
 - Add TV divergence rho filtering for GRPO (https://github.com/allenai/open-instruct/pull/1681).

--- a/open_instruct/judge_utils.py
+++ b/open_instruct/judge_utils.py
@@ -21,6 +21,7 @@ PRICE_PER_MILLION_TOKENS = {
     "deepseek-chat": {"input": 0.07, "output": 1.0},
     "deepseek-reasoner": {"input": 0.14, "output": 2.0},
     "claude-3-7-sonnet-20250219": {"input": 3.0, "output": 15.0},
+    "minimax-m3": {"input": 0.6, "output": 2.4},
     "minimax-m2.7": {"input": 0.3, "output": 1.2},
     "minimax-m2.7-highspeed": {"input": 0.6, "output": 2.4},
 }


### PR DESCRIPTION
## Summary
Register the latest MiniMax flagship model (`MiniMax-M3`) in the judge pricing table so cost tracking in `open_instruct/ground_truth_utils.py` continues to work when M3 is used as a judge model.

## Changes
- `open_instruct/judge_utils.py`: add `"minimax-m3": {"input": 0.6, "output": 2.4}` to `PRICE_PER_MILLION_TOKENS`, placed before the existing M2.7 entries.
- `CHANGELOG.md`: add an entry under `### Added`.

## Why
MiniMax recently published M3 as its new flagship chat model. Adding it here keeps M3 calls from silently being priced at `$0` in the cost computation, while leaving the existing `minimax-m2.7` and `minimax-m2.7-highspeed` entries unchanged for backwards compatibility. The substring check in `context_window_checker.get_encoding_for_model` (`"minimax" in model_name_lower`) already routes M3 to the `cl100k_base` encoding without further changes.

## Testing
- `uv run ruff format --check open_instruct/judge_utils.py` -> file already formatted
- `uv run ruff check open_instruct/judge_utils.py` -> all checks passed
- The change is data-only (one new dict entry), no behavior change for callers that don't reference M3.

GPU_TESTS=bypass