### PR TITLE
Fix `detect_attn_implementation` for `flash-attn-2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Replace olmo-core's `save_hf_model` path with a direct `convert_state_to_hf` + HF `save_pretrained` flow; verify HF export works at startup in `dpo.py`/`grpo.py` (https://github.com/allenai/open-instruct/pull/1671).
 
 ### Fixed
+- Fix `detect_attn_implementation` for `flash-attn-2`. (https://github.com/allenai/open-instruct/pull/1716).
 - Pass packed-sequence `doc_lens`/`max_doc_lens` to OLMo-core models in `forward_for_logprobs` (instead of relying on `attention_mask`), so OLMo-core GRPO uses correct intra-document attention; bumps olmo-core to a commit that accepts these kwargs (https://github.com/allenai/open-instruct/pull/1670).
 - Fix gpt-4o / gpt-4o-standard output pricing (was 10× too low) and restate `open_instruct/judge_utils.py` rates as dollars per 1M tokens (renamed `PRICE_PER_TOKEN` → `PRICE_PER_MILLION_TOKENS`); update the cost calculation in `open_instruct/ground_truth_utils.py` accordingly (supersedes #1618) (https://github.com/allenai/open-instruct/pull/1686).
 - Use processed vLLM logprobs in GRPO rollouts so sampled-token logprobs include sampling transforms like temperature (https://github.com/allenai/open-instruct/pull/1678).

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -16,7 +16,6 @@
 
 import asyncio
 import functools
-import importlib.util
 import itertools
 import pathlib
 import tempfile

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -65,10 +65,6 @@ def detect_hf_attn_implementation() -> str:
     return olmo_core_attn_to_hf(detect_attn_implementation())
 
 
-def _is_flash_attn_4_available() -> bool:
-    return importlib.util.find_spec("flash_attn.cute") is not None
-
-
 @functools.lru_cache(maxsize=1)
 def _gpu_compute_major() -> int | None:
     """Return the CUDA compute capability major version (e.g. 9=Hopper, 10=Blackwell)."""
@@ -82,7 +78,7 @@ def _gpu_compute_major() -> int | None:
 def detect_attn_implementation() -> AttentionBackendName:
     if not torch.cuda.is_available():
         result = AttentionBackendName.torch
-    elif _is_flash_attn_4_available() and _gpu_compute_major() >= 10:
+    elif transformers.utils.is_flash_attn_4_available() and _gpu_compute_major() >= 10:
         result = AttentionBackendName.flash_4
     elif transformers.utils.is_flash_attn_3_available() and _gpu_compute_major() >= 9:
         result = AttentionBackendName.flash_3


### PR DESCRIPTION
`detect_attn_implementation` incorrectly detects `flash-attn-4` as available even when only `flash-attn-2` is installed since the latter still distributes the cute subdirectory (see https://github.com/huggingface/transformers/blob/main/src/transformers/utils/import_utils.py#L1017-L1026)

This PR replaces the internal helper `_is_flash_attention_4_available` with its correct upstream version from transformers.