### PR TITLE
Harden DockerBackend with retries, OOM detection, and concurrency limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
+- Harden DockerBackend with transient-exec retries, OOM detection, and concurrency limits (https://github.com/allenai/open-instruct/pull/1732).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
-- Harden DockerBackend with transient-exec retries, OOM detection, and concurrency limits (https://github.com/allenai/open-instruct/pull/1732).
+- Harden DockerBackend with transient-exec retries, OOM detection, and concurrency limits (https://github.com/allenai/open-instruct/pull/1744).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
-- Harden DockerBackend with transient-exec retries, OOM detection, and concurrency limits (https://github.com/allenai/open-instruct/pull/1744).
+- Harden DockerBackend with transient-exec retries and concurrency limits, and end the episode when the sandbox container is OOM-killed or otherwise lost instead of continuing against a dead container (https://github.com/allenai/open-instruct/pull/1744).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/open_instruct/environments/backends.py
+++ b/open_instruct/environments/backends.py
@@ -54,7 +54,10 @@ class _FileSlotSemaphore:
     def __init__(self, name: str, slots: int):
         self.name = name
         self.slots = max(0, slots)
-        self.lock_dir = os.getenv("SWERL_DOCKER_LOCK_DIR", "/tmp/open_instruct_docker_locks")
+        # User-specific default dir so a shared /tmp doesn't cause cross-user permission
+        # conflicts (and the EACCES-skip loop never finding a usable slot).
+        uid = os.getuid() if hasattr(os, "getuid") else "default"
+        self.lock_dir = os.getenv("SWERL_DOCKER_LOCK_DIR", f"/tmp/open_instruct_docker_locks_{uid}")
         if self.slots > 0:
             os.makedirs(self.lock_dir, exist_ok=True)
 

--- a/open_instruct/environments/backends.py
+++ b/open_instruct/environments/backends.py
@@ -69,11 +69,15 @@ class _FileSlotSemaphore:
         while handle is None:
             for slot in range(self.slots):
                 path = os.path.join(self.lock_dir, f"{self.name}.{slot}.lock")
-                candidate = open(path, "a+")  # noqa: SIM115 - lock handle lives through the context manager
+                candidate = None
                 try:
+                    candidate = open(path, "a+")  # noqa: SIM115 - lock handle lives through the context manager
                     fcntl.flock(candidate.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 except OSError as e:
-                    candidate.close()
+                    if candidate is not None:
+                        candidate.close()
+                    # A slot owned by another user (PermissionError/EACCES) or already
+                    # locked (EAGAIN) just means we should try the next slot.
                     if e.errno in (errno.EACCES, errno.EAGAIN):
                         continue
                     raise

--- a/open_instruct/environments/backends.py
+++ b/open_instruct/environments/backends.py
@@ -1,9 +1,14 @@
 """Sandbox backend abstraction for code/command execution."""
 
+import contextlib
+import errno
+import fcntl
 import io
 import os
+import random
 import shlex
 import tarfile
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
@@ -12,6 +17,77 @@ import docker as docker_sdk
 from open_instruct import logger_utils
 
 logger = logger_utils.setup_logger(__name__)
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        logger.warning("Invalid integer for %s=%r; using default %s", name, value, default)
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        logger.warning("Invalid float for %s=%r; using default %s", name, value, default)
+        return default
+
+
+class _FileSlotSemaphore:
+    """Small cross-process semaphore using advisory locks on per-node files."""
+
+    def __init__(self, name: str, slots: int):
+        self.name = name
+        self.slots = max(0, slots)
+        self.lock_dir = os.getenv("SWERL_DOCKER_LOCK_DIR", "/tmp/open_instruct_docker_locks")
+        if self.slots > 0:
+            os.makedirs(self.lock_dir, exist_ok=True)
+
+    @contextlib.contextmanager
+    def acquire(self):
+        if self.slots <= 0:
+            yield 0.0
+            return
+
+        start_time = time.perf_counter()
+        handle = None
+        while handle is None:
+            for slot in range(self.slots):
+                path = os.path.join(self.lock_dir, f"{self.name}.{slot}.lock")
+                candidate = open(path, "a+")  # noqa: SIM115 - lock handle lives through the context manager
+                try:
+                    fcntl.flock(candidate.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except OSError as e:
+                    candidate.close()
+                    if e.errno in (errno.EACCES, errno.EAGAIN):
+                        continue
+                    raise
+                handle = candidate
+                break
+            if handle is None:
+                time.sleep(0.05 + random.uniform(0.0, 0.05))
+
+        wait_s = time.perf_counter() - start_time
+        try:
+            yield wait_s
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            handle.close()
 
 
 @dataclass
@@ -23,6 +99,15 @@ class ExecutionResult:
     exit_code: int
 
 
+class SandboxOOMError(RuntimeError):
+    """Raised when the sandbox container was killed by the OOM reaper.
+
+    Callers should treat this as a terminal condition for the current
+    episode (reward 0, done=True) rather than retrying, because the
+    agent's next command will almost certainly trip the same limit.
+    """
+
+
 class SandboxBackend(ABC):
     """Abstract interface for code/command execution backends."""
 
@@ -31,7 +116,7 @@ class SandboxBackend(ABC):
         """Initialize the sandbox. Must be called before other operations."""
 
     @abstractmethod
-    def run_command(self, command: str) -> ExecutionResult:
+    def run_command(self, command: str, timeout: int | None = None) -> ExecutionResult:
         """Execute a shell command in the sandbox."""
 
     @abstractmethod
@@ -55,49 +140,299 @@ class DockerBackend(SandboxBackend):
     """
 
     _MAX_OUTPUT_BYTES = 1_000_000
+    _TRANSIENT_EXEC_API_ERROR_RETRIES = 5
+    _TRANSIENT_EXEC_RETRY_BASE_DELAY_S = 0.5
+    _TRANSIENT_EXEC_RETRY_MAX_DELAY_S = 8.0
+    _TRANSIENT_EXEC_RETRY_JITTER_S = 0.5
+    _TRANSIENT_EXEC_API_ERROR_MARKERS = ("database is locked", "retrieving exec session", "timed out waiting for file")
+    _START_SEMAPHORE = _FileSlotSemaphore("docker-start", _env_int("SWERL_DOCKER_START_CONCURRENCY", 64))
+    _EXEC_SEMAPHORE = _FileSlotSemaphore("docker-exec", _env_int("SWERL_DOCKER_EXEC_CONCURRENCY", 256))
+    _TIMING_LOGS = _env_flag("SWERL_SANDBOX_TIMING_LOGS", False)
+    _TIMING_LOG_THRESHOLD_S = _env_float("SWERL_SANDBOX_TIMING_LOG_THRESHOLD_S", 1.0)
 
-    def __init__(self, image: str = "python:3.12-slim", timeout: int = 1800, mem_limit: str = "4g"):
+    def __init__(
+        self,
+        image: str = "python:3.12-slim",
+        timeout: int = 1800,
+        mem_limit: str = "4g",
+        docker_host: str | None = None,
+    ):
         """
         Args:
             image: Docker image to use (default: python:3.12-slim)
             timeout: Per-command timeout in seconds (default: 1800 / 30 min)
             mem_limit: Memory limit for the container (default: 4g)
+            docker_host: Optional Docker API endpoint, e.g. ``unix:///tmp/podman.sock``.
         """
         self._image = image
         self._timeout = timeout
         self._mem_limit = mem_limit
+        self._docker_host = docker_host
+        self._auto_remove = _env_flag("SWERL_DOCKER_AUTO_REMOVE", True)
         self._container = None
         self._client = None
 
+    def _create_client(self):
+        if self._docker_host:
+            return docker_sdk.DockerClient(base_url=self._docker_host, timeout=300)
+        return docker_sdk.from_env(timeout=300)
+
     def start(self) -> None:
-        logger.info(f"Starting Docker container (image={self._image})")
-        if self._client is None:
-            self._client = docker_sdk.from_env()
-        self._container = self._client.containers.run(
+        previous_cid = self._container.short_id if self._container is not None else None
+        logger.info(
+            "Starting Docker container (image=%s, previous_container=%s, auto_remove=%s, docker_host=%s)",
             self._image,
-            command="sleep infinity",
-            detach=True,
-            remove=True,
-            mem_limit=self._mem_limit,
-            memswap_limit=self._mem_limit,
+            previous_cid,
+            self._auto_remove,
+            self._docker_host or "<from_env>",
         )
+        if self._client is None:
+            self._client = self._create_client()
+        start_time = time.perf_counter()
+        with self._START_SEMAPHORE.acquire() as semaphore_wait_s:
+            lifecycle_start_time = time.perf_counter()
+            phase_timings: dict[str, float] = {}
+
+            phase_start_time = time.perf_counter()
+            try:
+                self._client.images.get(self._image)
+                phase_timings["image_get"] = time.perf_counter() - phase_start_time
+            except docker_sdk.errors.ImageNotFound:
+                phase_timings["image_get"] = time.perf_counter() - phase_start_time
+                phase_start_time = time.perf_counter()
+                self._client.images.pull(self._image)
+                phase_timings["image_pull"] = time.perf_counter() - phase_start_time
+
+            phase_start_time = time.perf_counter()
+            self._container = self._client.containers.create(
+                self._image,
+                command="sleep infinity",
+                detach=True,
+                auto_remove=self._auto_remove,
+                labels={"open_instruct": "swerl_sandbox"},
+                mem_limit=self._mem_limit,
+                memswap_limit=self._mem_limit,
+            )
+            phase_timings["container_create"] = time.perf_counter() - phase_start_time
+
+            phase_start_time = time.perf_counter()
+            self._container.start()
+            phase_timings["container_start"] = time.perf_counter() - phase_start_time
+        elapsed_s = time.perf_counter() - start_time
+        create_s = time.perf_counter() - lifecycle_start_time
+        if self._TIMING_LOGS and elapsed_s >= self._TIMING_LOG_THRESHOLD_S:
+            logger.info(
+                "DockerBackend.start timing image=%s container=%s total=%.3fs semaphore_wait=%.3fs create_start=%.3fs phases=%s",
+                self._image,
+                self._container.short_id,
+                elapsed_s,
+                semaphore_wait_s,
+                create_s,
+                {key: round(value, 3) for key, value in phase_timings.items()},
+            )
         logger.info(f"Docker container started: {self._container.short_id}")
 
-    def run_command(self, command: str) -> ExecutionResult:
+    def run_command(self, command: str, timeout: int | None = None) -> ExecutionResult:
         if self._container is None:
             raise RuntimeError("Container not started. Call start() first.")
 
-        wrapped = (
-            f"timeout --signal=TERM --kill-after=10 {shlex.quote(str(self._timeout))} bash -c {shlex.quote(command)}"
+        effective_timeout = self._timeout if timeout is None else timeout
+        container_id = self._container.short_id
+        logger.debug(
+            "Docker exec start (container=%s, image=%s, timeout=%ss, command=%r)",
+            container_id,
+            self._image,
+            effective_timeout,
+            command,
         )
-        exit_code, output = self._container.exec_run(["bash", "-c", wrapped], demux=True)
+        wrapped = (
+            f"timeout --signal=TERM --kill-after=10 {shlex.quote(str(effective_timeout))} "
+            f"bash -c {shlex.quote(command)}"
+        )
+        try:
+            exit_code, output = self._exec_run(wrapped)
+        except docker_sdk.errors.NotFound:
+            self._log_container_state("exec_not_found", container_id)
+            logger.warning(
+                "Docker container disappeared before exec (container=%s, image=%s). "
+                "Restarting and retrying command once.",
+                container_id,
+                self._image,
+            )
+            exit_code, output = self._restart_and_retry_exec(wrapped, container_id)
+        except docker_sdk.errors.APIError as e:
+            # 409 Conflict is typically "container is not running" (OOM, crash,
+            # external stop). Raise SandboxOOMError when OOM-killed so the
+            # episode can terminate cleanly; otherwise restart + retry.
+            self._log_container_state("exec_api_error", container_id)
+            if getattr(e, "status_code", None) == 409:
+                if self._container_was_oom_killed(container_id):
+                    raise SandboxOOMError(
+                        f"Sandbox container {container_id} (image={self._image}) was OOM-killed. Aborting episode."
+                    ) from e
+                logger.warning(
+                    "Docker exec 409 Conflict (container=%s, image=%s): %s. Restarting and retrying command once.",
+                    container_id,
+                    self._image,
+                    e,
+                )
+                exit_code, output = self._restart_and_retry_exec(wrapped, container_id)
+            else:
+                if self._is_transient_exec_api_error(e):
+                    logger.warning(
+                        "Transient Docker exec APIError (container=%s, image=%s): %s. "
+                        "Retrying command on the same container.",
+                        container_id,
+                        self._image,
+                        e,
+                    )
+                    exit_code, output = self._retry_exec_same_container(wrapped, container_id)
+                else:
+                    logger.warning("Docker exec APIError (container=%s, image=%s): %s", container_id, self._image, e)
+                    raise
         stdout_raw = (output[0] or b"") if output else b""
         stderr_raw = (output[1] or b"") if output else b""
         stdout = stdout_raw[: self._MAX_OUTPUT_BYTES].decode("utf-8", errors="replace")
         stderr = stderr_raw[: self._MAX_OUTPUT_BYTES].decode("utf-8", errors="replace")
         if exit_code == 124:
-            stderr = f"Command timed out after {self._timeout}s.\n" + stderr
+            stderr = f"Command timed out after {effective_timeout}s.\n" + stderr
         return ExecutionResult(stdout=stdout, stderr=stderr, exit_code=exit_code)
+
+    @classmethod
+    def _is_transient_exec_api_error(cls, error: docker_sdk.errors.APIError) -> bool:
+        message = str(error).lower()
+        return any(marker in message for marker in cls._TRANSIENT_EXEC_API_ERROR_MARKERS)
+
+    def _exec_run(self, wrapped: str):
+        if self._container is None:
+            raise RuntimeError("Container missing during Docker exec.")
+        start_time = time.perf_counter()
+        with self._EXEC_SEMAPHORE.acquire() as semaphore_wait_s:
+            exec_start_time = time.perf_counter()
+            result = self._container.exec_run(["bash", "-c", wrapped], demux=True)
+        elapsed_s = time.perf_counter() - start_time
+        exec_s = time.perf_counter() - exec_start_time
+        if self._TIMING_LOGS and elapsed_s >= self._TIMING_LOG_THRESHOLD_S:
+            logger.info(
+                "DockerBackend.exec timing image=%s container=%s total=%.3fs semaphore_wait=%.3fs exec=%.3fs",
+                self._image,
+                self._container.short_id,
+                elapsed_s,
+                semaphore_wait_s,
+                exec_s,
+            )
+        return result
+
+    def _retry_exec_same_container(self, wrapped: str, container_id: str):
+        """Retry an exec after a transient Docker daemon/storage error."""
+        if self._container is None:
+            raise RuntimeError("Container missing during Docker exec retry.")
+        last_error = None
+        for attempt in range(1, self._TRANSIENT_EXEC_API_ERROR_RETRIES + 1):
+            delay = self._transient_exec_retry_delay(attempt)
+            time.sleep(delay)
+            with contextlib.suppress(Exception):
+                self._container.reload()
+            logger.info(
+                "Retrying command after transient Docker exec APIError "
+                "(container=%s, image=%s, attempt=%s/%s, delay=%.2fs)",
+                container_id,
+                self._image,
+                attempt,
+                self._TRANSIENT_EXEC_API_ERROR_RETRIES,
+                delay,
+            )
+            try:
+                return self._exec_run(wrapped)
+            except docker_sdk.errors.APIError as e:
+                if not self._is_transient_exec_api_error(e):
+                    raise
+                last_error = e
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("Docker exec retry failed without capturing an error.")
+
+    @classmethod
+    def _transient_exec_retry_delay(cls, attempt: int) -> float:
+        backoff = min(
+            cls._TRANSIENT_EXEC_RETRY_BASE_DELAY_S * (2 ** (attempt - 1)), cls._TRANSIENT_EXEC_RETRY_MAX_DELAY_S
+        )
+        return backoff + random.uniform(0.0, cls._TRANSIENT_EXEC_RETRY_JITTER_S)
+
+    def _container_was_oom_killed(self, container_id: str) -> bool:
+        """Best-effort probe for ``State.OOMKilled``. Returns False on any error."""
+        if self._client is None:
+            return False
+        try:
+            container = self._client.containers.get(container_id)
+            with contextlib.suppress(Exception):
+                container.reload()
+            return bool(container.attrs.get("State", {}).get("OOMKilled"))
+        except Exception:
+            return False
+
+    def _restart_and_retry_exec(self, wrapped: str, old_container_id: str):
+        """Recreate the container and re-run a prepared bash command once.
+
+        Shared between the NotFound and 409-Conflict paths. Returns
+        ``(exit_code, output)`` from the retried ``exec_run``.
+        """
+        self.start()
+        if self._container is None:
+            raise RuntimeError("Failed to restart Docker container during exec retry.")
+        logger.info(
+            "Retrying command after container restart (old_container=%s, new_container=%s)",
+            old_container_id,
+            self._container.short_id,
+        )
+        return self._exec_run(wrapped)
+
+    def _log_container_state(self, reason: str, container_id: str) -> None:
+        """Best-effort container state diagnostics for flaky lifecycle issues."""
+        if self._client is None:
+            logger.warning(
+                "Container state unavailable during %s (container=%s, image=%s): docker client is None",
+                reason,
+                container_id,
+                self._image,
+            )
+            return
+
+        try:
+            container = self._client.containers.get(container_id)
+        except docker_sdk.errors.NotFound:
+            logger.warning(
+                "Container state during %s (container=%s, image=%s): container not found in daemon",
+                reason,
+                container_id,
+                self._image,
+            )
+            return
+        except Exception as e:
+            logger.warning(
+                "Container state lookup failed during %s (container=%s, image=%s): %s",
+                reason,
+                container_id,
+                self._image,
+                e,
+            )
+            return
+
+        with contextlib.suppress(Exception):
+            container.reload()
+        state = container.attrs.get("State", {})
+        logger.warning(
+            "Container state during %s (container=%s, image=%s): status=%s running=%s exit_code=%s "
+            "oom_killed=%s error=%s",
+            reason,
+            container_id,
+            self._image,
+            state.get("Status"),
+            state.get("Running"),
+            state.get("ExitCode"),
+            state.get("OOMKilled"),
+            state.get("Error"),
+        )
 
     def write_file(self, path: str, content: str | bytes) -> None:
         if self._container is None:
@@ -140,15 +475,16 @@ class DockerBackend(SandboxBackend):
     def close(self) -> None:
         if self._container is not None:
             cid = self._container.short_id
-            logger.info(f"Closing Docker container: {cid}")
+            logger.info(f"Closing Docker container: {cid} (image={self._image})")
             try:
-                self._container.stop(timeout=5)
-            except Exception as e:
-                logger.warning(f"Error stopping container {cid}, attempting kill: {e}")
+                self._container.kill()
+                logger.info(f"Killed Docker container: {cid}")
+            except Exception:
                 try:
-                    self._container.kill()
-                except Exception as kill_err:
-                    logger.warning(f"Error killing container {cid}: {kill_err}")
+                    self._container.stop(timeout=3)
+                    logger.info(f"Stopped Docker container: {cid}")
+                except Exception as e:
+                    logger.warning(f"Error stopping container {cid}: {e}")
             self._container = None
 
 

--- a/open_instruct/environments/backends.py
+++ b/open_instruct/environments/backends.py
@@ -115,6 +115,18 @@ class SandboxOOMError(RuntimeError):
     """
 
 
+class SandboxContainerLostError(RuntimeError):
+    """Raised when the sandbox container died or vanished mid-episode.
+
+    Like :class:`SandboxOOMError`, this is terminal for the episode. The
+    container filesystem *is* the episode state — every file the agent edited,
+    plus the wrapper script and persisted cwd written during ``reset`` — so a
+    replacement container cannot continue the trajectory. Retrying the command
+    against a fresh container would silently run it against a pristine
+    filesystem and yield a trajectory that looks valid but is not.
+    """
+
+
 class SandboxBackend(ABC):
     """Abstract interface for code/command execution backends."""
 
@@ -258,32 +270,25 @@ class DockerBackend(SandboxBackend):
         )
         try:
             exit_code, output = self._exec_run(wrapped)
-        except docker_sdk.errors.NotFound:
+        except docker_sdk.errors.NotFound as e:
             self._log_container_state("exec_not_found", container_id)
-            logger.warning(
-                "Docker container disappeared before exec (container=%s, image=%s). "
-                "Restarting and retrying command once.",
-                container_id,
-                self._image,
-            )
-            exit_code, output = self._restart_and_retry_exec(wrapped, container_id)
+            raise SandboxContainerLostError(
+                f"Sandbox container {container_id} (image={self._image}) disappeared before exec. Aborting episode."
+            ) from e
         except docker_sdk.errors.APIError as e:
             # 409 Conflict is typically "container is not running" (OOM, crash,
-            # external stop). Raise SandboxOOMError when OOM-killed so the
-            # episode can terminate cleanly; otherwise restart + retry.
+            # external stop). Either way the container's filesystem — and with it
+            # the episode state — is gone, so both cases are terminal.
             self._log_container_state("exec_api_error", container_id)
             if getattr(e, "status_code", None) == 409:
                 if self._container_was_oom_killed(container_id):
                     raise SandboxOOMError(
                         f"Sandbox container {container_id} (image={self._image}) was OOM-killed. Aborting episode."
                     ) from e
-                logger.warning(
-                    "Docker exec 409 Conflict (container=%s, image=%s): %s. Restarting and retrying command once.",
-                    container_id,
-                    self._image,
-                    e,
-                )
-                exit_code, output = self._restart_and_retry_exec(wrapped, container_id)
+                raise SandboxContainerLostError(
+                    f"Sandbox container {container_id} (image={self._image}) is no longer running: {e}. "
+                    f"Aborting episode."
+                ) from e
             else:
                 if self._is_transient_exec_api_error(e):
                     logger.warning(
@@ -377,22 +382,6 @@ class DockerBackend(SandboxBackend):
             return bool(container.attrs.get("State", {}).get("OOMKilled"))
         except Exception:
             return False
-
-    def _restart_and_retry_exec(self, wrapped: str, old_container_id: str):
-        """Recreate the container and re-run a prepared bash command once.
-
-        Shared between the NotFound and 409-Conflict paths. Returns
-        ``(exit_code, output)`` from the retried ``exec_run``.
-        """
-        self.start()
-        if self._container is None:
-            raise RuntimeError("Failed to restart Docker container during exec retry.")
-        logger.info(
-            "Retrying command after container restart (old_container=%s, new_container=%s)",
-            old_container_id,
-            self._container.short_id,
-        )
-        return self._exec_run(wrapped)
 
     def _log_container_state(self, reason: str, container_id: str) -> None:
         """Best-effort container state diagnostics for flaky lifecycle issues."""

--- a/open_instruct/environments/generic_sandbox.py
+++ b/open_instruct/environments/generic_sandbox.py
@@ -12,7 +12,7 @@ from openenv.core.env_server.types import State
 
 from open_instruct import logger_utils
 
-from .backends import SandboxBackend, create_backend
+from .backends import SandboxBackend, SandboxContainerLostError, SandboxOOMError, create_backend
 from .base import BaseEnvConfig, EnvCall, RLEnvironment, StepResult
 from .tools.utils import coerce_args
 
@@ -209,7 +209,22 @@ class GenericSandboxEnv(RLEnvironment):
         if not command:
             return StepResult(result="Error: 'command' parameter is required for execute_bash.", reward=self._penalty)
 
-        result = self._backend.run_command(f"bash /tmp/.sandbox_bash_wrapper.sh {shlex.quote(command)}")
+        # A dead container is terminal: its filesystem holds the episode state (the
+        # agent's edits, the wrapper script, the persisted cwd), so there is nothing
+        # left to continue. Ending the episode here sets ``done`` on the rollout;
+        # letting the error propagate would instead hit the generic handler in
+        # ``vllm_utils``, which scores 0 but keeps stepping — so the agent would
+        # re-trip the same failure on every remaining step.
+        try:
+            result = self._backend.run_command(f"bash /tmp/.sandbox_bash_wrapper.sh {shlex.quote(command)}")
+        except (SandboxOOMError, SandboxContainerLostError) as e:
+            logger.warning(f"Ending episode after unrecoverable sandbox failure: {e}")
+            return StepResult(
+                result=f"Error: the sandbox terminated and cannot continue ({e}).",
+                reward=self._penalty,
+                done=True,
+                metadata={"sandbox_terminated": type(e).__name__},
+            )
 
         stdout = _truncate_output(result.stdout) if result.stdout else ""
         stderr = _truncate_output(result.stderr) if result.stderr else ""

--- a/tests/test_docker_backend.py
+++ b/tests/test_docker_backend.py
@@ -1,0 +1,121 @@
+"""Unit tests for DockerBackend retry behavior."""
+
+from unittest.mock import MagicMock, patch
+
+import docker as docker_sdk
+
+from open_instruct.environments.backends import DockerBackend
+
+
+class _FakeDockerContainer:
+    short_id = "abc123"
+
+    def __init__(self, *, exec_errors=None):
+        self.attrs = {"State": {"Status": "running", "Running": True, "ExitCode": 0, "OOMKilled": False, "Error": ""}}
+        self.exec_calls = 0
+        self.reload_calls = 0
+        self.exec_errors = list(exec_errors or [])
+
+    def exec_run(self, *_args, **_kwargs):
+        self.exec_calls += 1
+        if self.exec_errors:
+            raise self.exec_errors.pop(0)
+        return 0, (b"ok\n", b"")
+
+    def reload(self):
+        self.reload_calls += 1
+
+
+def _api_error(message: str) -> docker_sdk.errors.APIError:
+    return docker_sdk.errors.APIError(message)
+
+
+def test_create_client_uses_explicit_docker_host():
+    backend = DockerBackend(image="test-image", docker_host="unix:///tmp/podman-1.sock")
+    expected_client = MagicMock()
+
+    with (
+        patch(
+            "open_instruct.environments.backends.docker_sdk.DockerClient", return_value=expected_client
+        ) as docker_client,
+        patch("open_instruct.environments.backends.docker_sdk.from_env") as from_env,
+    ):
+        client = backend._create_client()
+
+    assert client is expected_client
+    docker_client.assert_called_once_with(base_url="unix:///tmp/podman-1.sock", timeout=300)
+    from_env.assert_not_called()
+
+
+def test_create_client_uses_environment_without_explicit_docker_host():
+    backend = DockerBackend(image="test-image")
+    expected_client = MagicMock()
+
+    with (
+        patch("open_instruct.environments.backends.docker_sdk.DockerClient") as docker_client,
+        patch("open_instruct.environments.backends.docker_sdk.from_env", return_value=expected_client) as from_env,
+    ):
+        client = backend._create_client()
+
+    assert client is expected_client
+    from_env.assert_called_once_with(timeout=300)
+    docker_client.assert_not_called()
+
+
+def test_run_command_retries_database_locked_exec_error_on_same_container():
+    container = _FakeDockerContainer(exec_errors=[_api_error("database is locked")])
+    backend = DockerBackend(image="test-image")
+    backend._container = container
+    backend._client = MagicMock()
+    backend._client.containers.get.return_value = container
+
+    with (
+        patch("open_instruct.environments.backends.random.uniform", return_value=0.25),
+        patch("open_instruct.environments.backends.time.sleep") as sleep,
+        patch.object(backend, "start") as start,
+    ):
+        result = backend.run_command("echo ok")
+
+    assert result.stdout == "ok\n"
+    assert result.exit_code == 0
+    assert container.exec_calls == 2
+    assert container.reload_calls == 2
+    sleep.assert_called_once_with(0.75)
+    start.assert_not_called()
+
+
+def test_run_command_allows_five_database_locked_exec_retries():
+    container = _FakeDockerContainer(exec_errors=[_api_error("database is locked") for _ in range(5)])
+    backend = DockerBackend(image="test-image")
+    backend._container = container
+    backend._client = MagicMock()
+    backend._client.containers.get.return_value = container
+
+    with (
+        patch("open_instruct.environments.backends.random.uniform", return_value=0.25),
+        patch("open_instruct.environments.backends.time.sleep") as sleep,
+    ):
+        result = backend.run_command("echo ok")
+
+    assert result.stdout == "ok\n"
+    assert result.exit_code == 0
+    assert container.exec_calls == 6
+    assert container.reload_calls == 6
+    assert [call.args[0] for call in sleep.call_args_list] == [0.75, 1.25, 2.25, 4.25, 8.25]
+
+
+def test_run_command_does_not_retry_unknown_exec_api_error():
+    container = _FakeDockerContainer(exec_errors=[_api_error("unknown docker failure")])
+    backend = DockerBackend(image="test-image")
+    backend._container = container
+    backend._client = MagicMock()
+    backend._client.containers.get.return_value = container
+
+    try:
+        backend.run_command("echo ok")
+    except docker_sdk.errors.APIError:
+        pass
+    else:
+        raise AssertionError("Expected APIError to be raised")
+
+    assert container.exec_calls == 1

--- a/tests/test_docker_backend.py
+++ b/tests/test_docker_backend.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import docker as docker_sdk
 
-from open_instruct.environments.backends import DockerBackend
+from open_instruct.environments.backends import DockerBackend, SandboxContainerLostError, SandboxOOMError
 
 
 class _FakeDockerContainer:
@@ -118,4 +118,70 @@ def test_run_command_does_not_retry_unknown_exec_api_error():
     else:
         raise AssertionError("Expected APIError to be raised")
 
+    assert container.exec_calls == 1
+
+
+def _conflict_error(message: str) -> docker_sdk.errors.APIError:
+    # APIError.status_code is read-only and derived from the response object.
+    return docker_sdk.errors.APIError(message, response=MagicMock(status_code=409))
+
+
+def test_run_command_raises_oom_error_when_container_was_oom_killed():
+    container = _FakeDockerContainer(exec_errors=[_conflict_error("container is not running")])
+    container.attrs = {"State": {"Status": "exited", "Running": False, "ExitCode": 137, "OOMKilled": True}}
+    backend = DockerBackend(image="test-image")
+    backend._container = container
+    backend._client = MagicMock()
+    backend._client.containers.get.return_value = container
+
+    with patch.object(backend, "start") as start:
+        try:
+            backend.run_command("echo ok")
+        except SandboxOOMError:
+            pass
+        else:
+            raise AssertionError("Expected SandboxOOMError to be raised")
+
+    # The container must not be recreated: a fresh one would silently discard the
+    # episode's filesystem state instead of ending the episode.
+    start.assert_not_called()
+    assert container.exec_calls == 1
+
+
+def test_run_command_raises_container_lost_on_409_without_oom():
+    container = _FakeDockerContainer(exec_errors=[_conflict_error("container is not running")])
+    container.attrs = {"State": {"Status": "exited", "Running": False, "ExitCode": 1, "OOMKilled": False}}
+    backend = DockerBackend(image="test-image")
+    backend._container = container
+    backend._client = MagicMock()
+    backend._client.containers.get.return_value = container
+
+    with patch.object(backend, "start") as start:
+        try:
+            backend.run_command("echo ok")
+        except SandboxContainerLostError:
+            pass
+        else:
+            raise AssertionError("Expected SandboxContainerLostError to be raised")
+
+    start.assert_not_called()
+    assert container.exec_calls == 1
+
+
+def test_run_command_raises_container_lost_when_container_not_found():
+    container = _FakeDockerContainer(exec_errors=[docker_sdk.errors.NotFound("no such container")])
+    backend = DockerBackend(image="test-image")
+    backend._container = container
+    backend._client = MagicMock()
+    backend._client.containers.get.side_effect = docker_sdk.errors.NotFound("no such container")
+
+    with patch.object(backend, "start") as start:
+        try:
+            backend.run_command("echo ok")
+        except SandboxContainerLostError:
+            pass
+        else:
+            raise AssertionError("Expected SandboxContainerLostError to be raised")
+
+    start.assert_not_called()
     assert container.exec_calls == 1

--- a/tests/test_generic_sandbox.py
+++ b/tests/test_generic_sandbox.py
@@ -22,7 +22,7 @@ class MockBackend(SandboxBackend):
         self._files = {}
         self._cwd = "/testbed"
 
-    def run_command(self, command: str) -> ExecutionResult:
+    def run_command(self, command: str, timeout: int | None = None) -> ExecutionResult:
         if "which git" in command:
             return ExecutionResult(stdout="", stderr="", exit_code=1)
         if "mkdir -p" in command:
@@ -102,7 +102,6 @@ def _step(env: GenericSandboxEnv, name: str, args: dict) -> StepResult:
 
 
 class TestGenericSandboxReset(unittest.TestCase):
-
     @patch(_MOCK_BACKEND_PATCH, side_effect=_mock_create_backend)
     def test_reset_returns_observation_and_tools(self, _mock):
         env = GenericSandboxEnv(backend="docker")
@@ -145,7 +144,6 @@ class TestGenericSandboxReset(unittest.TestCase):
 
 
 class TestExecuteBash(unittest.TestCase):
-
     def test_successful_command(self):
         env = _make_env()
         result = _step(env, "execute_bash", {"command": "echo hello"})
@@ -177,148 +175,114 @@ class TestExecuteBash(unittest.TestCase):
 
 
 class TestStrReplaceEditor(unittest.TestCase):
-
     def test_create_file(self):
         env = _make_env()
-        result = _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/hello.py",
-            "file_text": "print('hello')\n",
-        })
+        result = _step(
+            env,
+            "str_replace_editor",
+            {"command": "create", "path": "/testbed/hello.py", "file_text": "print('hello')\n"},
+        )
 
         self.assertIn("File created successfully", result.result)
         self.assertEqual(result.reward, 0.0)
 
     def test_create_existing_file_errors(self):
         env = _make_env()
-        _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/exists.py",
-            "file_text": "original",
-        })
-        result = _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/exists.py",
-            "file_text": "overwrite",
-        })
+        _step(env, "str_replace_editor", {"command": "create", "path": "/testbed/exists.py", "file_text": "original"})
+        result = _step(
+            env, "str_replace_editor", {"command": "create", "path": "/testbed/exists.py", "file_text": "overwrite"}
+        )
 
         self.assertIn("already exists", result.result)
         self.assertIn("ERROR", result.result)
 
     def test_create_without_file_text(self):
         env = _make_env()
-        result = _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/no_content.py",
-        })
+        result = _step(env, "str_replace_editor", {"command": "create", "path": "/testbed/no_content.py"})
 
         self.assertIn("'file_text' parameter is required", result.result)
 
     def test_view_file(self):
         env = _make_env()
