### PR TITLE
Add keep_last_n_saves to bound intermediate HF-format model saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
+- Add `keep_last_n_saves` to `grpo.py`/`grpo_fast.py` to bound the number of intermediate HuggingFace-format model saves kept under `{output_dir}_checkpoints` (-1 for unlimited, matching current behavior); on the OLMo-core (`grpo.py`) training path, periodic HF-format saves following `save_freq` are now performed via a new `HFCheckpointCallback`, since previously `save_freq` was a no-op there (only the final model was saved in HF format). Builds on the `keep_last_n_checkpoints`/`max_checkpoints` wiring from https://github.com/allenai/open-instruct/pull/1701 (https://github.com/allenai/open-instruct/pull/1754).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/open_instruct/grpo_callbacks.py
+++ b/open_instruct/grpo_callbacks.py
@@ -7,6 +7,7 @@ These callbacks handle:
 """
 
 import contextlib
+import os
 import re
 import time
 from collections.abc import Callable
@@ -18,6 +19,7 @@ import ray.exceptions
 import ray.util.queue as ray_queue
 import torch
 import torch.nn as nn
+import transformers
 from datasets import Dataset
 from olmo_core.train.callbacks import Callback
 from olmo_core.train.train_module import TransformerTrainModule
@@ -25,7 +27,7 @@ from torch.distributed._composable.fsdp import FSDPModule
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 from open_instruct import data_loader as data_loader_lib
-from open_instruct import grpo_utils, logger_utils, utils, vllm_utils
+from open_instruct import grpo_utils, logger_utils, olmo_core_utils, utils, vllm_utils
 
 logger = logger_utils.setup_logger(__name__)
 
@@ -224,6 +226,47 @@ class RefPolicyUpdateCallback(Callback):
         finally:
             for m in fsdp2_submodules:
                 m.reshard()
+
+
+@dataclass
+class HFCheckpointCallback(Callback):
+    """Periodically saves a HuggingFace-format model, mirroring grpo_fast.py's
+    maybe_save_checkpoint on the streaming/DeepSpeed path.
+
+    The OLMo-core Trainer's own CheckpointerCallback only saves native (resumable)
+    checkpoints; this callback additionally converts and writes an HF-format copy
+    every ``save_freq`` steps to ``{checkpoint_dir}/step_N``, trimming old saves
+    down to ``keep_last_n_saves``.
+    """
+
+    model_name_or_path: str
+    tokenizer: transformers.PreTrainedTokenizerBase
+    checkpoint_dir: str
+    save_freq: int
+    keep_last_n_saves: int
+    rank: int
+
+    @property
+    def train_module(self) -> TransformerTrainModule:
+        return cast(TransformerTrainModule, self.trainer.train_module)
+
+    def post_step(self) -> None:
+        step = self.trainer.global_step
+        if self.save_freq <= 0 or step % self.save_freq != 0:
+            return
+
+        state_dict = self.train_module.model.state_dict()
+        state_dict = {
+            k: v.full_tensor().cpu() if hasattr(v, "full_tensor") else v.cpu() for k, v in state_dict.items()
+        }
+        if self.rank != 0:
+            return
+
+        step_dir = os.path.join(self.checkpoint_dir, f"step_{step}")
+        os.makedirs(step_dir, exist_ok=True)
+        olmo_core_utils.save_state_dict_as_hf(state_dict, step_dir, self.model_name_or_path, self.tokenizer)
+        logger.info(f"Saved intermediate HuggingFace checkpoint at step {step} to {step_dir}")
+        utils.clean_last_n_checkpoints(self.checkpoint_dir, self.keep_last_n_saves)
 
 
 @dataclass

--- a/open_instruct/grpo_callbacks.py
+++ b/open_instruct/grpo_callbacks.py
@@ -256,12 +256,17 @@ class HFCheckpointCallback(Callback):
             return
 
         state_dict = self.train_module.model.state_dict()
+        if self.rank != 0:
+            # full_tensor() is a collective and must still be called on every rank to avoid
+            # hanging, but only rank 0 needs the gathered tensors to write the checkpoint.
+            for v in state_dict.values():
+                if hasattr(v, "full_tensor"):
+                    v.full_tensor()
+            return
+
         state_dict = {
             k: v.full_tensor().cpu() if hasattr(v, "full_tensor") else v.cpu() for k, v in state_dict.items()
         }
-        if self.rank != 0:
-            return
-
         step_dir = os.path.join(self.checkpoint_dir, f"step_{step}")
         os.makedirs(step_dir, exist_ok=True)
         olmo_core_utils.save_state_dict_as_hf(state_dict, step_dir, self.model_name_or_path, self.tokenizer)

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -113,6 +113,7 @@ from open_instruct.utils import (
     RayProcess,
     UlyssesSPSplitter,
     _z3_params_to_fetch,
+    clean_last_n_checkpoints,
     clean_last_n_checkpoints_deepspeed,
     get_eval_ds_config,
     get_optimizer_grouped_parameters,
@@ -1675,6 +1676,7 @@ def maybe_save_checkpoint(
                 ],
                 desc=f"Saving model at step {training_step}",
             )
+            clean_last_n_checkpoints(checkpoint_dir, args.keep_last_n_saves)
             if args.try_launch_beaker_eval_jobs_on_weka and is_beaker_job():
                 leaderboard_name = f"{args.hf_repo_revision}_step_{training_step}"
                 for i in range(args.world_size):

--- a/open_instruct/grpo_olmo_core_actor.py
+++ b/open_instruct/grpo_olmo_core_actor.py
@@ -418,13 +418,17 @@ class PolicyTrainerOLMoCoreProcess(RayProcess):
         are collective operations when FSDP is enabled.
         """
         state_dict = self.train_module.model.state_dict()
