### PR TITLE
Skip ray start in ray_node_setup.sh for single-node jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Fixed
+- Skip `ray start` in `ray_node_setup.sh` for single-node jobs (detected via the `MASON_NUM_NODES` env var injected by `mason.py`), letting `ray.init()` pick a random port; previously two single-node jobs packed onto the same Beaker node collided on the hardcoded Ray head port and crashed at startup (https://github.com/allenai/open-instruct/pull/1752).

--- a/configs/beaker_configs/ray_node_setup.sh
+++ b/configs/beaker_configs/ray_node_setup.sh
@@ -13,11 +13,21 @@ echo PATH=$PATH
 
 # python3 -c "import os, ray; print(os.path.dirname(ray.__file__))"
 
-BEAKER_LEADER_REPLICA_IP=$(getent hosts ${BEAKER_LEADER_REPLICA_HOSTNAME} | awk '{print $1}')
-
 RAY_NODE_PORT=8888
 mkdir -p "$HOME/.triton/autotune"  # Create Triton autotune cache directory to silence warnings
 ray stop --force
+
+if [ "${MASON_NUM_NODES:-1}" == "1" ]; then
+    # Single-node job: skip `ray start` entirely and let `ray.init()` pick a
+    # random port. Beaker can pack multiple single-node jobs onto the same
+    # physical node, and a hardcoded Ray head port causes them to collide.
+    # This script is `source`d, so `return` (not `exit`) lets the caller's
+    # `&&`-chained training command still run.
+    echo "Single-node job detected (MASON_NUM_NODES=1); skipping ray start, ray.init() will use a random port"
+    return 0
+fi
+
+BEAKER_LEADER_REPLICA_IP=$(getent hosts ${BEAKER_LEADER_REPLICA_HOSTNAME} | awk '{print $1}')
 
 if [ "$BEAKER_REPLICA_RANK" == "0" ]; then
     echo "Starting Ray head node"

--- a/configs/beaker_configs/ray_node_setup.sh
+++ b/configs/beaker_configs/ray_node_setup.sh
@@ -24,7 +24,7 @@ if [ "${MASON_NUM_NODES:-1}" == "1" ]; then
     # This script is `source`d, so `return` (not `exit`) lets the caller's
     # `&&`-chained training command still run.
     echo "Single-node job detected (MASON_NUM_NODES=1); skipping ray start, ray.init() will use a random port"
-    return 0
+    return 0 2>/dev/null || exit 0
 fi
 
 BEAKER_LEADER_REPLICA_IP=$(getent hosts ${BEAKER_LEADER_REPLICA_HOSTNAME} | awk '{print $1}')

--- a/mason.py
+++ b/mason.py
@@ -286,6 +286,8 @@ def get_env_vars(
         [beaker.BeakerEnvVar(name=env_var["name"], value=env_var["value"]) for env_var in additional_env_vars]
     )
 
+    env_vars.append(beaker.BeakerEnvVar(name="MASON_NUM_NODES", value=str(num_nodes)))
+
     # add user-specific secrets
     env_vars.extend(
         [beaker.BeakerEnvVar(name=secret["name"], secret=secret["value"]) for secret in additional_secrets]


### PR DESCRIPTION
## Summary
- Two single-node Beaker jobs can be packed onto the same physical node; both previously called `ray start --head --port=8888`, colliding on the hardcoded Ray head port and crashing at startup.
- `mason.py` now injects a `MASON_NUM_NODES` env var into every launched task.
- `ray_node_setup.sh` skips `ray start` entirely when `MASON_NUM_NODES` is `1`, letting `ray.init()` pick a random port instead.

GPU_TESTS=bypass

## Test plan
- [x] `make style && make quality`
- [x] `uv run pytest test_mason.py -q`
- [x] Verified locally (outside the real script) that `return 0` inside a `source`d script lets the caller's `&&`-chained command still run, unlike `exit 0` which would have killed the whole Beaker task before the training command started.