-        _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/view_me.txt",
-            "file_text": "line one\nline two\nline three\n",
-        })
-        result = _step(env, "str_replace_editor", {
-            "command": "view",
-            "path": "/testbed/view_me.txt",
-        })
+        _step(
+            env,
+            "str_replace_editor",
+            {"command": "create", "path": "/testbed/view_me.txt", "file_text": "line one\nline two\nline three\n"},
+        )
+        result = _step(env, "str_replace_editor", {"command": "view", "path": "/testbed/view_me.txt"})
 
         self.assertIn("str_replace_editor", result.result)
         self.assertIn("line one", result.result)
 
     def test_view_nonexistent_file(self):
         env = _make_env()
-        result = _step(env, "str_replace_editor", {
-            "command": "view",
-            "path": "/testbed/nope.txt",
-        })
+        result = _step(env, "str_replace_editor", {"command": "view", "path": "/testbed/nope.txt"})
 
         self.assertIn("ERROR", result.result)
 
     def test_str_replace(self):
         env = _make_env()
-        _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/edit.py",
-            "file_text": "x = 1\ny = 2\nz = 3\n",
-        })
-        result = _step(env, "str_replace_editor", {
-            "command": "str_replace",
-            "path": "/testbed/edit.py",
-            "old_str": "y = 2",
-            "new_str": "y = 42",
-        })
+        _step(
+            env,
+            "str_replace_editor",
+            {"command": "create", "path": "/testbed/edit.py", "file_text": "x = 1\ny = 2\nz = 3\n"},
+        )
+        result = _step(
+            env,
+            "str_replace_editor",
+            {"command": "str_replace", "path": "/testbed/edit.py", "old_str": "y = 2", "new_str": "y = 42"},
+        )
 
         self.assertIn("has been edited", result.result)
 
     def test_str_replace_not_found(self):
         env = _make_env()