+        if self.rank != 0:
+            # full_tensor() is a collective and must still be called on every rank to avoid
+            # hanging, but only rank 0 needs the gathered tensors to write the checkpoint.
+            for v in state_dict.values():
+                if hasattr(v, "full_tensor"):
+                    v.full_tensor()
+            return
+
         state_dict = {
             k: v.full_tensor().cpu() if hasattr(v, "full_tensor") else v.cpu() for k, v in state_dict.items()
         }
-
-        if self.rank != 0:
-            return
-
         os.makedirs(output_dir, exist_ok=True)
         olmo_core_utils.save_state_dict_as_hf(state_dict, output_dir, self.model_name_or_path, tokenizer)
         logger.info(f"[Rank {self.rank}] Model saved to {output_dir}")

--- a/open_instruct/grpo_olmo_core_actor.py
+++ b/open_instruct/grpo_olmo_core_actor.py
@@ -32,6 +32,7 @@ from open_instruct import grpo_callbacks as grpo_callbacks_lib
 from open_instruct import grpo_utils, logger_utils, model_utils, olmo_core_utils, utils, vllm_utils
 from open_instruct.grpo_callbacks import (
     EvalCallback,
+    HFCheckpointCallback,
     RefPolicyUpdateCallback,
     StepTimingCallback,
     VLLMWeightSyncCallback,
@@ -378,6 +379,15 @@ class PolicyTrainerOLMoCoreProcess(RayProcess):
         if self.grpo_config.checkpoint_state_freq > 0:
             trainer_callbacks["checkpointer"] = olmo_core_utils.build_checkpointer_callback(
                 checkpointing_steps=self.grpo_config.checkpoint_state_freq, ephemeral_save_interval=None
+            )
+        if self.grpo_config.save_freq > 0:
+            trainer_callbacks["hf_checkpoint"] = HFCheckpointCallback(
+                model_name_or_path=self.model_name_or_path,
+                tokenizer=self.tokenizer,
+                checkpoint_dir=f"{self.grpo_config.output_dir}_checkpoints",
+                save_freq=self.grpo_config.save_freq,
+                keep_last_n_saves=self.grpo_config.keep_last_n_saves,
+                rank=self.rank,
             )
         trainer_callbacks["data_prep_state"] = grpo_callbacks_lib.DataPreparationActorCheckpointCallback()
 

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -93,6 +93,10 @@ class GRPOExperimentConfig(
     """Run evaluation after this many training steps. This controls in-loop evals, which reuse the generation/reward verifier setup. Set to -1 to disable."""
     save_freq: int = 200
     """How many train steps to save the model"""
+    keep_last_n_saves: int = -1
+    """How many intermediate HuggingFace-format model saves (under `{output_dir}_checkpoints`) to
+    keep on disk. -1 for all (default). Distinct from `keep_last_n_checkpoints`, which bounds the
+    OLMo-core native/resumable checkpoints under `output_dir` (or `checkpoint_state_dir`)."""
     backend_timeout: int = 120
     """Timeout for inference/training backends in minutes. Default is 2 hours (120 min)."""
     model_dtype: str = "bfloat16"


### PR DESCRIPTION
## Summary
- Adds `keep_last_n_saves` (default `-1`, unlimited) to `GRPOExperimentConfig`, bounding the number of intermediate HuggingFace-format model saves kept under `{output_dir}_checkpoints`.
- `grpo_fast.py`: `maybe_save_checkpoint` now trims old step saves via the existing `clean_last_n_checkpoints` helper after each periodic save.
- `grpo.py` (OLMo-core path): previously `--save_freq` was a no-op for periodic saves -- only the final model was ever saved in HF format (see the warning in `GRPOExperimentConfig.__post_init__`). Adds a new `HFCheckpointCallback` (in `grpo_callbacks.py`, wired in `grpo_olmo_core_actor.py`) that performs periodic HF-format saves on the `save_freq` cadence, gathering the FSDP-sharded state dict and writing/trimming from rank 0, mirroring the streaming path's behavior.

This is similar in spirit to #1701, which wired `keep_last_n_checkpoints`/`max_checkpoints` through the OLMo-core *native* (resumable) checkpoints. `keep_last_n_saves` is a distinct, independent knob for the separate HF-format saves used for eval/pushing during training.

## Test plan
- [x] `uv run pytest open_instruct/test_grpo_fast.py open_instruct/test_grpo_utils.py open_instruct/test_utils.py` (excluding an unrelated, pre-existing local test-data failure in `CombineDatasetTest`)
- [x] `make style && make quality`
- [ ] GPU smoke test: OLMo-core GRPO run with `--save_freq` and `--keep_last_n_saves` set, verify intermediate HF saves are trimmed under `{output_dir}_checkpoints`
- [ ] GPU smoke test: DeepSpeed GRPO run (`grpo_fast.py`) with `--keep_last_n_saves`, verify trimming behavior unchanged from `keep_last_n_checkpoints`'s existing semantics

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)