### PR TITLE
Add tool-schema support to SFT tokenization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
+- Add tool-schema support to SFT tokenization: the `tools` column is parsed (JSON strings accepted) and passed to `apply_chat_template`, assistant labels are derived from offset mappings, and the tools column is consumed rather than persisted (https://github.com/allenai/open-instruct/pull/PR_NUMBER).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
-- Add tool-schema support to SFT tokenization: the `tools` column is parsed (JSON strings accepted) and passed to `apply_chat_template`, assistant labels are derived from offset mappings, and the tools column is consumed rather than persisted (https://github.com/allenai/open-instruct/pull/PR_NUMBER).
+- Add tool-schema support to SFT tokenization: the `tools` column is parsed (JSON strings accepted) and passed to `apply_chat_template`, assistant labels are derived from offset mappings, and the tools column is consumed rather than persisted (https://github.com/allenai/open-instruct/pull/1746).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -950,7 +950,8 @@ DATASET_CACHE_VERSION = "v7"
 
 def _normalize_tools_for_chat_template(tools: Any) -> list | None:
     """Normalize dataset tool schemas before passing them to chat templates."""
-    if tools is None or tools == "":
+    # pandas/CSV-backed datasets may represent a missing object cell as float('nan').
+    if tools is None or tools == "" or (isinstance(tools, float) and np.isnan(tools)):
         return None
 
     if isinstance(tools, str):

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1204,10 +1204,7 @@ def mask_labels(
 
 
 def _tokenize_tulu_sft_with_assistant_labels(
-    messages: list[dict[str, Any]],
-    tokenizer: PreTrainedTokenizer,
-    tools: list | None,
-    max_seq_length: int | None,
+    messages: list[dict[str, Any]], tokenizer: PreTrainedTokenizer, tools: list | None, max_seq_length: int | None
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # Assistant label spans are derived from `return_offsets_mapping`, which slow
     # (Python) tokenizers do not support. Fail with a clear message instead of the

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1209,6 +1209,15 @@ def _tokenize_tulu_sft_with_assistant_labels(
     tools: list[dict[str, Any]] | None,
     max_seq_length: int | None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    # Assistant label spans are derived from `return_offsets_mapping`, which slow
+    # (Python) tokenizers do not support. Fail with a clear message instead of the
+    # opaque ValueError/NotImplementedError the tokenizer would raise.
+    if not getattr(tokenizer, "is_fast", False):
+        raise ValueError(
+            f"SFT tokenization requires a fast tokenizer because it relies on "
+            f"`return_offsets_mapping` to derive assistant label spans, but got a slow tokenizer "
+            f"({type(tokenizer).__name__}). Load the tokenizer with `use_fast=True`."
+        )
     rendered = tokenizer.apply_chat_template(
         conversation=messages, tools=tools, tokenize=False, add_generation_prompt=False
     )

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -943,8 +943,35 @@ ENV_CONFIG_KEY = "env_config"
 EMPTY_DATASET_STATISTICS = {"per_dataset_stats": [], "dataset_order": []}
 
 # Cache version: increment this when transformation logic changes significantly
-# to invalidate old caches. v6: Added return_dict=False to apply_chat_template calls for transformers 5.x.
-DATASET_CACHE_VERSION = "v6"
+# to invalidate old caches. v7: SFT tokenization passes the tools column to the chat
+# template (parsing JSON-string schemas) and derives assistant labels from offset mappings.
+DATASET_CACHE_VERSION = "v7"
+
+
+def _normalize_tools_for_chat_template(tools: Any) -> list[dict[str, Any]] | None:
+    """Normalize dataset tool schemas before passing them to chat templates."""
+    if tools is None or tools == "":
+        return None
+
+    if isinstance(tools, str):
+        try:
+            tools = json.loads(tools)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{TOOLS_COLUMN_KEY} must be a JSON-encoded tool schema list, got: {tools!r}") from exc
+
+    if isinstance(tools, dict):
+        tools = [tools]
+
+    if not isinstance(tools, list):
+        raise TypeError(f"{TOOLS_COLUMN_KEY} must be a list, dict, JSON string, or None, got {type(tools).__name__}")
+
+    if not tools:
+        return None
+
+    if not all(isinstance(tool, dict) for tool in tools):
+        raise TypeError(f"{TOOLS_COLUMN_KEY} must contain JSON-schema dictionaries, got: {tools!r}")
+
+    return tools
 
 
 def _normalize_env_config_column(row: dict[str, Any]) -> None:
@@ -1173,30 +1200,81 @@ def mask_labels(
             break
 
 
-def sft_tulu_tokenize_and_truncate_v1(row: dict[str, Any], tokenizer: PreTrainedTokenizer, max_seq_length: int):
+def _tokenize_tulu_sft_with_assistant_labels(
+    messages: list[dict[str, Any]],
+    tokenizer: PreTrainedTokenizer,
+    tools: list[dict[str, Any]] | None,
+    max_seq_length: int | None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    rendered = tokenizer.apply_chat_template(
+        conversation=messages, tools=tools, tokenize=False, add_generation_prompt=False
+    )
+    tokenized = tokenizer(
+        rendered,
+        add_special_tokens=False,
+        return_offsets_mapping=True,
+        return_tensors="pt",
+        padding=False,
+        truncation=max_seq_length is not None,
+        max_length=max_seq_length,
+    )
+    input_ids = tokenized[INPUT_IDS_KEY]
+    attention_mask = tokenized[ATTENTION_MASK_KEY]
+    offsets = tokenized["offset_mapping"][0].tolist()
+    labels = torch.full_like(input_ids, MASKED_TOKEN_VALUE)
+
+    trainable_char_spans: list[tuple[int, int]] = []
+    for message_idx, message in enumerate(messages):
+        if message["role"] != "assistant":
+            continue
+
+        rendered_before = tokenizer.apply_chat_template(
+            conversation=messages[:message_idx], tools=tools, tokenize=False, add_generation_prompt=False
+        )
+        rendered_through_message = tokenizer.apply_chat_template(
+            conversation=messages[: message_idx + 1], tools=tools, tokenize=False, add_generation_prompt=False
+        )
+        if not rendered_through_message.startswith(rendered_before):
+            raise ValueError("Chat template rendering is not prefix-stable; cannot compute assistant label spans.")
+
+        assistant_text = rendered_through_message[len(rendered_before) :]
+        content_offset = assistant_text.find("\n")
+        if content_offset == -1:
+            content_offset = 0
+        else:
+            content_offset += 1
+        trainable_char_spans.append((len(rendered_before) + content_offset, len(rendered_through_message)))
+
+    for token_idx, (token_start, token_end) in enumerate(offsets):
+        if token_start == token_end:
+            continue
+        if any(span_start <= token_start and token_end <= span_end for span_start, span_end in trainable_char_spans):
+            labels[0, token_idx] = input_ids[0, token_idx]
+
+    return input_ids, attention_mask, labels
+
+
+def _sft_tulu_tokenize(row: dict[str, Any], tokenizer: PreTrainedTokenizer, max_seq_length: int | None):
     """taken directly from https://github.com/allenai/open-instruct/blob/ba11286e5b9eb00d4ce5b40ef4cac1389888416a/open_instruct/finetune.py#L385"""
     messages = row["messages"]
     if len(messages) == 0:
         raise ValueError("messages field is empty.")
-    input_ids_result = tokenizer.apply_chat_template(
-        conversation=messages,
-        tokenize=True,
-        return_tensors="pt",
-        return_dict=False,
-        padding=False,
-        truncation=True,
-        max_length=max_seq_length,
-        add_generation_prompt=False,
+    tools = _normalize_tools_for_chat_template(row.get(TOOLS_COLUMN_KEY))
+    input_ids, attention_mask, labels = _tokenize_tulu_sft_with_assistant_labels(
+        messages, tokenizer, tools, max_seq_length
     )
-    assert isinstance(input_ids_result, torch.Tensor)
-    input_ids = input_ids_result
-    labels = input_ids.clone()
-    mask_labels(labels, messages, tokenizer, max_seq_length, lambda idx, msg, _msgs: msg["role"] != "assistant")
-    attention_mask = torch.ones_like(input_ids)
     row[INPUT_IDS_KEY] = input_ids.flatten()
     row[LABELS_KEY] = labels.flatten()
     row[ATTENTION_MASK_KEY] = attention_mask.flatten()
     return row
+
+
+def sft_tulu_tokenize_without_truncation_v1(row: dict[str, Any], tokenizer: PreTrainedTokenizer):
+    return _sft_tulu_tokenize(row, tokenizer, max_seq_length=None)
+
+
+def sft_tulu_tokenize_and_truncate_v1(row: dict[str, Any], tokenizer: PreTrainedTokenizer, max_seq_length: int):
+    return _sft_tulu_tokenize(row, tokenizer, max_seq_length=max_seq_length)
 
 
 def last_turn_tulu_tokenize_and_truncate_v1(row: dict[str, Any], tokenizer: PreTrainedTokenizer, max_seq_length: int):
@@ -1204,8 +1282,10 @@ def last_turn_tulu_tokenize_and_truncate_v1(row: dict[str, Any], tokenizer: PreT
     messages = row["messages"]
     if len(messages) == 0:
         raise ValueError("messages field is empty.")
+    tools = _normalize_tools_for_chat_template(row.get(TOOLS_COLUMN_KEY))
     input_ids_result = tokenizer.apply_chat_template(
         conversation=messages,
+        tools=tools,
         tokenize=True,
         return_tensors="pt",
         return_dict=False,
@@ -1535,14 +1615,25 @@ TRANSFORM_FNS = {
     "sft_tokenize_v1": (sft_tokenize_v1, "map"),
     "sft_tokenize_mask_out_prompt_v1": (sft_tokenize_mask_out_prompt_v1, "map"),
     "sft_filter_v1": (sft_filter_v1, "filter"),
+    "sft_tulu_tokenize_without_truncation_v1": (sft_tulu_tokenize_without_truncation_v1, "map"),
     "sft_tulu_tokenize_and_truncate_v1": (sft_tulu_tokenize_and_truncate_v1, "map"),
     "sft_tulu_filter_v1": (sft_tulu_filter_v1, "filter"),
+    "last_turn_tulu_tokenize_and_truncate_v1": (last_turn_tulu_tokenize_and_truncate_v1, "map"),
     "preference_tokenize_v1": (preference_tokenize_v1, "map"),
     "preference_filter_v1": (preference_filter_v1, "filter"),
     "preference_tulu_tokenize_and_truncate_v1": (preference_tulu_tokenize_and_truncate_v1_2, "map"),
     "preference_tulu_filter_v1": (preference_tulu_filter_v1, "filter"),
     "rlvr_tokenize_v1": (rlvr_tokenize_v3, "map"),
     "rlvr_max_length_filter_v1": (rlvr_max_length_filter_v2, "filter"),
+}
+
+# SFT tokenization functions that consume the tools column — don't re-add it to target_columns
+_SFT_TOKENIZE_FNS = {
+    "sft_tokenize_v1",
+    "sft_tokenize_mask_out_prompt_v1",
+    "sft_tulu_tokenize_without_truncation_v1",
+    "sft_tulu_tokenize_and_truncate_v1",
+    "last_turn_tulu_tokenize_and_truncate_v1",
 }
 
 
@@ -1731,7 +1822,9 @@ def get_dataset_v1(dc: DatasetConfig, tc: TokenizerConfig):
         target_columns = dataset.column_names if dc.target_columns is None else dc.target_columns
         # Always preserve dataset_source if it exists
         target_columns = _preserve_column(DATASET_ORIGIN_KEY, dataset, target_columns)
-        target_columns = _preserve_column(TOOLS_COLUMN_KEY, dataset, target_columns)
+        # Only preserve tools for non-SFT transforms; SFT tokenization consumes tools and must not keep it
+        if fn_name not in _SFT_TOKENIZE_FNS:
+            target_columns = _preserve_column(TOOLS_COLUMN_KEY, dataset, target_columns)
         target_columns = _preserve_column(ENV_CONFIG_KEY, dataset, target_columns)
 
         if fn_type == "map":

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1204,7 +1204,11 @@ def mask_labels(
 
 
 def _tokenize_tulu_sft_with_assistant_labels(
-    messages: list[dict[str, Any]], tokenizer: PreTrainedTokenizer, tools: list | None, max_seq_length: int | None
+    messages: list[dict[str, Any]],
+    tokenizer: PreTrainedTokenizer,
+    tools: list | None,
+    max_seq_length: int | None,
+    last_turn_only: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # Assistant label spans are derived from `return_offsets_mapping`, which slow
     # (Python) tokenizers do not support. Fail with a clear message instead of the
@@ -1237,6 +1241,8 @@ def _tokenize_tulu_sft_with_assistant_labels(
     for message_idx, message in enumerate(messages):
         if message["role"] != "assistant":
             continue
+        if last_turn_only and message_idx < len(messages) - 1:
+            continue
 
         rendered_before = tokenizer.apply_chat_template(
             conversation=messages[:message_idx], tools=tools, tokenize=False, add_generation_prompt=False
@@ -1256,7 +1262,7 @@ def _tokenize_tulu_sft_with_assistant_labels(
         # look-alikes); fall back to the newline heuristic when the content can't be
         # located verbatim (empty content, tool calls, or template-transformed text).
         content = message.get("content")
-        content_offset = assistant_text.rfind(content) if isinstance(content, str) and content else -1
+        content_offset = assistant_text.rfind(content) if isinstance(content, str) and content.strip() else -1
         if content_offset == -1:
             newline_idx = assistant_text.find("\n")
             content_offset = 0 if newline_idx == -1 else newline_idx + 1
@@ -1298,27 +1304,18 @@ def sft_tulu_tokenize_and_truncate_v1(row: dict[str, Any], tokenizer: PreTrained
 
 
 def last_turn_tulu_tokenize_and_truncate_v1(row: dict[str, Any], tokenizer: PreTrainedTokenizer, max_seq_length: int):
-    """taken directly from https://github.com/allenai/open-instruct/blob/ba11286e5b9eb00d4ce5b40ef4cac1389888416a/open_instruct/finetune.py#L385"""
+    """Tokenize a conversation, training only on the final assistant turn.
+
+    Reuses the offset-based assistant-label derivation (which forwards the tools
+    column to the chat template) rather than the legacy mask_labels path.
+    """
     messages = row["messages"]
     if len(messages) == 0:
         raise ValueError("messages field is empty.")
     tools = _normalize_tools_for_chat_template(row.get(TOOLS_COLUMN_KEY))
-    input_ids_result = tokenizer.apply_chat_template(
-        conversation=messages,
-        tools=tools,
-        tokenize=True,
-        return_tensors="pt",
-        return_dict=False,
-        padding=False,
-        truncation=True,
-        max_length=max_seq_length,
-        add_generation_prompt=False,
+    input_ids, attention_mask, labels = _tokenize_tulu_sft_with_assistant_labels(
+        messages, tokenizer, tools, max_seq_length, last_turn_only=True
     )
-    assert isinstance(input_ids_result, torch.Tensor)
-    input_ids = input_ids_result
-    labels = input_ids.clone()
-    mask_labels(labels, messages, tokenizer, max_seq_length, lambda idx, _msg, msgs: idx < len(msgs) - 1)
-    attention_mask = torch.ones_like(input_ids)
     row[INPUT_IDS_KEY] = input_ids.flatten()
     row[LABELS_KEY] = labels.flatten()
     row[ATTENTION_MASK_KEY] = attention_mask.flatten()

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1277,14 +1277,27 @@ def _tokenize_tulu_sft_with_assistant_labels(
         # Locate where the assistant's actual content begins so the header (e.g.
         # "<|assistant|>\n" or "Assistant: ") is masked but the content is trained.
         # Prefer matching the real content string (rfind avoids matching header
-        # look-alikes); fall back to the newline heuristic when the content can't be
-        # located verbatim (empty content, tool calls, or template-transformed text).
+        # look-alikes). When the content can't be located verbatim (empty content,
+        # tool calls, or template-transformed text), determine the header exactly from
+        # the chat template's generation prompt rather than guessing with a newline.
         content = message.get("content")
         stripped_content = content.strip() if isinstance(content, str) else ""
         content_offset = assistant_text.rfind(stripped_content) if stripped_content else -1
         if content_offset == -1:
-            newline_idx = assistant_text.find("\n")
-            content_offset = 0 if newline_idx == -1 else newline_idx + 1
+            # The generation prompt is exactly the assistant header the template emits
+            # before the assistant content, so its length gives the header offset.
+            rendered_with_generation_prompt = tokenizer.apply_chat_template(
+                conversation=messages[:message_idx], tools=tools, tokenize=False, add_generation_prompt=True
+            )
+            assert isinstance(rendered_with_generation_prompt, str)
+            if not rendered_with_generation_prompt.startswith(rendered_before):
+                raise ValueError(
+                    "Cannot determine the assistant header offset for label masking: "
+                    "add_generation_prompt did not extend the rendered prefix."
+                )
+            content_offset = len(rendered_with_generation_prompt) - len(rendered_before)
+            if content_offset > len(assistant_text):
+                raise ValueError("Computed assistant content offset exceeds the assistant turn length.")
         trainable_char_spans.append((len(rendered_before) + content_offset, len(rendered_through_message)))
 
     for token_idx, (token_start, token_end) in enumerate(offsets):

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1238,11 +1238,14 @@ def _tokenize_tulu_sft_with_assistant_labels(
     offsets = tokenized["offset_mapping"][0].tolist()
     labels = torch.full_like(input_ids, MASKED_TOKEN_VALUE)
 
+    assistant_indices = [idx for idx, m in enumerate(messages) if m["role"] == "assistant"]
+    last_assistant_idx = assistant_indices[-1] if assistant_indices else -1
+
     trainable_char_spans: list[tuple[int, int]] = []
     for message_idx, message in enumerate(messages):
         if message["role"] != "assistant":
             continue
-        if last_turn_only and message_idx < len(messages) - 1:
+        if last_turn_only and message_idx != last_assistant_idx:
             continue
 
         rendered_before = tokenizer.apply_chat_template(

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1248,57 +1248,33 @@ def _tokenize_tulu_sft_with_assistant_labels(
         if last_turn_only and message_idx != last_assistant_idx:
             continue
 
-        # An empty conversation (assistant is the first message) raises in most chat
-        # templates, so treat the prefix as empty.
+        # The trainable span runs from the end of the assistant header (the generation
+        # prompt the template emits before the assistant's content) to the end of the
+        # assistant turn, i.e. content + closing tokens. ``header`` and ``through`` are
+        # taken as char offsets into the full ``rendered`` string (which is what we
+        # tokenize), so both must be a prefix of it; if not, the template/conversation
+        # is not prefix-stable (e.g. eos appended only on the final turn) and we error
+        # rather than silently mis-masking. ``messages[:0]`` is empty for an assistant
+        # opening turn, so the header is taken as empty there.
         if message_idx == 0:
-            rendered_before = ""
+            header = ""
         else:
-            rendered_before = tokenizer.apply_chat_template(
-                conversation=messages[:message_idx], tools=tools, tokenize=False, add_generation_prompt=False
-            )
-        rendered_through_message = tokenizer.apply_chat_template(
-            conversation=messages[: message_idx + 1], tools=tools, tokenize=False, add_generation_prompt=False
-        )
-        assert isinstance(rendered_before, str)
-        assert isinstance(rendered_through_message, str)
-        if not rendered_through_message.startswith(rendered_before):
-            # Some templates append eos_token only on the final turn (loop.last), so
-            # rendered_before ends with an eos that is absent at that position in the
-            # longer render. Strip a trailing eos_token and retry before failing.
-            eos_token = tokenizer.eos_token
-            if eos_token and rendered_before.endswith(eos_token):
-                stripped = rendered_before[: -len(eos_token)]
-                if rendered_through_message.startswith(stripped):
-                    rendered_before = stripped
-            if not rendered_through_message.startswith(rendered_before):
-                raise ValueError("Chat template rendering is not prefix-stable; cannot compute assistant label spans.")
-
-        assistant_text = rendered_through_message[len(rendered_before) :]
-        # Locate where the assistant's actual content begins so the header (e.g.
-        # "<|assistant|>\n" or "Assistant: ") is masked but the content is trained.
-        # Prefer matching the real content string (rfind avoids matching header
-        # look-alikes). When the content can't be located verbatim (empty content,
-        # tool calls, or template-transformed text), determine the header exactly from
-        # the chat template's generation prompt rather than guessing with a newline.
-        content = message.get("content")
-        stripped_content = content.strip() if isinstance(content, str) else ""
-        content_offset = assistant_text.rfind(stripped_content) if stripped_content else -1
-        if content_offset == -1:
-            # The generation prompt is exactly the assistant header the template emits
-            # before the assistant content, so its length gives the header offset.
-            rendered_with_generation_prompt = tokenizer.apply_chat_template(
+            header = tokenizer.apply_chat_template(
                 conversation=messages[:message_idx], tools=tools, tokenize=False, add_generation_prompt=True
             )
-            assert isinstance(rendered_with_generation_prompt, str)
-            if not rendered_with_generation_prompt.startswith(rendered_before):
-                raise ValueError(
-                    "Cannot determine the assistant header offset for label masking: "
-                    "add_generation_prompt did not extend the rendered prefix."
-                )
-            content_offset = len(rendered_with_generation_prompt) - len(rendered_before)
-            if content_offset > len(assistant_text):
-                raise ValueError("Computed assistant content offset exceeds the assistant turn length.")
-        trainable_char_spans.append((len(rendered_before) + content_offset, len(rendered_through_message)))
+        through = tokenizer.apply_chat_template(
+            conversation=messages[: message_idx + 1], tools=tools, tokenize=False, add_generation_prompt=False
+        )
+        assert isinstance(header, str)
+        assert isinstance(through, str)
+        if not (len(header) <= len(through) and rendered.startswith(header) and rendered.startswith(through)):
+            raise ValueError(
+                "Cannot compute assistant label spans for this chat template/conversation: the "
+                "rendered conversation is not prefix-stable. This happens, for example, when the "
+                "template appends eos_token only on the final turn or does not support "
+                "add_generation_prompt."
+            )
+        trainable_char_spans.append((len(header), len(through)))
 
     for token_idx, (token_start, token_end) in enumerate(offsets):
         if token_start == token_end:

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -958,6 +958,9 @@ def _normalize_tools_for_chat_template(tools: Any) -> list[dict[str, Any]] | Non
             tools = json.loads(tools)
         except json.JSONDecodeError as exc:
             raise ValueError(f"{TOOLS_COLUMN_KEY} must be a JSON-encoded tool schema list, got: {tools!r}") from exc
+        # Re-check after parsing: a JSON "null" or "" decodes to None / "".
+        if tools is None or tools == "":
+            return None
 
     if isinstance(tools, dict):
         tools = [tools]

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1257,7 +1257,16 @@ def _tokenize_tulu_sft_with_assistant_labels(
         assert isinstance(rendered_before, str)
         assert isinstance(rendered_through_message, str)
         if not rendered_through_message.startswith(rendered_before):
-            raise ValueError("Chat template rendering is not prefix-stable; cannot compute assistant label spans.")
+            # Some templates append eos_token only on the final turn (loop.last), so
+            # rendered_before ends with an eos that is absent at that position in the
+            # longer render. Strip a trailing eos_token and retry before failing.
+            eos_token = tokenizer.eos_token
+            if eos_token and rendered_before.endswith(eos_token):
+                stripped = rendered_before[: -len(eos_token)]
+                if rendered_through_message.startswith(stripped):
+                    rendered_before = stripped
+            if not rendered_through_message.startswith(rendered_before):
+                raise ValueError("Chat template rendering is not prefix-stable; cannot compute assistant label spans.")
 
         assistant_text = rendered_through_message[len(rendered_before) :]
         # Locate where the assistant's actual content begins so the header (e.g.

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1263,7 +1263,8 @@ def _tokenize_tulu_sft_with_assistant_labels(
         # look-alikes); fall back to the newline heuristic when the content can't be
         # located verbatim (empty content, tool calls, or template-transformed text).
         content = message.get("content")
-        content_offset = assistant_text.rfind(content) if isinstance(content, str) and content.strip() else -1
+        stripped_content = content.strip() if isinstance(content, str) else ""
+        content_offset = assistant_text.rfind(stripped_content) if stripped_content else -1
         if content_offset == -1:
             newline_idx = assistant_text.find("\n")
             content_offset = 0 if newline_idx == -1 else newline_idx + 1

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1858,9 +1858,11 @@ def get_dataset_v1(dc: DatasetConfig, tc: TokenizerConfig):
         target_columns = dataset.column_names if dc.target_columns is None else dc.target_columns
         # Always preserve dataset_source if it exists
         target_columns = _preserve_column(DATASET_ORIGIN_KEY, dataset, target_columns)
-        # Only preserve tools for non-SFT transforms; SFT tokenization consumes tools and must not keep it
+        # SFT tokenization consumes the tools column and must not persist it; other transforms keep it.
         if fn_name not in _SFT_TOKENIZE_FNS:
             target_columns = _preserve_column(TOOLS_COLUMN_KEY, dataset, target_columns)
+        else:
+            target_columns = [col for col in target_columns if col != TOOLS_COLUMN_KEY]
         target_columns = _preserve_column(ENV_CONFIG_KEY, dataset, target_columns)
 
         if fn_type == "map":

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1248,9 +1248,14 @@ def _tokenize_tulu_sft_with_assistant_labels(
         if last_turn_only and message_idx != last_assistant_idx:
             continue
 
-        rendered_before = tokenizer.apply_chat_template(
-            conversation=messages[:message_idx], tools=tools, tokenize=False, add_generation_prompt=False
-        )
+        # An empty conversation (assistant is the first message) raises in most chat
+        # templates, so treat the prefix as empty.
+        if message_idx == 0:
+            rendered_before = ""
+        else:
+            rendered_before = tokenizer.apply_chat_template(
+                conversation=messages[:message_idx], tools=tools, tokenize=False, add_generation_prompt=False
+            )
         rendered_through_message = tokenizer.apply_chat_template(
             conversation=messages[: message_idx + 1], tools=tools, tokenize=False, add_generation_prompt=False
         )

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -948,7 +948,7 @@ EMPTY_DATASET_STATISTICS = {"per_dataset_stats": [], "dataset_order": []}
 DATASET_CACHE_VERSION = "v7"
 
 
-def _normalize_tools_for_chat_template(tools: Any) -> list[dict[str, Any]] | None:
+def _normalize_tools_for_chat_template(tools: Any) -> list | None:
     """Normalize dataset tool schemas before passing them to chat templates."""
     if tools is None or tools == "":
         return None
@@ -1206,7 +1206,7 @@ def mask_labels(
 def _tokenize_tulu_sft_with_assistant_labels(
     messages: list[dict[str, Any]],
     tokenizer: PreTrainedTokenizer,
-    tools: list[dict[str, Any]] | None,
+    tools: list | None,
     max_seq_length: int | None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     # Assistant label spans are derived from `return_offsets_mapping`, which slow
@@ -1221,6 +1221,7 @@ def _tokenize_tulu_sft_with_assistant_labels(
     rendered = tokenizer.apply_chat_template(
         conversation=messages, tools=tools, tokenize=False, add_generation_prompt=False
     )
+    assert isinstance(rendered, str)
     tokenized = tokenizer(
         rendered,
         add_special_tokens=False,
@@ -1246,6 +1247,8 @@ def _tokenize_tulu_sft_with_assistant_labels(
         rendered_through_message = tokenizer.apply_chat_template(
             conversation=messages[: message_idx + 1], tools=tools, tokenize=False, add_generation_prompt=False
         )
+        assert isinstance(rendered_before, str)
+        assert isinstance(rendered_through_message, str)
         if not rendered_through_message.startswith(rendered_before):
             raise ValueError("Chat template rendering is not prefix-stable; cannot compute assistant label spans.")
 

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1250,17 +1250,25 @@ def _tokenize_tulu_sft_with_assistant_labels(
             raise ValueError("Chat template rendering is not prefix-stable; cannot compute assistant label spans.")
 
         assistant_text = rendered_through_message[len(rendered_before) :]
-        content_offset = assistant_text.find("\n")
+        # Locate where the assistant's actual content begins so the header (e.g.
+        # "<|assistant|>\n" or "Assistant: ") is masked but the content is trained.
+        # Prefer matching the real content string (rfind avoids matching header
+        # look-alikes); fall back to the newline heuristic when the content can't be
+        # located verbatim (empty content, tool calls, or template-transformed text).
+        content = message.get("content")
+        content_offset = assistant_text.rfind(content) if isinstance(content, str) and content else -1
         if content_offset == -1:
-            content_offset = 0
-        else:
-            content_offset += 1
+            newline_idx = assistant_text.find("\n")
+            content_offset = 0 if newline_idx == -1 else newline_idx + 1
         trainable_char_spans.append((len(rendered_before) + content_offset, len(rendered_through_message)))
 
     for token_idx, (token_start, token_end) in enumerate(offsets):
         if token_start == token_end:
             continue
-        if any(span_start <= token_start and token_end <= span_end for span_start, span_end in trainable_char_spans):
+        # Train a token if it overlaps a trainable span. Overlap (rather than full
+        # containment) keeps a boundary token that straddles the header/content edge —
+        # e.g. a leading-space-merged " ok" token in "Assistant: ok" — trainable.
+        if any(token_start < span_end and span_start < token_end for span_start, span_end in trainable_char_spans):
             labels[0, token_idx] = input_ids[0, token_idx]
 
     return input_ids, attention_mask, labels

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1256,15 +1256,31 @@ def _tokenize_tulu_sft_with_assistant_labels(
         # is not prefix-stable (e.g. eos appended only on the final turn) and we error
         # rather than silently mis-masking. ``messages[:0]`` is empty for an assistant
         # opening turn, so the header is taken as empty there.
-        if message_idx == 0:
-            header = ""
-        else:
-            header = tokenizer.apply_chat_template(
-                conversation=messages[:message_idx], tools=tools, tokenize=False, add_generation_prompt=True
+        #
+        # Rendering a partial conversation is itself template-dependent: some templates
+        # (e.g. Qwen3.5) raise when handed a prefix containing only system/tool turns and
+        # no user turn, which happens when the first assistant turn is not preceded by a
+        # user turn (``[system, assistant, ...]``). We cannot derive the span boundary
+        # without that render, so surface an actionable error rather than the template's
+        # opaque one.
+        try:
+            if message_idx == 0:
+                header = ""
+            else:
+                header = tokenizer.apply_chat_template(
+                    conversation=messages[:message_idx], tools=tools, tokenize=False, add_generation_prompt=True
+                )
+            through = tokenizer.apply_chat_template(
+                conversation=messages[: message_idx + 1], tools=tools, tokenize=False, add_generation_prompt=False
             )
-        through = tokenizer.apply_chat_template(
-            conversation=messages[: message_idx + 1], tools=tools, tokenize=False, add_generation_prompt=False
-        )
+        except Exception as exc:
+            roles = [m["role"] for m in messages[: message_idx + 1]]
+            raise ValueError(
+                f"Chat template {type(tokenizer).__name__} failed to render the conversation prefix "
+                f"{roles} while deriving assistant label spans for message {message_idx}. Some "
+                f"templates reject prefixes that contain no user turn; such conversations are not "
+                f"supported by this tokenization path."
+            ) from exc
         assert isinstance(header, str)
         assert isinstance(through, str)
         if not (len(header) <= len(through) and rendered.startswith(header) and rendered.startswith(through)):
@@ -1652,10 +1668,12 @@ TRANSFORM_FNS = {
     "rlvr_max_length_filter_v1": (rlvr_max_length_filter_v2, "filter"),
 }
 
-# SFT tokenization functions that consume the tools column — don't re-add it to target_columns
+# SFT tokenization functions that consume the tools column — don't re-add it to target_columns.
+# Only list functions that actually forward `tools` to the chat template: for a function that
+# ignores the column, dropping it here would silently discard the tool schemas instead of
+# rendering them. `sft_tokenize_v1` / `sft_tokenize_mask_out_prompt_v1` do not support tools,
+# so they keep the column (as before tool support was added).
 _SFT_TOKENIZE_FNS = {
-    "sft_tokenize_v1",
-    "sft_tokenize_mask_out_prompt_v1",
     "sft_tulu_tokenize_without_truncation_v1",
     "sft_tulu_tokenize_and_truncate_v1",
     "last_turn_tulu_tokenize_and_truncate_v1",

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -441,6 +441,17 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
         self.assertIn("HELLOWORLD", trained_text)
         self.assertNotIn("hi", trained_text)
 
+    def test_conversation_starting_with_assistant(self):
+        # message_idx == 0 -> messages[:0] is empty; must not call apply_chat_template([]).
+        row = {"messages": [{"role": "assistant", "content": "OPENINGLINE"}]}
+        out = open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
+            dict(row), self.tokenizer, max_seq_length=4096
+        )
+        input_ids = out[open_instruct.dataset_transformation.INPUT_IDS_KEY].tolist()
+        labels = out[open_instruct.dataset_transformation.LABELS_KEY].tolist()
+        trained_text = self.tokenizer.decode([tid for tid, lab in zip(input_ids, labels) if lab != -100])
+        self.assertIn("OPENINGLINE", trained_text)
+
     def test_slow_tokenizer_raises_clear_error(self):
         slow_tokenizer = mock.MagicMock()
         slow_tokenizer.is_fast = False

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -1,6 +1,7 @@
 import gc
 import gzip
 import hashlib
+import json
 import os
 import shutil
 import tempfile
@@ -314,6 +315,85 @@ class TestMaskLabels(unittest.TestCase):
         self.assertTrue(
             any(x != -100 for x in flat[boundary:]), f"Tokens from {boundary} onward should have kept tokens"
         )
+
+
+class TestToolNormalization(unittest.TestCase):
+    def test_normalize_tools_accepts_json_encoded_schema_list(self):
+        tool_schema = {
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": "Execute bash",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        }
+        tools = open_instruct.dataset_transformation._normalize_tools_for_chat_template(json.dumps([tool_schema]))
+
+        self.assertEqual(tools, [tool_schema])
+
+    def test_normalize_tools_wraps_single_dict(self):
+        tool_schema = {"type": "function", "function": {"name": "bash"}}
+        self.assertEqual(
+            open_instruct.dataset_transformation._normalize_tools_for_chat_template(tool_schema), [tool_schema]
+        )
+
+    def test_normalize_tools_treats_empty_as_none(self):
+        self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template(None))
+        self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template(""))
+        self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template([]))
+
+    def test_normalize_tools_rejects_tool_name_lists(self):
+        with self.assertRaises(TypeError):
+            open_instruct.dataset_transformation._normalize_tools_for_chat_template(["bash"])
+
+    def test_normalize_tools_rejects_invalid_json(self):
+        with self.assertRaises(ValueError):
+            open_instruct.dataset_transformation._normalize_tools_for_chat_template("{not json")
+
+
+class TestSFTTuluTokenizeLabels(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH)
+
+    def test_only_assistant_tokens_are_trainable(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "What is 2+2?"},
+                {"role": "assistant", "content": "The answer is 4."},
+            ]
+        }
+        out = open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
+            dict(row), self.tokenizer, max_seq_length=4096
+        )
+        input_ids = out[open_instruct.dataset_transformation.INPUT_IDS_KEY].tolist()
+        labels = out[open_instruct.dataset_transformation.LABELS_KEY].tolist()
+
+        self.assertEqual(len(input_ids), len(labels))
+        # At least one assistant token is trainable, and every trainable label matches its input id.
+        self.assertTrue(any(label != -100 for label in labels))
+        for input_id, label in zip(input_ids, labels):
+            if label != -100:
+                self.assertEqual(label, input_id)
+        # The prompt prefix (first token, part of the user turn) must be masked.
+        self.assertEqual(labels[0], -100)
+
+    def test_tools_column_is_consumed_and_accepts_json_string(self):
+        # The test chat template ignores tools, but tokenization must still succeed
+        # when a JSON-encoded tools column is present (it is parsed, not crashed on).
+        row = {
+            "messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}],
+            "tools": json.dumps([{"type": "function", "function": {"name": "bash"}}]),
+        }
+        out = open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
+            dict(row), self.tokenizer, max_seq_length=4096
+        )
+        self.assertIn(open_instruct.dataset_transformation.LABELS_KEY, out)
+
+    def test_without_truncation_variant_runs(self):
+        row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello there"}]}
+        out = open_instruct.dataset_transformation.sft_tulu_tokenize_without_truncation_v1(dict(row), self.tokenizer)
+        self.assertTrue(any(label != -100 for label in out[open_instruct.dataset_transformation.LABELS_KEY].tolist()))
 
 
 if __name__ == "__main__":

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -443,6 +443,7 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
             "{% if m['role'] == 'user' %}User: {{ m['content'] }}\n"
             "{% elif m['role'] == 'assistant' %}Assistant: {{ m['content'] }}{{ eos_token }}{% endif %}"
             "{% endfor %}"
+            "{% if add_generation_prompt %}Assistant: {% endif %}"
         )
         row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok\ndone"}]}
         out = open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
@@ -457,24 +458,20 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
         self.assertNotIn("Assistant", trained_text)
         self.assertNotIn("User", trained_text)
 
-    def test_template_appending_eos_only_on_last_turn(self):
-        # A template that appends eos_token only on the final turn (loop.last) makes
-        # rendered_before end with an eos absent in the longer render; the prefix check
-        # must recover via the eos-strip fallback rather than raising.
+    def test_template_appending_eos_only_on_last_turn_raises(self):
+        # A template that appends eos_token only on the final turn (loop.last) is not
+        # prefix-stable, so label-span derivation should raise a clear error rather than
+        # silently mis-mask.
         tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH)
         tokenizer.chat_template = (
             "{% for m in messages %}{{ m['role'] }}: {{ m['content'] }}"
             "{% if loop.last %}{{ eos_token }}{% endif %}\n{% endfor %}"
         )
         row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "HELLOWORLD"}]}
-        out = open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
-            dict(row), tokenizer, max_seq_length=4096
-        )
-        input_ids = out[open_instruct.dataset_transformation.INPUT_IDS_KEY].tolist()
-        labels = out[open_instruct.dataset_transformation.LABELS_KEY].tolist()
-        trained_text = tokenizer.decode([tid for tid, lab in zip(input_ids, labels) if lab != -100])
-        self.assertIn("HELLOWORLD", trained_text)
-        self.assertNotIn("hi", trained_text)
+        with self.assertRaisesRegex(ValueError, "prefix-stable"):
+            open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
+                dict(row), tokenizer, max_seq_length=4096
+            )
 
     def test_conversation_starting_with_assistant(self):
         # message_idx == 0 -> messages[:0] is empty; must not call apply_chat_template([]).
@@ -549,6 +546,7 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
             "messages": [
                 {"role": "user", "content": "first question"},
                 {"role": "assistant", "content": "FIRSTANSWER"},
+                {"role": "user", "content": "second question"},
                 {"role": "assistant", "content": "SECONDANSWER"},
                 {"role": "user", "content": "trailing user message"},
             ]

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -342,6 +342,11 @@ class TestToolNormalization(unittest.TestCase):
         self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template(""))
         self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template([]))
 
+    def test_normalize_tools_treats_json_null_and_empty_string_as_none(self):
+        self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template("null"))
+        self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template('""'))
+        self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template("[]"))
+
     def test_normalize_tools_rejects_tool_name_lists(self):
         with self.assertRaises(TypeError):
             open_instruct.dataset_transformation._normalize_tools_for_chat_template(["bash"])

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -422,6 +422,25 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
         self.assertNotIn("Assistant", trained_text)
         self.assertNotIn("User", trained_text)
 
+    def test_template_appending_eos_only_on_last_turn(self):
+        # A template that appends eos_token only on the final turn (loop.last) makes
+        # rendered_before end with an eos absent in the longer render; the prefix check
+        # must recover via the eos-strip fallback rather than raising.
+        tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH)
+        tokenizer.chat_template = (
+            "{% for m in messages %}{{ m['role'] }}: {{ m['content'] }}"
+            "{% if loop.last %}{{ eos_token }}{% endif %}\n{% endfor %}"
+        )
+        row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "HELLOWORLD"}]}
+        out = open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
+            dict(row), tokenizer, max_seq_length=4096
+        )
+        input_ids = out[open_instruct.dataset_transformation.INPUT_IDS_KEY].tolist()
+        labels = out[open_instruct.dataset_transformation.LABELS_KEY].tolist()
+        trained_text = tokenizer.decode([tid for tid, lab in zip(input_ids, labels) if lab != -100])
+        self.assertIn("HELLOWORLD", trained_text)
+        self.assertNotIn("hi", trained_text)
+
     def test_slow_tokenizer_raises_clear_error(self):
         slow_tokenizer = mock.MagicMock()
         slow_tokenizer.is_fast = False

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -487,6 +487,28 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
         trained_text = self.tokenizer.decode([tid for tid, lab in zip(input_ids, labels) if lab != -100])
         self.assertIn("OPENINGLINE", trained_text)
 
+    def test_content_offset_falls_back_to_generation_prompt(self):
+        # Template uppercases assistant content so rfind(content) fails, forcing the
+        # add_generation_prompt header-length fallback (no newline heuristic).
+        tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH)
+        tokenizer.chat_template = (
+            "{% for m in messages %}"
+            "{% if m['role'] == 'user' %}User: {{ m['content'] }}\n"
+            "{% elif m['role'] == 'assistant' %}Assistant: {{ m['content'] | upper }}{% endif %}"
+            "{% endfor %}"
+            "{% if add_generation_prompt %}Assistant: {% endif %}"
+        )
+        row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]}
+        out = open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
+            dict(row), tokenizer, max_seq_length=4096
+        )
+        input_ids = out[open_instruct.dataset_transformation.INPUT_IDS_KEY].tolist()
+        labels = out[open_instruct.dataset_transformation.LABELS_KEY].tolist()
+        trained_text = tokenizer.decode([tid for tid, lab in zip(input_ids, labels) if lab != -100])
+        self.assertIn("HELLO", trained_text)
+        self.assertNotIn("Assistant", trained_text)
+        self.assertNotIn("hi", trained_text)
+
     def test_slow_tokenizer_raises_clear_error(self):
         slow_tokenizer = mock.MagicMock()
         slow_tokenizer.is_fast = False

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
 import torch
 from parameterized import parameterized
@@ -394,6 +395,16 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
             dict(row), self.tokenizer, max_seq_length=4096
         )
         self.assertIn(open_instruct.dataset_transformation.LABELS_KEY, out)
+
+    def test_slow_tokenizer_raises_clear_error(self):
+        slow_tokenizer = mock.MagicMock()
+        slow_tokenizer.is_fast = False
+        type(slow_tokenizer).__name__ = "FakeSlowTokenizer"
+        row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]}
+        with self.assertRaisesRegex(ValueError, "fast tokenizer"):
+            open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
+                dict(row), slow_tokenizer, max_seq_length=4096
+            )
 
     def test_without_truncation_variant_runs(self):
         row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello there"}]}

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -342,6 +342,7 @@ class TestToolNormalization(unittest.TestCase):
         self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template(None))
         self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template(""))
         self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template([]))