-        _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/sr.py",
-            "file_text": "a = 1\n",
-        })
-        result = _step(env, "str_replace_editor", {
-            "command": "str_replace",
-            "path": "/testbed/sr.py",
-            "old_str": "not here",
-            "new_str": "replacement",
-        })
+        _step(env, "str_replace_editor", {"command": "create", "path": "/testbed/sr.py", "file_text": "a = 1\n"})
+        result = _step(
+            env,
+            "str_replace_editor",
+            {"command": "str_replace", "path": "/testbed/sr.py", "old_str": "not here", "new_str": "replacement"},
+        )
 
         self.assertIn("old_str not found", result.result)
 
     def test_str_replace_multiple_matches(self):
         env = _make_env()
-        _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/dup.py",
-            "file_text": "x = 1\nx = 1\n",
-        })
-        result = _step(env, "str_replace_editor", {
-            "command": "str_replace",
-            "path": "/testbed/dup.py",
-            "old_str": "x = 1",
-            "new_str": "x = 2",
-        })
+        _step(
+            env, "str_replace_editor", {"command": "create", "path": "/testbed/dup.py", "file_text": "x = 1\nx = 1\n"}
+        )
+        result = _step(
+            env,
+            "str_replace_editor",
+            {"command": "str_replace", "path": "/testbed/dup.py", "old_str": "x = 1", "new_str": "x = 2"},
+        )
 
         self.assertIn("found 2 times", result.result)
 
     def test_insert(self):
         env = _make_env()
