### PR TITLE
Increase default environment pool acquire timeout to 7200s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- Increase default environment pool acquire timeout to 7200s (https://github.com/allenai/open-instruct/pull/1729).
 - Change the default generation `temperature` to 1.0 and make `SamplingConfig.temperature` a required field so `StreamingConfig.temperature` is the single source of truth (https://github.com/allenai/open-instruct/pull/1725).
 - Bump OLMo-core to the latest `main` commit (`9aa3280`) (https://github.com/allenai/open-instruct/pull/1723).
 - Refactor OLMo-core DPO metrics: reduce token-weighted metrics inline in `train_batch` with a single `all_reduce` over the DP group (matching `GRPOTrainModule`), align wandb keys with `dpo_tune_cache.py` (`train_loss`, `logps/*`, `rewards/*`, `perf/mfu_step`, `perf/tokens_per_second_step`/`_total`), add `train/padding_fraction`, `train/sequences_per_rank`, and `train/global_sequences_per_step` metrics, and make `get_num_sequences` always return an `int` (https://github.com/allenai/open-instruct/pull/1719).

--- a/open_instruct/environments/pool.py
+++ b/open_instruct/environments/pool.py
@@ -9,7 +9,7 @@ from open_instruct import logger_utils
 
 logger = logger_utils.setup_logger(__name__)
 
-DEFAULT_ACQUIRE_TIMEOUT_S = 600
+DEFAULT_ACQUIRE_TIMEOUT_S = 7200
 
 
 @ray.remote


### PR DESCRIPTION
## Summary
- Bump `DEFAULT_ACQUIRE_TIMEOUT_S` in the environment pool from 600s to 7200s so long-running sandbox rollouts don't spuriously time out while waiting to acquire an actor.

This helps for settings where rollouts are really long.

GPU_TESTS=bypass

Made with [Cursor](https://cursor.com)