### PR TITLE
Make ModelDims.from_hf_config robust to explicit head_dim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- Make ModelDims.from_hf_config robust to explicit head_dim (https://github.com/allenai/open-instruct/pull/1731).
 - Change the default generation `temperature` to 1.0 and make `SamplingConfig.temperature` a required field so `StreamingConfig.temperature` is the single source of truth (https://github.com/allenai/open-instruct/pull/1725).
 - Bump OLMo-core to the latest `main` commit (`9aa3280`) (https://github.com/allenai/open-instruct/pull/1723).
 - Refactor OLMo-core DPO metrics: reduce token-weighted metrics inline in `train_batch` with a single `all_reduce` over the DP group (matching `GRPOTrainModule`), align wandb keys with `dpo_tune_cache.py` (`train_loss`, `logps/*`, `rewards/*`, `perf/mfu_step`, `perf/tokens_per_second_step`/`_total`), add `train/padding_fraction`, `train/sequences_per_rank`, and `train/global_sequences_per_step` metrics, and make `get_num_sequences` always return an `int` (https://github.com/allenai/open-instruct/pull/1719).

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -1857,7 +1857,7 @@ class ModelDims:
         if self.device_name is None and torch.cuda.is_available():
             self.device_name = get_device_name(torch.cuda.get_device_name(0))
 
-        assert self.hidden_size % self.num_attn_heads == 0, "hidden_size must be divisible by num_attn_heads"
+        assert self.head_dim > 0, "head_dim must be positive"
         assert self.num_attn_heads % self.num_kv_heads == 0, (
             "num_attn_heads must be divisible by num_kv_heads (GQA/MQA)"
         )
@@ -1925,7 +1925,12 @@ class ModelDims:
                 num_sliding_window_layers = layer_types.count("sliding_attention")
             else:
                 num_sliding_window_layers = config.num_hidden_layers
-        head_dim = getattr(config, "head_dim", hidden_size // config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", None)
+        if head_dim is None:
+            assert hidden_size % config.num_attention_heads == 0, (
+                "hidden_size must be divisible by num_attention_heads"
+            )
+            head_dim = hidden_size // config.num_attention_heads
 
         num_linear_attn_layers = layer_types.count("linear_attention") if layer_types is not None else 0
         linear_attn_kwargs = {}


### PR DESCRIPTION
## Summary
- Honor an explicit `head_dim` from HF configs (e.g. composite/VLM models) instead of always deriving it from `hidden_size // num_attention_heads`, which fails when `hidden_size` is not divisible by `num_attention_heads`.
- Relax the `__post_init__` assertion to require a positive `head_dim`.

## Test plan
- Existing ModelDims tests.

GPU_TESTS=bypass

Made with [Cursor](https://cursor.com)