-        _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/ins.py",
-            "file_text": "line 1\nline 3\n",
-        })
-        result = _step(env, "str_replace_editor", {
-            "command": "insert",
-            "path": "/testbed/ins.py",
-            "insert_line": 1,
-            "new_str": "line 2",
-        })
+        _step(
+            env,
+            "str_replace_editor",
+            {"command": "create", "path": "/testbed/ins.py", "file_text": "line 1\nline 3\n"},
+        )
+        result = _step(
+            env,
+            "str_replace_editor",
+            {"command": "insert", "path": "/testbed/ins.py", "insert_line": 1, "new_str": "line 2"},
+        )
 
         self.assertIn("has been edited", result.result)
 
     def test_insert_missing_params(self):
         env = _make_env()
-        _step(env, "str_replace_editor", {
-            "command": "create",
-            "path": "/testbed/ins2.py",
-            "file_text": "content\n",
-        })
-        result = _step(env, "str_replace_editor", {
-            "command": "insert",
-            "path": "/testbed/ins2.py",
-        })
+        _step(env, "str_replace_editor", {"command": "create", "path": "/testbed/ins2.py", "file_text": "content\n"})
+        result = _step(env, "str_replace_editor", {"command": "insert", "path": "/testbed/ins2.py"})
 
         self.assertIn("'insert_line' parameter is required", result.result)
 
 
 class TestUnknownTool(unittest.TestCase):