+        self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template(float("nan")))
 
     def test_normalize_tools_treats_json_null_and_empty_string_as_none(self):
         self.assertIsNone(open_instruct.dataset_transformation._normalize_tools_for_chat_template("null"))

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -396,6 +396,31 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
         )
         self.assertIn(open_instruct.dataset_transformation.LABELS_KEY, out)
 
+    def test_content_span_handles_header_without_newline_and_multiline_content(self):
+        # A "simple_chat"-style template: the assistant header ("Assistant: ") has no
+        # trailing newline, and the content itself spans a newline. The newline heuristic
+        # would mis-mask here; matching the actual content keeps the full content trainable
+        # and the header masked.
+        tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH)
+        tokenizer.chat_template = (
+            "{% for m in messages %}"
+            "{% if m['role'] == 'user' %}User: {{ m['content'] }}\n"
+            "{% elif m['role'] == 'assistant' %}Assistant: {{ m['content'] }}{{ eos_token }}{% endif %}"
+            "{% endfor %}"
+        )
+        row = {"messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "ok\ndone"}]}
+        out = open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
+            dict(row), tokenizer, max_seq_length=4096
+        )
+        input_ids = out[open_instruct.dataset_transformation.INPUT_IDS_KEY].tolist()
+        labels = out[open_instruct.dataset_transformation.LABELS_KEY].tolist()
+        trained_ids = [tid for tid, lab in zip(input_ids, labels) if lab != -100]
+        trained_text = tokenizer.decode(trained_ids)
+        self.assertIn("ok", trained_text)
+        self.assertIn("done", trained_text)
+        self.assertNotIn("Assistant", trained_text)
+        self.assertNotIn("User", trained_text)
+
     def test_slow_tokenizer_raises_clear_error(self):
         slow_tokenizer = mock.MagicMock()
         slow_tokenizer.is_fast = False

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -151,6 +151,41 @@ class TestCachedDataset(unittest.TestCase):
             dataset_hash.update(str(row["input_ids"]).encode())
         self.assertEqual(dataset_hash.hexdigest(), GOLD_SFT["hash"])
 
