### PR TITLE
Fix IFEvalG word-counting checkers to ignore punctuation

### DIFF
--- a/open_instruct/IFEvalG/instructions.py
+++ b/open_instruct/IFEvalG/instructions.py
@@ -2389,13 +2389,16 @@ class CountingCompositionChecker(Instruction):
         Returns:
           True if the response meets the requirements; otherwise, False.
         """
-        paragraphs = re.split(r"\s?\*\*\*\s?", value)
+        # Split on the "* * *" divider this instruction specifies (asterisks
+        # separated by spaces).
+        paragraphs = re.split(r"\s?\* \* \*\s?", value)
         num_paragraphs = len(paragraphs)
 
         for index, paragraph in enumerate(paragraphs):
             if not paragraph.strip():
                 if index == 0 or index == len(paragraphs) - 1:
                     num_paragraphs -= 1
+                    continue
                 else:
                     return False
 
@@ -2406,8 +2409,9 @@ class CountingCompositionChecker(Instruction):
                 return False
 
             for sentence in sentences:
-                words = instructions_util.nltk.word_tokenize(sentence)
-                num_words = len(words)
+                # split_into_sentences keeps each sentence's terminal ".", which
+                # must not count toward the n_words total.
+                num_words = len(instructions_util.word_tokens(sentence))
 
                 if num_words != self._n_words:
                     return False
@@ -2432,7 +2436,9 @@ class CountUniqueChecker(Instruction):
 
     def check_following(self, value):
         """Checks that the response contains unique words."""
-        words = instructions_util.nltk.word_tokenize(value)
+        # Compare words only; pure-punctuation tokens (".", ",") must not count as
+        # repeated words.
+        words = instructions_util.word_tokens(value)
         unique_words = set(words)
         return len(words) == len(unique_words)
 

--- a/open_instruct/IFEvalG/instructions_util.py
+++ b/open_instruct/IFEvalG/instructions_util.py
@@ -1648,6 +1648,17 @@ def count_words(text):
     return num_words
 
 
+def word_tokens(text):
+    """Return the word tokens in ``text``, excluding pure-punctuation tokens.
+
+    Tokenizes with ``nltk.word_tokenize`` (so non-Latin scripts tokenize correctly)
+    and keeps only tokens containing at least one alphanumeric character. Use this
+    for word counts and word de-duplication, where standalone punctuation tokens
+    (".", ",", ...) should not be treated as words.
+    """
+    return [tok for tok in nltk.word_tokenize(text) if any(ch.isalnum() for ch in tok)]
+
+
 @functools.cache
 def _get_sentence_tokenizer():
     return nltk.data.load("nltk:tokenizers/punkt/english.pickle")

--- a/open_instruct/test_ground_truth_utils.py
+++ b/open_instruct/test_ground_truth_utils.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 from parameterized import parameterized
 
 from open_instruct import ground_truth_utils
+from open_instruct.IFEvalG import instructions_registry
 from open_instruct.ground_truth_utils import (
     F1Verifier,
     GSM8KVerifier,
@@ -239,6 +240,64 @@ class TestIFEvalVerifierEmptyInstructions(unittest.TestCase):
         label = str([{"instruction_id": [], "kwargs": []}])
         result = verifier(tokenized_prediction=[1, 2, 3], prediction="some non-empty response", label=label)
         self.assertEqual(result.score, 0.0)
+
+
+class TestIFEvalGWordCounting(unittest.TestCase):
+    """Regression tests: `count:counting_composition` and `count:count_unique` used
+    nltk.word_tokenize, which emits punctuation (".", ",") as standalone tokens. That
+    made "exactly N words per sentence" off by one and any multi-sentence response look
+    like it had duplicate words. The checkers now count only word tokens (instructions_util.word_tokens)."""
+
+    def setUp(self):
+        self.cc = instructions_registry.INSTRUCTION_DICT["count:counting_composition"]("count:counting_composition")
+        self.cu = instructions_registry.INSTRUCTION_DICT["count:count_unique"]("count:count_unique")
+
+    def test_counting_composition_compliant_with_spaced_divider(self):
+        # 3 paragraphs, 3 sentences each, 2 words each, using the "* * *" divider the prompt asks for.
+        self.cc.build_description(n_sent=3, n_words=2)
+        response = (
+            "Cats run. Dogs jump. Birds fly.\n\n* * *\n\n"
+            "Fish swim. Foxes leap. Owls hoot.\n\n* * *\n\n"
+            "Apes climb. Bats hang. Eels glide."
+        )
+        self.assertTrue(self.cc.check_following(response))
+
+    def test_counting_composition_rejects_spaceless_divider(self):
+        # The instruction specifies the "* * *" divider; a "***" response does not follow it.
+        self.cc.build_description(n_sent=3, n_words=2)
+        response = (
+            "Cats run. Dogs jump. Birds fly.\n\n***\n\n"
+            "Fish swim. Foxes leap. Owls hoot.\n\n***\n\n"
+            "Apes climb. Bats hang. Eels glide."
+        )
+        self.assertFalse(self.cc.check_following(response))
+
+    def test_counting_composition_rejects_wrong_word_count(self):
+        self.cc.build_description(n_sent=3, n_words=2)
+        response = (
+            "Cats run fast. Dogs jump. Birds fly.\n\n* * *\n\n"  # first sentence has 3 words
+            "Fish swim. Foxes leap. Owls hoot.\n\n* * *\n\n"
+            "Apes climb. Bats hang. Eels glide."
+        )
+        self.assertFalse(self.cc.check_following(response))
+
+    def test_count_unique_allows_unique_multi_sentence(self):
+        self.cu.build_description()
+        self.assertTrue(self.cu.check_following("Alpha beta gamma. Delta epsilon zeta."))
+
+    def test_count_unique_rejects_repeated_word(self):
+        self.cu.build_description()
+        self.assertFalse(self.cu.check_following("The sun is hot. The moon is cold."))  # "The"/"is" repeat
+
+    def test_count_unique_via_ifeval_verifier(self):
+        verifier = ground_truth_utils.IFEvalVerifier()
+        label = str([{"instruction_id": ["count:count_unique"], "kwargs": [None]}])
+        result = verifier(
+            tokenized_prediction=[1, 2, 3],
+            prediction="Alpha beta gamma. Delta epsilon zeta.",
+            label=label,
+        )
+        self.assertEqual(result.score, 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`count:counting_composition` and `count:count_unique` count words with `nltk.word_tokenize`, which emits punctuation (`.`, `,`, `:`) as standalone tokens. As a result a correctly-formed response scores 0:

- **`counting_composition`** — `split_into_sentences` keeps each sentence's terminal `.`, so `word_tokenize("Cats run.")` → `["Cats", "run", "."]` (length 3). "exactly N words per sentence" is therefore off by one and a compliant sentence can never pass. Separately, the paragraph-split regex matched `***`, while this instruction specifies the spaced `* * *` divider — so a response that used the divider exactly as instructed was never split into paragraphs. In the `IF_multi_constraints_upto5` train set ~97% of responses for this constraint use `* * *`. Either defect alone drives this checker to ~100% false rejection.
- **`count_unique`** — a multi-sentence response repeats the `.` (and `,`) tokens, so `len(words) == len(set(words))` is `False` regardless of the actual words used. Any response longer than one sentence fails.

These are the RLVR reward functions for these constraints, so the false negatives directly penalize compliant generations. Because a broken-but-non-crashing reward just looks like "a very hard constraint" when averaged across many constraints, it isn't obvious from inside training — it only shows up when you check pass rates against known-compliant text.

## Fix

Add `instructions_util.word_tokens(text)`, which tokenizes with `word_tokenize` (so non-Latin scripts tokenize correctly) but keeps only tokens containing at least one alphanumeric character. Both checkers use it for counting / de-duplication. `counting_composition` also splits on the `* * *` divider the instruction actually specifies and skips empty leading/trailing segments.

I used this surgical punctuation-drop rather than switching to a `\w+` tokenizer on purpose: a plain `\w+` tokenizer regresses non-Latin scripts (e.g. it mis-splits Tamil), whereas dropping punctuation tokens from `word_tokenize` preserves the existing tokenization for real words.

## Tests

Adds `TestIFEvalGWordCounting` in `open_instruct/test_ground_truth_utils.py` covering: compliant `* * *` divider, rejection of the non-instructed `***` divider, rejection of a wrong word count, unique vs. repeated-word `count_unique`, and an end-to-end `IFEvalVerifier` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