-
     def test_unknown_tool_name(self):
         env = _make_env()
         result = _step(env, "nonexistent_tool", {"arg": "val"})
@@ -328,7 +292,6 @@ class TestUnknownTool(unittest.TestCase):
 
 
 class TestMetricsAndState(unittest.TestCase):
-
     def test_step_count_increments(self):
         env = _make_env()
         self.assertEqual(env.get_metrics()["step_count"], 0.0)
@@ -346,7 +309,6 @@ class TestMetricsAndState(unittest.TestCase):
 
 
 class TestConfigurablePenalty(unittest.TestCase):
-
     @patch(_MOCK_BACKEND_PATCH, side_effect=_mock_create_backend)
     def test_custom_penalty(self, _mock):
         env = GenericSandboxEnv(backend="docker", penalty=-0.1)
@@ -360,7 +322,6 @@ class TestConfigurablePenalty(unittest.TestCase):
 
 
 class TestCloseAndShutdown(unittest.TestCase):
-
     @patch(_MOCK_BACKEND_PATCH, side_effect=_mock_create_backend)
     def test_close(self, _mock):
         env = GenericSandboxEnv(backend="docker")

--- a/tests/test_generic_sandbox.py
+++ b/tests/test_generic_sandbox.py
@@ -4,7 +4,12 @@ import asyncio
 import unittest
 from unittest.mock import MagicMock, patch
 