+    def test_sft_tokenization_drops_tools_column_when_target_columns_none(self):
+        # With target_columns=None it defaults to all dataset columns (including "tools");
+        # SFT tokenization must still drop the consumed tools column.
+        tc = open_instruct.dataset_transformation.TokenizerConfig(
+            tokenizer_name_or_path=TOKENIZER_PATH,
+            tokenizer_revision="main",
+            use_fast=True,
+            chat_template_name="tulu",
+            add_bos=False,
+        )
+        jsonl_path = os.path.join(self.temp_dir.name, "sft_with_tools.jsonl")
+        with open(jsonl_path, "w") as f:
+            for _ in range(3):
+                f.write(
+                    json.dumps(
+                        {
+                            "messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}],
+                            "tools": None,
+                        }
+                    )
+                    + "\n"
+                )
+
+        dataset = open_instruct.dataset_transformation.get_cached_dataset_tulu(
+            [jsonl_path, "1.0"],
+            ["train"],
+            tc,
+            ["sft_tulu_tokenize_and_truncate_v1", "sft_tulu_filter_v1"],
+            [{"max_seq_length": 4096}, {}],
+            target_columns=None,
+            dataset_skip_cache=True,
+            dataset_local_cache_dir=self.temp_dir.name,
+        )
+        self.assertNotIn(open_instruct.dataset_transformation.TOOLS_COLUMN_KEY, dataset.column_names)
+
     def test_get_cached_dataset_tulu_preference(self):
         tc = open_instruct.dataset_transformation.TokenizerConfig(
             tokenizer_name_or_path=TOKENIZER_PATH,

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -436,6 +436,25 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
         out = open_instruct.dataset_transformation.sft_tulu_tokenize_without_truncation_v1(dict(row), self.tokenizer)
         self.assertTrue(any(label != -100 for label in out[open_instruct.dataset_transformation.LABELS_KEY].tolist()))
 
+    def test_last_turn_only_trains_final_assistant_turn(self):
+        row = {
+            "messages": [
+                {"role": "user", "content": "first question"},
+                {"role": "assistant", "content": "FIRSTANSWER"},
+                {"role": "user", "content": "second question"},
+                {"role": "assistant", "content": "SECONDANSWER"},
+            ]
+        }
+        out = open_instruct.dataset_transformation.last_turn_tulu_tokenize_and_truncate_v1(
+            dict(row), self.tokenizer, max_seq_length=4096
+        )
+        input_ids = out[open_instruct.dataset_transformation.INPUT_IDS_KEY].tolist()
+        labels = out[open_instruct.dataset_transformation.LABELS_KEY].tolist()
+        trained_text = self.tokenizer.decode([tid for tid, lab in zip(input_ids, labels) if lab != -100])
+        # Only the final assistant turn is trained; the earlier assistant turn is masked.
+        self.assertIn("SECONDANSWER", trained_text)
+        self.assertNotIn("FIRSTANSWER", trained_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -456,6 +456,26 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
         self.assertIn("SECONDANSWER", trained_text)
         self.assertNotIn("FIRSTANSWER", trained_text)
 
+    def test_last_turn_only_when_conversation_does_not_end_with_assistant(self):
+        # Trailing non-assistant message must not cause the real last assistant turn to be skipped.
+        row = {
+            "messages": [
+                {"role": "user", "content": "first question"},
+                {"role": "assistant", "content": "FIRSTANSWER"},
+                {"role": "assistant", "content": "SECONDANSWER"},
+                {"role": "user", "content": "trailing user message"},
+            ]
+        }
+        out = open_instruct.dataset_transformation.last_turn_tulu_tokenize_and_truncate_v1(
+            dict(row), self.tokenizer, max_seq_length=4096
+        )
+        input_ids = out[open_instruct.dataset_transformation.INPUT_IDS_KEY].tolist()
+        labels = out[open_instruct.dataset_transformation.LABELS_KEY].tolist()
+        trained_text = self.tokenizer.decode([tid for tid, lab in zip(input_ids, labels) if lab != -100])
+        self.assertIn("SECONDANSWER", trained_text)
+        self.assertNotIn("FIRSTANSWER", trained_text)
+        self.assertNotIn("trailing user message", trained_text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/open_instruct/test_dataset_transformation.py
+++ b/open_instruct/test_dataset_transformation.py
@@ -186,6 +186,43 @@ class TestCachedDataset(unittest.TestCase):
         )
         self.assertNotIn(open_instruct.dataset_transformation.TOOLS_COLUMN_KEY, dataset.column_names)
 
+    def test_tools_column_preserved_for_transforms_that_do_not_consume_it(self):
+        # sft_tokenize_v1 does not forward `tools` to the chat template, so the column must
+        # survive tokenization. Dropping it there would silently discard the tool schemas
+        # without ever rendering them into the prompt.
+        tc = open_instruct.dataset_transformation.TokenizerConfig(
+            tokenizer_name_or_path=TOKENIZER_PATH,
+            tokenizer_revision="main",
+            use_fast=True,
+            chat_template_name="tulu",
+            add_bos=False,
+        )
+        jsonl_path = os.path.join(self.temp_dir.name, "sft_with_tools_preserved.jsonl")
+        tools = [{"type": "function", "function": {"name": "search", "parameters": {}}}]
+        with open(jsonl_path, "w") as f:
+            for _ in range(3):
+                f.write(
+                    json.dumps(
+                        {
+                            "messages": [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}],
+                            "tools": tools,
+                        }
+                    )
+                    + "\n"
+                )
+
+        dataset = open_instruct.dataset_transformation.get_cached_dataset_tulu(
+            [jsonl_path, "1.0"],
+            ["train"],
+            tc,
+            ["sft_tokenize_v1"],
+            [{}],
+            target_columns=None,
+            dataset_skip_cache=True,
+            dataset_local_cache_dir=self.temp_dir.name,
+        )
+        self.assertIn(open_instruct.dataset_transformation.TOOLS_COLUMN_KEY, dataset.column_names)
+
     def test_get_cached_dataset_tulu_preference(self):
         tc = open_instruct.dataset_transformation.TokenizerConfig(
             tokenizer_name_or_path=TOKENIZER_PATH,
@@ -457,6 +494,30 @@ class TestSFTTuluTokenizeLabels(unittest.TestCase):
         self.assertIn("done", trained_text)
         self.assertNotIn("Assistant", trained_text)
         self.assertNotIn("User", trained_text)
+
+    def test_template_rejecting_prefix_without_user_turn_raises_clear_error(self):
+        # Some templates (e.g. Qwen3.5) raise when handed a prefix containing only
+        # system/tool turns. That happens here for the assistant at index 1, whose prefix
+        # is [system]. The error should name the situation, not surface the template's.
+        tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_PATH)
+        tokenizer.chat_template = (
+            "{% if messages | selectattr('role', 'equalto', 'user') | list | length == 0 %}"
+            "{{ raise_exception('conversation must contain a user turn') }}{% endif %}"
+            "{% for m in messages %}{{ m['role'] }}: {{ m['content'] }}\n{% endfor %}"
+            "{% if add_generation_prompt %}assistant: {% endif %}"
+        )
+        row = {
+            "messages": [
+                {"role": "system", "content": "be nice"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "bye"},
+            ]
+        }
+        with self.assertRaisesRegex(ValueError, "no user turn"):
+            open_instruct.dataset_transformation.sft_tulu_tokenize_and_truncate_v1(
+                dict(row), tokenizer, max_seq_length=4096
+            )
 
     def test_template_appending_eos_only_on_last_turn_raises(self):
         # A template that appends eos_token only on the final turn (loop.last) is not


### PR DESCRIPTION
Replacement for #1734, rebased onto current `main` and pushed from `hamishivi/open-instruct`.

## Summary
- Pass the dataset `tools` column to `apply_chat_template` during SFT tokenization so tool schemas are rendered into the prompt. A new `_normalize_tools_for_chat_template` helper accepts a list/dict/JSON-string (and treats empty/`None` as no tools), rejecting tool-name-string lists.
- Derive assistant labels from token offset mappings against the rendered conversation (prefix-stable per-assistant-turn spans) instead of `mask_labels`, so labels stay correct when tools are present.
- Consume the `tools` column during SFT tokenization rather than persisting it to the cached dataset (`_SFT_TOKENIZE_FNS`).
- Add `sft_tulu_tokenize_without_truncation_v1` and register `last_turn_tulu_tokenize_and_truncate_v1` (which now also forwards `tools`).
- Bump `DATASET_CACHE_VERSION` to `v7` to invalidate stale caches.

## Notes
- For the no-tools tulu path the new tokenizer is byte-identical to the previous `mask_labels` path: the existing `GOLD_SFT` golden-hash test passes unchanged.
- This PR intentionally excludes the unrelated `dataset_config_name` plumbing and the `sft_filter_v1` rename that were bundled alongside this work on the source branch.

## Test plan
- `uv run pytest open_instruct/test_dataset_transformation.py` (20 passed locally), including:
  - existing `GOLD_SFT`/preference/rlvr golden-hash tests (unchanged),
  - new `TestToolNormalization` (JSON parsing, dict-wrapping, empty handling, rejection cases),
  - new `TestSFTTuluTokenizeLabels` (assistant-only trainable labels, tools column consumed, no-truncation variant).

GPU_TESTS=bypass

Made with [Cursor](https://cursor.com)
