### PR TITLE
Add DPPO loss function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
+- Add the DPPO loss function (`--loss_fn dppo`), a binary-divergence trust-region policy update (https://arxiv.org/abs/2602.04879) gated on `--use_vllm_logprobs` (https://github.com/allenai/open-instruct/pull/PR_NUMBER).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
-- Add the DPPO loss function (`--loss_fn dppo`), a binary-divergence trust-region policy update (https://arxiv.org/abs/2602.04879) gated on `--use_vllm_logprobs` (https://github.com/allenai/open-instruct/pull/PR_NUMBER).
+- Add the DPPO loss function (`--loss_fn dppo`), a binary-divergence trust-region policy update (https://arxiv.org/abs/2602.04879) gated on `--use_vllm_logprobs` (https://github.com/allenai/open-instruct/pull/1745).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -706,6 +706,21 @@ class PolicyTrainerRayProcess(RayProcess):
                     )
                     grpo_utils.accumulate_rho_histograms(rho_histograms, rho_BT)
 
+                    # DPPO enforces its trust region via a per-token mask computed from the
+                    # binary divergence between the rollout policy μ_θ' (old_logprob_BT, which
+                    # equals the vLLM logprobs when use_vllm_logprobs=True) and the trainer policy.
+                    dppo_mask_BT = None
+                    if self.args.loss_fn == grpo_utils.GRPOLossType.dppo:
+                        dppo_mask_BT, _ = grpo_utils.compute_dppo_mask(
+                            new_logprobs=new_logprobs_BT,
+                            behavior_logprobs=old_logprob_BT,
+                            advantages=data_BT.advantages[i][:, 1:],
+                            ratio=ratio_BT,
+                            response_mask=response_mask_BT,
+                            divergence_type=self.args.dppo_divergence_type,
+                            divergence_threshold=self.args.dppo_divergence_threshold,
+                        )
+
                     pg_loss_BT, clipfrac_BT, kl_BT = grpo_utils.compute_grpo_loss(
                         new_logprobs=new_logprobs_BT,
                         ratio=ratio_BT,
@@ -713,6 +728,7 @@ class PolicyTrainerRayProcess(RayProcess):
                         ref_logprobs=ref_logprobs_BT[i] if self.args.load_ref_policy else None,
                         config=self.args,
                         rho_weights=rho_BT.weights,
+                        dppo_mask=dppo_mask_BT,
                     )
 
                     per_token_loss_BT = pg_loss_BT + self.args.beta * kl_BT

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -720,6 +720,8 @@ class PolicyTrainerRayProcess(RayProcess):
                             divergence_type=self.args.dppo_divergence_type,
                             divergence_threshold=self.args.dppo_divergence_threshold,
                         )
+                        # Fraction of response tokens whose gradient DPPO masks out (1 - keep).
+                        loss_stats_B["policy/dppo_masked_frac"][i] = masked_mean(1.0 - dppo_mask_BT, response_mask_BT)
 
                     pg_loss_BT, clipfrac_BT, kl_BT = grpo_utils.compute_grpo_loss(
                         new_logprobs=new_logprobs_BT,

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -550,7 +550,12 @@ def compute_binary_divergence(
         Float tensor of the same shape as ``policy_logprobs``; entries outside
         ``response_mask`` are zeroed.
     """
-    eps = 1e-9
+    orig_dtype = policy_logprobs.dtype
+    # Upcast to float32 for numerical stability. In bfloat16 the machine epsilon is ~0.0078,
+    # so a tiny eps would make ``1.0 - eps`` round to 1.0 and ``log(1 - pi)`` blow up to -inf.
+    behavior_logprobs = behavior_logprobs.to(torch.float32)
+    policy_logprobs = policy_logprobs.to(torch.float32)
+    eps = 1e-6
     # Real logprobs are <= 0; non-response sentinel positions can be > 0
     # (see ``mask_logprobs`` / INVALID_LOGPROB). Clamp so exp() stays in [eps, 1].
     mu = torch.exp(behavior_logprobs.clamp(min=-30.0, max=0.0))
@@ -560,14 +565,15 @@ def compute_binary_divergence(
     elif divergence_type == DPPODivergenceType.kl:
         mu_clip = mu.clamp(eps, 1.0 - eps)
         pi_clip = pi.clamp(eps, 1.0 - eps)
+        # ``log1p(-x)`` keeps precision for x near 1, where ``(1 - x).log()`` loses it.
         divergence = mu_clip * (mu_clip.log() - pi_clip.log()) + (1.0 - mu_clip) * (
-            (1.0 - mu_clip).log() - (1.0 - pi_clip).log()
+            torch.log1p(-mu_clip) - torch.log1p(-pi_clip)
         )
     else:
         raise ValueError(
             f"Unknown DPPO divergence type: {divergence_type}. Expected one of {list(DPPODivergenceType)}."
         )
-    return torch.where(response_mask, divergence, torch.zeros_like(divergence))
+    return torch.where(response_mask, divergence, torch.zeros_like(divergence)).to(orig_dtype)
 
 
 def compute_dppo_mask(

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -565,7 +565,6 @@ def compute_binary_divergence(
     elif divergence_type == DPPODivergenceType.kl:
         mu_clip = mu.clamp(eps, 1.0 - eps)
         pi_clip = pi.clamp(eps, 1.0 - eps)
-        # ``log1p(-x)`` keeps precision for x near 1, where ``(1 - x).log()`` loses it.
         divergence = mu_clip * (mu_clip.log() - pi_clip.log()) + (1.0 - mu_clip) * (
             torch.log1p(-mu_clip) - torch.log1p(-pi_clip)
         )

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -69,6 +69,12 @@ def compute_pass_at_k_metrics(correct_per_prompt: np.ndarray) -> dict[str, float
 class GRPOLossType(enum.StrEnum):
     dapo = "dapo"
     cispo = "cispo"
+    dppo = "dppo"
+
+
+class DPPODivergenceType(enum.StrEnum):
+    tv = "tv"
+    kl = "kl"
 
 
 @dataclass
@@ -148,7 +154,15 @@ class GRPOExperimentConfig(
     load_ref_policy: bool = True
     """Whether to load and use a reference policy for KL penalty calculation."""
     loss_fn: GRPOLossType = GRPOLossType.dapo
-    """Whether to use DAPO or CISPO loss function."""
+    """Which policy-loss function to use: 'dapo', 'cispo', or 'dppo'."""
+    dppo_divergence_type: DPPODivergenceType = DPPODivergenceType.tv
+    """For DPPO: which binary divergence defines the trust region ('tv' or 'kl'),
+    following Eqs. 13/14 of the DPPO paper (https://arxiv.org/abs/2602.04879).
+    Only used when ``loss_fn=dppo``."""
+    dppo_divergence_threshold: float = 0.1
+    """For DPPO: the trust-region threshold δ on the binary divergence. Tokens whose
+    update would push the policy away from the rollout policy beyond δ are masked out
+    of the policy gradient. Only used when ``loss_fn=dppo``."""
     record_entropy: bool = False
     """whether to record the entropy of the policy during training. Uses extra memory."""
     use_vllm_logprobs: bool = False
@@ -248,6 +262,20 @@ class GRPOExperimentConfig(
                 "Cannot use both `use_vllm_logprobs` and `use_rho_correction`. "
                 "use_vllm_logprobs sets old_logprobs to vLLM logprobs, making the ρ correction pointless."
             )
+        if self.loss_fn == GRPOLossType.dppo:
+            if self.dppo_divergence_threshold <= 0.0:
+                raise ValueError(
+                    f"DPPO requires `dppo_divergence_threshold` > 0 (got {self.dppo_divergence_threshold})."
+                )
+            # DPPO's trust region must be anchored on the rollout policy μ_θ', so the
+            # importance ratio has to be π_θ / μ_θ'. That only holds when old_logprobs
+            # are the vLLM (rollout) logprobs.
+            if not self.use_vllm_logprobs:
+                raise ValueError(
+                    "DPPO requires `use_vllm_logprobs=True` so the importance ratio is "
+                    "anchored on the rollout policy μ_θ' (π_θ / μ_θ'). Pass `--use_vllm_logprobs` "
+                    "alongside `--loss_fn dppo`."
+                )
         if self.loss_denominator != "token" and float(self.loss_denominator) <= 0:
             raise ValueError(
                 f"loss_denominator must be a valid float greater than 0 if not 'token', got: {self.loss_denominator}"
@@ -501,6 +529,93 @@ def resolve_old_logprob(
     return result
 
 
+def compute_binary_divergence(
+    behavior_logprobs: torch.Tensor, policy_logprobs: torch.Tensor, response_mask: torch.Tensor, divergence_type: str
+) -> torch.Tensor:
+    """Per-token binary (Bernoulli) divergence between behavior and policy.
+
+    Implements the binary approximation from Eqs. 13/14 of the DPPO paper
+    (https://arxiv.org/abs/2602.04879): collapse the categorical distribution
+    over the vocabulary into a Bernoulli over ``{sampled_token, all_others}``
+    using only the per-token logprobs. This is a memory-cheap lower bound on
+    the true policy divergence that requires no extra forward passes.
+
+    Args:
+        behavior_logprobs: log μ(a_t|s_t), the rollout (vLLM) policy.
+        policy_logprobs:   log π(a_t|s_t), the current trainer policy.
+        response_mask:     bool mask selecting valid response positions.
+        divergence_type:   ``"tv"`` for total variation or ``"kl"`` for KL.
+
+    Returns:
+        Float tensor of the same shape as ``policy_logprobs``; entries outside
+        ``response_mask`` are zeroed.
+    """
+    eps = 1e-9
+    # Real logprobs are <= 0; non-response sentinel positions can be > 0
+    # (see ``mask_logprobs`` / INVALID_LOGPROB). Clamp so exp() stays in [eps, 1].
+    mu = torch.exp(behavior_logprobs.clamp(min=-30.0, max=0.0))
+    pi = torch.exp(policy_logprobs.clamp(min=-30.0, max=0.0))
+    if divergence_type == DPPODivergenceType.tv:
+        divergence = (mu - pi).abs()
+    elif divergence_type == DPPODivergenceType.kl:
+        mu_clip = mu.clamp(eps, 1.0 - eps)
+        pi_clip = pi.clamp(eps, 1.0 - eps)
+        divergence = mu_clip * (mu_clip.log() - pi_clip.log()) + (1.0 - mu_clip) * (
+            (1.0 - mu_clip).log() - (1.0 - pi_clip).log()
+        )
+    else:
+        raise ValueError(
+            f"Unknown DPPO divergence type: {divergence_type}. Expected one of {list(DPPODivergenceType)}."
+        )
+    return torch.where(response_mask, divergence, torch.zeros_like(divergence))
+
+
+def compute_dppo_mask(
+    new_logprobs: torch.Tensor,
+    behavior_logprobs: torch.Tensor,
+    advantages: torch.Tensor,
+    ratio: torch.Tensor,
+    response_mask: torch.Tensor,
+    divergence_type: str,
+    divergence_threshold: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute the DPPO trust-region mask M_t (Eq. 12).
+
+    The mask zeros out updates that would both push the policy further away from
+    the rollout (``r_t > 1`` for positive advantage, or ``r_t < 1`` for negative
+    advantage) AND have already exceeded the divergence threshold ``δ``.
+    Updates that move the ratio back towards 1 are never masked, preserving
+    PPO's beneficial asymmetric structure.
+
+    Args:
+        new_logprobs:        log π_θ at the sampled tokens.
+        behavior_logprobs:   log μ_θ' at the sampled tokens (from the rollout).
+        advantages:          per-token advantages, same shape.
+        ratio:               π_θ(y_t|s_t) / μ_θ'(y_t|s_t).
+        response_mask:       bool mask selecting valid response positions.
+        divergence_type:     ``"tv"`` or ``"kl"`` (passed to
+            :func:`compute_binary_divergence`).
+        divergence_threshold: scalar trust-region radius δ.
+
+    Returns:
+        ``(mask, divergence)`` where ``mask`` is a 0/1 float tensor and
+        ``divergence`` is the per-token binary divergence (for logging).
+    """
+    with torch.no_grad():
+        divergence = compute_binary_divergence(
+            behavior_logprobs=behavior_logprobs,
+            policy_logprobs=new_logprobs,
+            response_mask=response_mask,
+            divergence_type=divergence_type,
+        )
+        outside_region = divergence > divergence_threshold
+        bad_high = (advantages > 0) & (ratio > 1.0) & outside_region
+        bad_low = (advantages < 0) & (ratio < 1.0) & outside_region
+        bad = bad_high | bad_low
+        mask = (~bad & response_mask).to(new_logprobs.dtype)
+    return mask, divergence
+
+
 def compute_grpo_loss(
     new_logprobs: torch.Tensor,
     ratio: torch.Tensor,
@@ -508,6 +623,7 @@ def compute_grpo_loss(
     ref_logprobs: torch.Tensor | None,
     config: GRPOExperimentConfig,
     rho_weights: torch.Tensor,
+    dppo_mask: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if config.loss_fn == GRPOLossType.dapo:
         pg_losses = -advantages * ratio
@@ -519,6 +635,15 @@ def compute_grpo_loss(
         # reinforce loss, so multiply by new logprobs
         clipfrac = (ratio > 1.0 + config.clip_higher).float()
         pg_loss = -advantages * torch.clamp(ratio.detach(), max=1.0 + config.clip_higher) * new_logprobs
+    elif config.loss_fn == GRPOLossType.dppo:
+        # DPPO (https://arxiv.org/abs/2602.04879). The trust region is enforced by
+        # ``dppo_mask`` (see :func:`compute_dppo_mask`); the caller computes ``ratio``
+        # as π_θ / μ_θ' (rollout/behavior policy) — see Takeaway 2. Eq. 11:
+        # L_DPPO = E[Σ_t M_t · r_t · A_t]. No symmetric clipping.
+        pg_loss = -advantages * ratio
+        if dppo_mask is not None:
+            pg_loss = pg_loss * dppo_mask
+        clipfrac = torch.zeros_like(pg_loss)
     else:
         raise ValueError(f"Invalid loss function: {config.loss_fn}")
 

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -811,6 +811,7 @@ _SCALAR_LOSS_STAT_KEYS = [
     "objective/kl2_avg",
     "objective/kl3_avg",
     "policy/clipfrac_avg",
+    "policy/dppo_masked_frac",
     "val/ratio",
     "val/rho_clipfrac",
     "val/rho_weight",

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -551,8 +551,7 @@ def compute_binary_divergence(
         ``response_mask`` are zeroed.
     """
     orig_dtype = policy_logprobs.dtype
-    # Upcast to float32 for numerical stability. In bfloat16 the machine epsilon is ~0.0078,
-    # so a tiny eps would make ``1.0 - eps`` round to 1.0 and ``log(1 - pi)`` blow up to -inf.
+    # Upcast to float32 for numerical stability.
     behavior_logprobs = behavior_logprobs.to(torch.float32)
     policy_logprobs = policy_logprobs.to(torch.float32)
     eps = 1e-6

--- a/open_instruct/test_grpo_utils_dppo.py
+++ b/open_instruct/test_grpo_utils_dppo.py
@@ -1,0 +1,226 @@
+"""Unit tests for the DPPO loss helpers in grpo_utils."""
+
+import unittest
+from unittest.mock import MagicMock
+
+import torch
+
+from open_instruct import grpo_utils
+from open_instruct.utils import INVALID_LOGPROB
+
+
+def _make_grpo_config(**kwargs) -> grpo_utils.GRPOExperimentConfig:
+    defaults = {
+        "clip_lower": 0.2,
+        "clip_higher": 0.2,
+        "beta": 0.0,
+        "kl_estimator": 2,
+        "loss_fn": grpo_utils.GRPOLossType.dapo,
+        "load_ref_policy": False,
+        "dppo_divergence_type": grpo_utils.DPPODivergenceType.tv,
+        "dppo_divergence_threshold": 0.1,
+    }
+    defaults.update(kwargs)
+    config = MagicMock(spec=grpo_utils.GRPOExperimentConfig)
+    for key, value in defaults.items():
+        setattr(config, key, value)
+    return config
+
+
+class TestComputeBinaryDivergence(unittest.TestCase):
+    def test_tv_matches_definition(self):
+        # Eq. 13 in arXiv:2602.04879: D_TV^Bin = |μ - π|.
+        behavior_logprobs = torch.log(torch.tensor([[0.1, 0.5, 0.9]]))
+        policy_logprobs = torch.log(torch.tensor([[0.2, 0.5, 0.3]]))
+        response_mask = torch.ones_like(behavior_logprobs, dtype=torch.bool)
+
+        divergence = grpo_utils.compute_binary_divergence(
+            behavior_logprobs=behavior_logprobs,
+            policy_logprobs=policy_logprobs,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.DPPODivergenceType.tv,
+        )
+
+        expected = torch.tensor([[0.1, 0.0, 0.6]])
+        torch.testing.assert_close(divergence, expected, atol=1e-5, rtol=1e-5)
+
+    def test_kl_zero_when_distributions_match(self):
+        logprobs = torch.log(torch.tensor([[0.3, 0.7]]))
+        response_mask = torch.ones_like(logprobs, dtype=torch.bool)
+
+        divergence = grpo_utils.compute_binary_divergence(
+            behavior_logprobs=logprobs,
+            policy_logprobs=logprobs,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.DPPODivergenceType.kl,
+        )
+
+        torch.testing.assert_close(divergence, torch.zeros_like(divergence), atol=1e-5, rtol=1e-5)
+
+    def test_response_mask_zeroes_invalid_positions(self):
+        behavior_logprobs = torch.tensor([[INVALID_LOGPROB, -0.1]])
+        policy_logprobs = torch.tensor([[INVALID_LOGPROB, -2.0]])
+        response_mask = torch.tensor([[False, True]])
+
+        divergence = grpo_utils.compute_binary_divergence(
+            behavior_logprobs=behavior_logprobs,
+            policy_logprobs=policy_logprobs,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.DPPODivergenceType.tv,
+        )
+
+        self.assertEqual(float(divergence[0, 0]), 0.0)
+        self.assertGreater(float(divergence[0, 1]), 0.0)
+
+    def test_unknown_divergence_type_raises(self):
+        with self.assertRaises(ValueError):
+            grpo_utils.compute_binary_divergence(
+                behavior_logprobs=torch.zeros(1, 1),
+                policy_logprobs=torch.zeros(1, 1),
+                response_mask=torch.ones(1, 1, dtype=torch.bool),
+                divergence_type="not_a_divergence",
+            )
+
+
+class TestComputeDPPOMask(unittest.TestCase):
+    def _make_inputs(self):
+        # Behavior probs: [0.1, 0.1, 0.1]; policy probs: [0.5, 0.5, 0.5].
+        # Binary TV per token is 0.4 -> well above any small δ.
+        behavior_logprobs = torch.log(torch.tensor([[0.1, 0.1, 0.1]]))
+        new_logprobs = torch.log(torch.tensor([[0.5, 0.5, 0.5]]))
+        # ratio = exp(new - behavior) = 5 for all tokens.
+        ratio = torch.exp(new_logprobs - behavior_logprobs)
+        response_mask = torch.ones_like(new_logprobs, dtype=torch.bool)
+        return new_logprobs, behavior_logprobs, ratio, response_mask
+
+    def test_blocks_only_unsafe_directions(self):
+        new_logprobs, behavior_logprobs, ratio, response_mask = self._make_inputs()
+        # Per Eq. 12: A>0 and r>1 with D>δ -> mask. A<0 and r>1 -> safe (ratio
+        # heading back towards 1 under negative advantage), so don't mask.
+        advantages = torch.tensor([[1.0, -1.0, 0.0]])
+
+        mask, divergence = grpo_utils.compute_dppo_mask(
+            new_logprobs=new_logprobs,
+            behavior_logprobs=behavior_logprobs,
+            advantages=advantages,
+            ratio=ratio,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.DPPODivergenceType.tv,
+            divergence_threshold=0.05,
+        )
+
+        self.assertTrue(torch.all(divergence > 0.05))
+        torch.testing.assert_close(mask, torch.tensor([[0.0, 1.0, 1.0]]))
+
+    def test_below_threshold_keeps_all_tokens(self):
+        # Same μ/π so divergence is 0 everywhere.
+        logprobs = torch.log(torch.tensor([[0.4, 0.6]]))
+        ratio = torch.ones_like(logprobs)
+        response_mask = torch.ones_like(logprobs, dtype=torch.bool)
+        advantages = torch.tensor([[1.0, -1.0]])
+
+        mask, _ = grpo_utils.compute_dppo_mask(
+            new_logprobs=logprobs,
+            behavior_logprobs=logprobs,
+            advantages=advantages,
+            ratio=ratio,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.DPPODivergenceType.tv,
+            divergence_threshold=0.01,
+        )
+
+        torch.testing.assert_close(mask, torch.ones_like(mask))
+
+    def test_response_mask_zeroes_padding(self):
+        new_logprobs, behavior_logprobs, ratio, _ = self._make_inputs()
+        advantages = torch.tensor([[-1.0, -1.0, -1.0]])
+        # Only middle token is a real response position. A<0 with r>1 is the
+        # "safe" direction (moving back towards 1), so it is never masked; the
+        # padding positions are always zeroed via response_mask.
+        response_mask = torch.tensor([[False, True, False]])
+
+        mask, _ = grpo_utils.compute_dppo_mask(
+            new_logprobs=new_logprobs,
+            behavior_logprobs=behavior_logprobs,
+            advantages=advantages,
+            ratio=ratio,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.DPPODivergenceType.tv,
+            divergence_threshold=0.05,
+        )
+
+        torch.testing.assert_close(mask, torch.tensor([[0.0, 1.0, 0.0]]))
+
+    def test_mask_does_not_propagate_gradients(self):
+        new_logprobs = torch.log(torch.tensor([[0.5]])).requires_grad_(True)
+        behavior_logprobs = torch.log(torch.tensor([[0.1]]))
+        ratio = torch.exp(new_logprobs - behavior_logprobs)
+        response_mask = torch.ones_like(new_logprobs, dtype=torch.bool)
+        advantages = torch.tensor([[1.0]])
+
+        mask, _ = grpo_utils.compute_dppo_mask(
+            new_logprobs=new_logprobs,
+            behavior_logprobs=behavior_logprobs,
+            advantages=advantages,
+            ratio=ratio,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.DPPODivergenceType.tv,
+            divergence_threshold=0.05,
+        )
+
+        self.assertFalse(mask.requires_grad)
+
+
+class TestDPPOLoss(unittest.TestCase):
+    def test_dppo_loss_masks_and_has_no_symmetric_clip(self):
+        config = _make_grpo_config(loss_fn=grpo_utils.GRPOLossType.dppo)
+        new_logprobs = torch.log(torch.tensor([[0.5, 0.5]]))
+        behavior_logprobs = torch.log(torch.tensor([[0.1, 0.1]]))
+        ratio = torch.exp(new_logprobs - behavior_logprobs)
+        advantages = torch.tensor([[1.0, -1.0]])
+        response_mask = torch.ones_like(new_logprobs, dtype=torch.bool)
+        rho_weights = torch.ones_like(new_logprobs)
+
+        dppo_mask, _ = grpo_utils.compute_dppo_mask(
+            new_logprobs=new_logprobs,
+            behavior_logprobs=behavior_logprobs,
+            advantages=advantages,
+            ratio=ratio,
+            response_mask=response_mask,
+            divergence_type=config.dppo_divergence_type,
+            divergence_threshold=config.dppo_divergence_threshold,
+        )
+
+        pg_loss, clipfrac, kl = grpo_utils.compute_grpo_loss(
+            new_logprobs=new_logprobs,
+            ratio=ratio,
+            advantages=advantages,
+            ref_logprobs=None,
+            config=config,
+            rho_weights=rho_weights,
+            dppo_mask=dppo_mask,
+        )
+
+        expected = -advantages * ratio * dppo_mask
+        torch.testing.assert_close(pg_loss, expected)
+        torch.testing.assert_close(clipfrac, torch.zeros_like(clipfrac))
+        torch.testing.assert_close(kl, torch.zeros_like(kl))
+
+
+class TestDPPOConfigValidation(unittest.TestCase):
+    def test_dppo_requires_positive_threshold(self):
+        with self.assertRaisesRegex(ValueError, "dppo_divergence_threshold"):
+            grpo_utils.GRPOExperimentConfig(
+                loss_fn=grpo_utils.GRPOLossType.dppo,
+                dppo_divergence_threshold=0.0,
+                use_vllm_logprobs=True,
+                use_rho_correction=False,
+            )
+
+    def test_dppo_requires_use_vllm_logprobs(self):
+        with self.assertRaisesRegex(ValueError, "use_vllm_logprobs"):
+            grpo_utils.GRPOExperimentConfig(loss_fn=grpo_utils.GRPOLossType.dppo, use_vllm_logprobs=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replacement for #1733, rebased onto current `main` and pushed from `hamishivi/open-instruct`.

## Summary
- Add the DPPO policy-loss function (`--loss_fn dppo`) from the [DPPO paper](https://arxiv.org/abs/2602.04879).
- DPPO enforces a trust region via a per-token binary (Bernoulli) divergence between the rollout policy μ_θ' and the trainer policy: tokens whose update would push the policy away from μ_θ' beyond a threshold δ (and only in the "unsafe" direction) are masked out of the policy gradient. There is no symmetric clipping (Eq. 11: `L_DPPO = E[Σ_t M_t · r_t · A_t]`).
- New config knobs `--dppo_divergence_type` (`tv`/`kl`) and `--dppo_divergence_threshold` (δ).
- Requires `--use_vllm_logprobs` so the importance ratio is anchored on the rollout policy (π_θ / μ_θ'); validated in `__post_init__`.
- Wired into the `grpo_fast`/DeepSpeed loss path: the mask is computed at the call site from the rollout (old) logprobs and passed into `compute_grpo_loss`.

## Implementation notes
- `compute_binary_divergence` and `compute_dppo_mask` are pure, well-tested functions added to `grpo_utils.py`.
- `compute_grpo_loss` gains a `dppo` branch and an optional `dppo_mask` argument; existing `dapo`/`cispo` behavior is unchanged.

## Test plan
- New CPU unit tests in `open_instruct/test_grpo_utils_dppo.py` cover the TV/KL divergence math, response-mask zeroing, the asymmetric trust-region masking, gradient detachment, the `dppo` loss branch, and config validation (positive threshold + `use_vllm_logprobs` requirement).

GPU_TESTS=bypass

Made with [Cursor](https://cursor.com)