-from open_instruct.environments.backends import ExecutionResult, SandboxBackend
+from open_instruct.environments.backends import (
+    ExecutionResult,
+    SandboxBackend,
+    SandboxContainerLostError,
+    SandboxOOMError,
+)
 from open_instruct.environments.base import EnvCall, StepResult
 from open_instruct.environments.generic_sandbox import GenericSandboxEnv
 
@@ -172,6 +177,32 @@ class TestExecuteBash(unittest.TestCase):
 
         self.assertIn("'command' parameter is required", result.result)
         self.assertEqual(result.reward, -0.05)
+
+    def test_oom_killed_sandbox_ends_the_episode(self):
+        # Without done=True the rollout keeps stepping and every later command
+        # re-trips the same dead container, burning the step budget for nothing.
+        env = _make_env()
+        backend = env._backend
+        assert backend is not None
+        with patch.object(backend, "run_command", side_effect=SandboxOOMError("container abc123 was OOM-killed")):
+            result = _step(env, "execute_bash", {"command": "echo hello"})
+
+        self.assertTrue(result.done)
+        self.assertEqual(result.reward, -0.05)
+        self.assertIn("OOM-killed", result.result)
+        self.assertEqual(result.metadata["sandbox_terminated"], "SandboxOOMError")
+
+    def test_lost_container_ends_the_episode(self):
+        env = _make_env()
+        backend = env._backend
+        assert backend is not None
+        error = SandboxContainerLostError("container abc123 disappeared")
+        with patch.object(backend, "run_command", side_effect=error):
+            result = _step(env, "execute_bash", {"command": "echo hello"})
+
+        self.assertTrue(result.done)
+        self.assertEqual(result.reward, -0.05)
+        self.assertEqual(result.metadata["sandbox_terminated"], "SandboxContainerLostError")
 
 
 class TestStrReplaceEditor(unittest.TestCase):


### PR DESCRIPTION
Replacement for #1732, rebased onto current `main` and pushed from `hamishivi/open-instruct`.

## Summary
- Add cross-process start/exec concurrency semaphores (`SWERL_DOCKER_START_CONCURRENCY` / `SWERL_DOCKER_EXEC_CONCURRENCY`) to avoid overwhelming the Docker daemon under many concurrent rollouts.
- Retry transient Docker exec `APIError`s (e.g. "database is locked") on the same container with exponential backoff, and restart-and-retry once on `NotFound` / 409 Conflict.
- Detect OOM-killed containers and raise `SandboxOOMError` so episodes terminate cleanly instead of looping.
- Add per-command `timeout` override to `run_command`, optional `docker_host` endpoint (e.g. Podman sockets), best-effort container-state diagnostics, and opt-in timing logs.
- Close containers kill-first (then stop) for faster, more reliable teardown.

## Test plan
- New unit tests in `tests/test_docker_backend.py` cover client selection, transient-error retry/backoff, retry exhaustion, and non-retry of unknown errors (mocked Docker SDK, no daemon needed).

GPU_TESTS=bypass

Made with [Cursor](https://cursor.com)
