### PR TITLE
Change default temperature to 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- Change the default generation `temperature` to 1.0 and make `SamplingConfig.temperature` a required field so `StreamingConfig.temperature` is the single source of truth (https://github.com/allenai/open-instruct/pull/PR_NUMBER).
 - Refactor OLMo-core DPO metrics: reduce token-weighted metrics inline in `train_batch` with a single `all_reduce` over the DP group (matching `GRPOTrainModule`), align wandb keys with `dpo_tune_cache.py` (`train_loss`, `logps/*`, `rewards/*`, `perf/mfu_step`, `perf/tokens_per_second_step`/`_total`), add `train/padding_fraction`, `train/sequences_per_rank`, and `train/global_sequences_per_step` metrics, and make `get_num_sequences` always return an `int` (https://github.com/allenai/open-instruct/pull/1719).
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-- Change the default generation `temperature` to 1.0 and make `SamplingConfig.temperature` a required field so `StreamingConfig.temperature` is the single source of truth (https://github.com/allenai/open-instruct/pull/PR_NUMBER).
+- Change the default generation `temperature` to 1.0 and make `SamplingConfig.temperature` a required field so `StreamingConfig.temperature` is the single source of truth (https://github.com/allenai/open-instruct/pull/1725).
 - Refactor OLMo-core DPO metrics: reduce token-weighted metrics inline in `train_batch` with a single `all_reduce` over the DP group (matching `GRPOTrainModule`), align wandb keys with `dpo_tune_cache.py` (`train_loss`, `logps/*`, `rewards/*`, `perf/mfu_step`, `perf/tokens_per_second_step`/`_total`), add `train/padding_fraction`, `train/sequences_per_rank`, and `train/global_sequences_per_step` metrics, and make `get_num_sequences` always return an `int` (https://github.com/allenai/open-instruct/pull/1719).
 
 ### Deprecated

--- a/open_instruct/data_loader.py
+++ b/open_instruct/data_loader.py
@@ -436,7 +436,7 @@ class StreamingDataLoaderConfig:
     system_prompt_override_file: str | None = None
 
     # Generation
-    temperature: float = 0.7
+    temperature: float = 1.0
     stop_strings: list[str] | None = None
     inflight_updates: bool = True
     eval_response_length: int | None = None

--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -136,7 +136,7 @@ class WeightUpdateRPCArgs(TypedDict):
 
 @dataclasses.dataclass
 class SamplingConfig:
-    temperature: float = 0.7
+    temperature: float
     top_p: float = 1.0
     max_tokens: int = 256
     min_tokens: int = 0


### PR DESCRIPTION
## Summary

- Changes the default generation `temperature` from 0.7 to **1.0**.
- Consolidates to a single source of truth: `StreamingConfig.temperature` (in `data_loader.py`) is the canonical default. Both production call sites (`grpo_fast.py` and `benchmark_generators.py`) already pass `temperature=streaming_config.temperature` explicitly into `SamplingConfig`, so `SamplingConfig`'s own default was a redundant, never-relied-upon fallback.
- Makes `SamplingConfig.temperature` a required field (no default) so there is exactly one place defining the temperature default.

## Test plan

- `make style && make quality` pass.
- Verified every `SamplingConfig(...)` construction (production + tests) passes `temperature` explicitly, so the now-required field has no missing-argument call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)