### PR TITLE
fix: parse --preemptible flag in Beaker submit scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Fix `--preemptible` parsing in Beaker submit scripts so `--no-preemptible` actually disables preemptible jobs (https://github.com/allenai/open-instruct/pull/1742).

--- a/scripts/submit_dpo_job.py
+++ b/scripts/submit_dpo_job.py
@@ -27,7 +27,12 @@ def main():
     )
     parser.add_argument("--cluster", type=str, default="ai2/jupiter", help="Beaker cluster to use")
     parser.add_argument("--priority", type=str, default="high", help="Priority of the job")
-    parser.add_argument("--preemptible", type=bool, default=True, help="Whether to use preemptible instances")
+    parser.add_argument(
+        "--preemptible",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Whether to use preemptible instances",
+    )
     parser.add_argument("--num_gpus", type=int, default=8, help="Number of GPUs to use")
     parser.add_argument("--num_nodes", type=int, default=1, help="Number of nodes to use")
     parser.add_argument("--image", type=str, default="nathanl/open_instruct_auto", help="Beaker image to use.")

--- a/scripts/submit_finetune_job.py
+++ b/scripts/submit_finetune_job.py
@@ -27,7 +27,12 @@ def main():
     )
     parser.add_argument("--cluster", type=str, default="ai2/jupiter", help="Beaker cluster to use")
     parser.add_argument("--priority", type=str, default="high", help="Priority of the job")
-    parser.add_argument("--preemptible", type=bool, default=True, help="Whether to use preemptible instances")
+    parser.add_argument(
+        "--preemptible",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Whether to use preemptible instances",
+    )
     parser.add_argument("--num_gpus", type=int, default=8, help="Number of GPUs to use")
     parser.add_argument("--num_nodes", type=int, default=1, help="Number of nodes to use")
     parser.add_argument("--image", type=str, default="nathanl/open_instruct_auto", help="Beaker image to use.")


### PR DESCRIPTION
## Summary
- switch `--preemptible` from `type=bool` to `BooleanOptionalAction` in finetune and DPO submit scripts

`type=bool` in argparse treats any non-empty string as True, so `--preemptible False` still set preemptible=True in the Beaker job config.

## Test plan
- [ ] run `python scripts/submit_finetune_job.py --no-preemptible --help` and confirm flag parses
- [ ] verify generated Beaker config sets `preemptible: false` when `--no-preemptible` is passed


Made with [Cursor](https://cursor.com)