### PR TITLE
Some `code_utils` cleanup; deflake a test and add type-checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ All notable changes to this project will be documented in this file.
 - Replace olmo-core's `save_hf_model` path with a direct `convert_state_to_hf` + HF `save_pretrained` flow; verify HF export works at startup in `dpo.py`/`grpo.py` (https://github.com/allenai/open-instruct/pull/1671).
 
 ### Fixed
+- Fix flaky `open_instruct/code_utils/test_api.py` server startup by using per-instance free ports, failing fast on uvicorn exits, and surfacing subprocess output in startup errors (https://github.com/allenai/open-instruct/pull/1721).
 - Fix `detect_attn_implementation` for `flash-attn-2`. (https://github.com/allenai/open-instruct/pull/1716).
 - Pass packed-sequence `doc_lens`/`max_doc_lens` to OLMo-core models in `forward_for_logprobs` (instead of relying on `attention_mask`), so OLMo-core GRPO uses correct intra-document attention; bumps olmo-core to a commit that accepts these kwargs (https://github.com/allenai/open-instruct/pull/1670).
 - Fix gpt-4o / gpt-4o-standard output pricing (was 10× too low) and restate `open_instruct/judge_utils.py` rates as dollars per 1M tokens (renamed `PRICE_PER_TOKEN` → `PRICE_PER_MILLION_TOKENS`); update the cost calculation in `open_instruct/ground_truth_utils.py` accordingly (supersedes #1618) (https://github.com/allenai/open-instruct/pull/1686).

--- a/open_instruct/code_utils/code_utils.py
+++ b/open_instruct/code_utils/code_utils.py
@@ -339,8 +339,8 @@ def reliability_guard(maximum_memory_bytes: int | None = None):
 
     import builtins  # noqa: PLC0415
 
-    builtins.exit = None
-    builtins.quit = None
+    for name in ("exit", "quit"):
+        setattr(builtins, name, None)
     # builtins.open = None
     # builtins.print = lambda *args, **kwargs: None
 
@@ -350,43 +350,43 @@ def reliability_guard(maximum_memory_bytes: int | None = None):
 
     # os.environ["OMP_NUM_THREADS"] = "1"
     # os.kill = None
-    os.system = None
-    os.putenv = None
-    os.remove = None
-    os.removedirs = None
-    os.rmdir = None
-    os.fchdir = None
-    os.setuid = None
+    for name in (
+        "system",
+        "putenv",
+        "remove",
+        "removedirs",
+        "rmdir",
+        "fchdir",
+        "setuid",
+        # "fork",
+        "forkpty",
+        "killpg",
+        "rename",
+        "renames",
+        "truncate",
+        "replace",
+        "unlink",
+        "fchmod",
+        "fchown",
+        "chmod",
+        "chown",
+        "chroot",
+        "lchflags",
+        "lchmod",
+        "lchown",
+        "getcwd",
+        "chdir",
+    ):
+        setattr(os, name, None)
+
     # os.fork = None
-    os.forkpty = None
-    os.killpg = None
-    os.rename = None
-    os.renames = None
-    os.truncate = None
-    os.replace = None
-    os.unlink = None
-    os.fchmod = None
-    os.fchown = None
-    os.chmod = None
-    os.chown = None
-    os.chroot = None
-    os.fchdir = None
-    os.lchflags = None
-    os.lchmod = None
-    os.lchown = None
-    os.getcwd = None
-    os.chdir = None
 
-    shutil.rmtree = None
-    shutil.move = None
-    shutil.chown = None
+    for name in ("rmtree", "move", "chown"):
+        setattr(shutil, name, None)
 
-    subprocess.Popen = None  # type: ignore
+    subprocess.Popen = None  # type: ignore[invalid-assignment]
 
     # __builtins__['help'] = None
 
-    sys.modules["ipdb"] = None
-    sys.modules["joblib"] = None
-    sys.modules["resource"] = None
-    sys.modules["psutil"] = None
-    sys.modules["tkinter"] = None
+    for name in ("ipdb", "joblib", "resource", "psutil", "tkinter"):
+        sys.modules[name] = None  # type: ignore[invalid-assignment]

--- a/open_instruct/code_utils/test_api.py
+++ b/open_instruct/code_utils/test_api.py
@@ -1,27 +1,28 @@
 """Integration test for the /test_program endpoint."""
 
 import subprocess
+import time
 import unittest
 
-import backoff
 import requests
 
 from open_instruct import logger_utils, utils
 
 logger = logger_utils.setup_logger(__name__)
-STARTUP_TIMEOUT_S = 30
 
 
 class APITestServer:
     """Manages starting and stopping the API server for testing."""
 
     def __init__(self) -> None:
+        self.host = "127.0.0.1"
         self.port = utils.find_free_port()
-        self.base_url = f"http://localhost:{self.port}"
+        self.startup_timeout = 30
+        self.base_url = f"http://{self.host}:{self.port}"
         self.health_url = f"{self.base_url}/health"
-        self.process: subprocess.Popen[str] | None = None
+        self.process = None
 
-    def is_running(self) -> bool:
+    def is_running(self):
         """Check if the server is already running."""
         try:
             response = requests.get(self.health_url, timeout=1)
@@ -29,19 +30,11 @@ class APITestServer:
         except requests.exceptions.RequestException:
             return False
 
-    @backoff.on_predicate(backoff.constant, interval=0.5, max_time=STARTUP_TIMEOUT_S, jitter=None)
-    def _wait_until_startup_complete(self) -> bool:
-        return self.is_running() or bool(self.process and self.process.poll() is not None)
-
-    @backoff.on_predicate(backoff.constant, interval=0.5, max_time=10, jitter=None)
-    def _wait_for_exit(self) -> bool:
-        return bool(self.process and self.process.poll() is not None)
-
-    def start(self) -> None:
+    def start(self):
         """Start the server if it's not already running."""
         if self.is_running():
             logger.info("Server already running, using existing instance")
-            return
+            return True
 
         logger.info("Starting API server...")
         self.process = subprocess.Popen(
@@ -51,44 +44,46 @@ class APITestServer:
                 "uvicorn",
                 "open_instruct.code_utils.api:app",
                 "--host",
-                "0.0.0.0",
+                self.host,
                 "--port",
                 str(self.port),
             ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+            stderr=subprocess.PIPE,
         )
 
-        self._wait_until_startup_complete()
-        if self.is_running():
-            logger.info("Server started successfully")
-            return
+        # Wait for server to start
+        for _ in range(self.startup_timeout):
+            if self.is_running():
+                logger.info("Server started successfully")
+                return True
+            time.sleep(1)
 
-        process_exited = bool(self.process and self.process.poll() is not None)
-        output = self.stop()
-        if process_exited:
-            raise RuntimeError(f"API server exited before startup completed:\n{output}")
-        raise RuntimeError(f"Failed to start server within {STARTUP_TIMEOUT_S} seconds:\n{output}")
+        # Server failed to start
+        if self.process:
+            self.process.terminate()
+            self.process = None
+        raise RuntimeError(f"Failed to start server within {self.startup_timeout} seconds")
 
-    def stop(self) -> str:
+    def stop(self):
         """Stop the server if we started it."""
-        if not self.process:
-            return ""
+        if self.process:
+            logger.info("Stopping API server...")
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait()
+            self.process = None
 
-        self.process.terminate()
-        self._wait_for_exit()
-        if self.process.poll() is None:
-            self.process.kill()
-        output = self.process.communicate()[0]
-        self.process = None
-        return output
-
-    def __enter__(self) -> "APITestServer":
+    def __enter__(self):
+        """Enter the context manager."""
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Exit the context manager."""
         self.stop()
         return False
 

--- a/open_instruct/code_utils/test_api.py
+++ b/open_instruct/code_utils/test_api.py
@@ -1,9 +1,9 @@
 """Integration test for the /test_program endpoint."""
 
 import subprocess
-import time
 import unittest
 
+import backoff
 import requests
 
 from open_instruct import logger_utils, utils
@@ -29,6 +29,27 @@ class APITestServer:
         except requests.exceptions.RequestException:
             return False
 
+    @backoff.on_predicate(backoff.constant, interval=0.5, max_time=STARTUP_TIMEOUT_S, jitter=None)
+    def _wait_until_startup_complete(self) -> bool:
+        return self.is_running() or bool(self.process and self.process.poll() is not None)
+
+    def _stop_process(self) -> str:
+        if not self.process:
+            return ""
+
+        process = self.process
+        if process.poll() is None:
+            process.terminate()
+            try:
+                output = process.communicate(timeout=10)[0]
+            except subprocess.TimeoutExpired:
+                process.kill()
+                output = process.communicate()[0]
+        else:
+            output = process.communicate()[0]
+        self.process = None
+        return output
+
     def start(self) -> bool:
         """Start the server if it's not already running."""
         if self.is_running():
@@ -52,41 +73,22 @@ class APITestServer:
             text=True,
         )
 
-        # Wait for server to start
-        deadline = time.monotonic() + STARTUP_TIMEOUT_S
-        while time.monotonic() < deadline:
-            if self.is_running():
-                logger.info("Server started successfully")
-                return True
-            if self.process.poll() is not None:
-                output = self.process.communicate()[0]
-                self.process = None
-                raise RuntimeError(f"API server exited before startup completed:\n{output}")
-            time.sleep(0.5)
+        startup_complete = self._wait_until_startup_complete()
+        if startup_complete and self.is_running():
+            logger.info("Server started successfully")
+            return True
 
-        # Server failed to start
-        output = ""
-        if self.process:
-            self.process.terminate()
-            try:
-                output = self.process.communicate(timeout=10)[0]
-            except subprocess.TimeoutExpired:
-                self.process.kill()
-                output = self.process.communicate()[0]
-            self.process = None
+        process_exited = bool(self.process and self.process.poll() is not None)
+        output = self._stop_process()
+        if process_exited:
+            raise RuntimeError(f"API server exited before startup completed:\n{output}")
         raise RuntimeError(f"Failed to start server within {STARTUP_TIMEOUT_S} seconds:\n{output}")
 
     def stop(self) -> None:
         """Stop the server if we started it."""
         if self.process:
             logger.info("Stopping API server...")
-            self.process.terminate()
-            try:
-                self.process.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                self.process.kill()
-                self.process.wait()
-            self.process = None
+            self._stop_process()
 
     def __enter__(self) -> "APITestServer":
         """Enter the context manager."""

--- a/open_instruct/code_utils/test_api.py
+++ b/open_instruct/code_utils/test_api.py
@@ -1,7 +1,9 @@
 """Integration test for the /test_program endpoint."""
 
+import contextlib
 import subprocess
 import unittest
+from collections.abc import Iterator
 
 import backoff
 import requests
@@ -13,7 +15,7 @@ STARTUP_TIMEOUT_S = 30
 
 
 class APITestServer:
-    """Manages starting and stopping the API server for testing."""
+    """Stores API server state for testing."""
 
     def __init__(self) -> None:
         self.port = utils.find_free_port()
@@ -50,14 +52,20 @@ class APITestServer:
         self.process = None
         return output
 
-    def start(self) -> bool:
-        """Start the server if it's not already running."""
-        if self.is_running():
+
+@contextlib.contextmanager
+def api_test_server() -> Iterator[APITestServer]:
+    """Start and stop the API server for testing."""
+    server = APITestServer()
+
+    try:
+        if server.is_running():
             logger.info("Server already running, using existing instance")
-            return True
+            yield server
+            return
 
         logger.info("Starting API server...")
-        self.process = subprocess.Popen(
+        server.process = subprocess.Popen(
             [
                 "uv",
                 "run",
@@ -66,45 +74,34 @@ class APITestServer:
                 "--host",
                 "0.0.0.0",
                 "--port",
-                str(self.port),
+                str(server.port),
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
         )
 
-        startup_complete = self._wait_until_startup_complete()
-        if startup_complete and self.is_running():
+        startup_complete = server._wait_until_startup_complete()
+        if startup_complete and server.is_running():
             logger.info("Server started successfully")
-            return True
+            yield server
+            return
 
-        process_exited = bool(self.process and self.process.poll() is not None)
-        output = self._stop_process()
+        process_exited = bool(server.process and server.process.poll() is not None)
+        output = server._stop_process()
         if process_exited:
             raise RuntimeError(f"API server exited before startup completed:\n{output}")
         raise RuntimeError(f"Failed to start server within {STARTUP_TIMEOUT_S} seconds:\n{output}")
-
-    def stop(self) -> None:
-        """Stop the server if we started it."""
-        if self.process:
+    finally:
+        if server.process:
             logger.info("Stopping API server...")
-            self._stop_process()
-
-    def __enter__(self) -> "APITestServer":
-        """Enter the context manager."""
-        self.start()
-        return self
-
-    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> bool:
-        """Exit the context manager."""
-        self.stop()
-        return False
+            server._stop_process()
 
 
 class TestAPI(unittest.TestCase):
     def test_add_program_results(self):
         """POST to the endpoint and verify JSON response structure & content."""
-        with APITestServer() as server:
+        with api_test_server() as server:
             payload = {
                 "program": ("def add(a, b):\n    return a + b\n"),
                 "tests": [
@@ -128,7 +125,7 @@ class TestAPI(unittest.TestCase):
 
     def test_multiple_calls_to_test_program(self, num_requests=3):
         """Test making multiple calls to /test_program endpoint."""
-        with APITestServer() as server:
+        with api_test_server() as server:
             # Use the same payload for all requests
             test_payload = {
                 "program": "def multiply(a, b):\n    return a * b",
@@ -146,7 +143,7 @@ class TestAPI(unittest.TestCase):
 
     def test_multiple_calls_to_test_program_stdio(self, num_requests=3):
         """Test making multiple calls to /test_program_stdio endpoint."""
-        with APITestServer() as server:
+        with api_test_server() as server:
             # Use the same payload for all requests
             stdio_payload = {
                 "program": "a, b = map(int, input().split())\nprint(a + b)",
@@ -175,7 +172,7 @@ class TestAPI(unittest.TestCase):
 
 class TestAPITestServer(unittest.TestCase):
     def test_health_check_with_context_manager(self):
-        with APITestServer() as server:
+        with api_test_server() as server:
             response = requests.get(server.health_url, timeout=5)
             self.assertEqual(response.status_code, 200)
 

--- a/open_instruct/code_utils/test_api.py
+++ b/open_instruct/code_utils/test_api.py
@@ -6,23 +6,22 @@ import unittest
 
 import requests
 
-from open_instruct import logger_utils
+from open_instruct import logger_utils, utils
 
 logger = logger_utils.setup_logger(__name__)
+STARTUP_TIMEOUT_S = 30
 
 
 class APITestServer:
     """Manages starting and stopping the API server for testing."""
 
-    def __init__(self, host="0.0.0.0", port=1234, startup_timeout=30):
-        self.host = host
-        self.port = port
-        self.startup_timeout = startup_timeout
-        self.base_url = f"http://localhost:{port}"
+    def __init__(self) -> None:
+        self.port = utils.find_free_port()
+        self.base_url = f"http://localhost:{self.port}"
         self.health_url = f"{self.base_url}/health"
-        self.process = None
+        self.process: subprocess.Popen[str] | None = None
 
-    def is_running(self):
+    def is_running(self) -> bool:
         """Check if the server is already running."""
         try:
             response = requests.get(self.health_url, timeout=1)
@@ -30,7 +29,7 @@ class APITestServer:
         except requests.exceptions.RequestException:
             return False
 
-    def start(self):
+    def start(self) -> bool:
         """Start the server if it's not already running."""
         if self.is_running():
             logger.info("Server already running, using existing instance")
@@ -44,28 +43,40 @@ class APITestServer:
                 "uvicorn",
                 "open_instruct.code_utils.api:app",
                 "--host",
-                self.host,
+                "0.0.0.0",
                 "--port",
                 str(self.port),
             ],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
         )
 
         # Wait for server to start
-        for _ in range(self.startup_timeout):
+        deadline = time.monotonic() + STARTUP_TIMEOUT_S
+        while time.monotonic() < deadline:
             if self.is_running():
                 logger.info("Server started successfully")
                 return True
-            time.sleep(1)
+            if self.process.poll() is not None:
+                output = self.process.communicate()[0]
+                self.process = None
+                raise RuntimeError(f"API server exited before startup completed:\n{output}")
+            time.sleep(0.5)
 
         # Server failed to start
+        output = ""
         if self.process:
             self.process.terminate()
+            try:
+                output = self.process.communicate(timeout=10)[0]
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                output = self.process.communicate()[0]
             self.process = None
-        raise RuntimeError(f"Failed to start server within {self.startup_timeout} seconds")
+        raise RuntimeError(f"Failed to start server within {STARTUP_TIMEOUT_S} seconds:\n{output}")
 
-    def stop(self):
+    def stop(self) -> None:
         """Stop the server if we started it."""
         if self.process:
             logger.info("Stopping API server...")
@@ -77,12 +88,12 @@ class APITestServer:
                 self.process.wait()
             self.process = None
 
-    def __enter__(self):
+    def __enter__(self) -> "APITestServer":
         """Enter the context manager."""
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> bool:
         """Exit the context manager."""
         self.stop()
         return False

--- a/open_instruct/code_utils/test_api.py
+++ b/open_instruct/code_utils/test_api.py
@@ -1,9 +1,7 @@
 """Integration test for the /test_program endpoint."""
 
-import contextlib
 import subprocess
 import unittest
-from collections.abc import Iterator
 
 import backoff
 import requests
@@ -15,7 +13,7 @@ STARTUP_TIMEOUT_S = 30
 
 
 class APITestServer:
-    """Stores API server state for testing."""
+    """Manages starting and stopping the API server for testing."""
 
     def __init__(self) -> None:
         self.port = utils.find_free_port()
@@ -35,37 +33,18 @@ class APITestServer:
     def _wait_until_startup_complete(self) -> bool:
         return self.is_running() or bool(self.process and self.process.poll() is not None)
 
-    def _stop_process(self) -> str:
-        if not self.process:
-            return ""
+    @backoff.on_predicate(backoff.constant, interval=0.5, max_time=10, jitter=None)
+    def _wait_for_exit(self) -> bool:
+        return bool(self.process and self.process.poll() is not None)
 
-        process = self.process
-        if process.poll() is None:
-            process.terminate()
-            try:
-                output = process.communicate(timeout=10)[0]
-            except subprocess.TimeoutExpired:
-                process.kill()
-                output = process.communicate()[0]
-        else:
-            output = process.communicate()[0]
-        self.process = None
-        return output
-
-
-@contextlib.contextmanager
-def api_test_server() -> Iterator[APITestServer]:
-    """Start and stop the API server for testing."""
-    server = APITestServer()
-
-    try:
-        if server.is_running():
+    def start(self) -> None:
+        """Start the server if it's not already running."""
+        if self.is_running():
             logger.info("Server already running, using existing instance")
-            yield server
             return
 
         logger.info("Starting API server...")
-        server.process = subprocess.Popen(
+        self.process = subprocess.Popen(
             [
                 "uv",
                 "run",
@@ -74,34 +53,50 @@ def api_test_server() -> Iterator[APITestServer]:
                 "--host",
                 "0.0.0.0",
                 "--port",
-                str(server.port),
+                str(self.port),
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
         )
 
-        startup_complete = server._wait_until_startup_complete()
-        if startup_complete and server.is_running():
+        self._wait_until_startup_complete()
+        if self.is_running():
             logger.info("Server started successfully")
-            yield server
             return
 
-        process_exited = bool(server.process and server.process.poll() is not None)
-        output = server._stop_process()
+        process_exited = bool(self.process and self.process.poll() is not None)
+        output = self.stop()
         if process_exited:
             raise RuntimeError(f"API server exited before startup completed:\n{output}")
         raise RuntimeError(f"Failed to start server within {STARTUP_TIMEOUT_S} seconds:\n{output}")
-    finally:
-        if server.process:
-            logger.info("Stopping API server...")
-            server._stop_process()
+
+    def stop(self) -> str:
+        """Stop the server if we started it."""
+        if not self.process:
+            return ""
+
+        self.process.terminate()
+        self._wait_for_exit()
+        if self.process.poll() is None:
+            self.process.kill()
+        output = self.process.communicate()[0]
+        self.process = None
+        return output
+
+    def __enter__(self) -> "APITestServer":
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        self.stop()
+        return False
 
 
 class TestAPI(unittest.TestCase):
     def test_add_program_results(self):
         """POST to the endpoint and verify JSON response structure & content."""
-        with api_test_server() as server:
+        with APITestServer() as server:
             payload = {
                 "program": ("def add(a, b):\n    return a + b\n"),
                 "tests": [
@@ -125,7 +120,7 @@ class TestAPI(unittest.TestCase):
 
     def test_multiple_calls_to_test_program(self, num_requests=3):
         """Test making multiple calls to /test_program endpoint."""
-        with api_test_server() as server:
+        with APITestServer() as server:
             # Use the same payload for all requests
             test_payload = {
                 "program": "def multiply(a, b):\n    return a * b",
@@ -143,7 +138,7 @@ class TestAPI(unittest.TestCase):
 
     def test_multiple_calls_to_test_program_stdio(self, num_requests=3):
         """Test making multiple calls to /test_program_stdio endpoint."""
-        with api_test_server() as server:
+        with APITestServer() as server:
             # Use the same payload for all requests
             stdio_payload = {
                 "program": "a, b = map(int, input().split())\nprint(a + b)",
@@ -172,7 +167,7 @@ class TestAPI(unittest.TestCase):
 
 class TestAPITestServer(unittest.TestCase):
     def test_health_check_with_context_manager(self):
-        with api_test_server() as server:
+        with APITestServer() as server:
             response = requests.get(server.health_url, timeout=5)
             self.assertEqual(response.status_code, 200)
 

--- a/open_instruct/code_utils/testing_util.py
+++ b/open_instruct/code_utils/testing_util.py
@@ -54,12 +54,15 @@ def timeout_handler(signum, frame):
 # used to capture stdout as a list
 # from https://stackoverflow.com/a/16571630/6416660
 # alternative use redirect_stdout() from contextlib
+class NonClosingStringIO(StringIO):
+    def close(self) -> None:
+        pass
+
+
 class Capturing(list):
     def __enter__(self):
         self._stdout = sys.stdout
-        sys.stdout = self._stringio = StringIO()
-        # Make closing the StringIO a no-op
-        self._stringio.close = lambda x: 1
+        sys.stdout = self._stringio = NonClosingStringIO()
         return self
 
     def __exit__(self, *args):
@@ -132,6 +135,7 @@ def make_function(code: str) -> str:
             body=all_other_stmts,
             decorator_list=[],
             lineno=-1,
+            type_params=[],
         )
         main_code = (
             import_string

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,7 +195,6 @@ exclude = [
     "scripts/",
     "decontamination/",
     "human_eval/",
-    "open_instruct/code_utils/",
     "open_instruct/test_*.py",
     "test_*.py",
     "open_instruct/IFEvalG/instructions.py",


### PR DESCRIPTION
Fixes a flaky API test server startup path in `open_instruct/code_utils/test_api.py`.

Also adds type annotations and adds the `code_utils/` dir to type checking. 