### PR TITLE
Add DPPO via the unified rho-divergence masking paradigm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
+- Add the DPPO loss function (`--loss_fn dppo`, https://arxiv.org/abs/2602.04879) and generalize the ρ token-drop mask with `--rho_divergence_type` (`rho`/`tv`/`dppo_tv`/`dppo_kl`, replacing `--rho_mask_tv_divergence`); `compute_grpo_loss` now computes the ratio and ρ correction internally and returns a `GRPOLossOutput` (https://github.com/allenai/open-instruct/pull/1755).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Added
-- Add the DPPO loss function (`--loss_fn dppo`, https://arxiv.org/abs/2602.04879) and generalize the ρ token-drop mask with `--rho_divergence_type` (`rho`/`tv`/`dppo_tv`/`dppo_kl`, replacing `--rho_mask_tv_divergence`); `compute_grpo_loss` now computes the ratio and ρ correction internally and returns a `GRPOLossOutput` (https://github.com/allenai/open-instruct/pull/1755).
+- Add the DPPO loss function (`--loss_fn dppo`, https://arxiv.org/abs/2602.04879) and generalize the ρ token-drop mask with `--rho_divergence_algo` (`icepop`/`vaco`/`dppo`, replacing `--rho_mask_tv_divergence`) and `--rho_divergence_type` (`tv`/`kl`); `compute_grpo_loss` now computes the ratio and ρ correction internally and returns a `GRPOLossOutput` (https://github.com/allenai/open-instruct/pull/1755).
 - Drop stale async rollout results whose generating policy is more than `async_steps` behind the trainer (`max_result_age_steps`), replenishing a fresh prompt and logging a `stale_results_dropped` metric (https://github.com/allenai/open-instruct/pull/1738).
 
 ### Changed

--- a/docs/algorithms/grpo.md
+++ b/docs/algorithms/grpo.md
@@ -50,7 +50,8 @@ Both `grpo.py` and `grpo_fast.py` share the same config classes and accept the s
 | **GRPO Algorithm** | `--beta` | KL coefficient for RLHF objective | `0.05` |
 | | `--clip_lower` | Lower clip range | `0.2` |
 | | `--clip_higher` | Higher clip range (see DAPO) | `0.2` |
-| | `--loss_fn` | Loss function: `dapo` or `cispo` | `dapo` |
+| | `--loss_fn` | Loss function: `dapo`, `cispo`, or `dppo` | `dapo` |
+| | `--rho_divergence_type` | Divergence for the ρ token-drop mask: `rho`, `tv` (VACO), `dppo_tv`, or `dppo_kl` (DPPO) | `rho` |
 | | `--load_ref_policy` | Load and use reference policy for KL | `True` |
 | **Rollout / Sampling** | `--num_unique_prompts_rollout` | Unique prompts per rollout | `16` |
 | | `--num_samples_per_prompt_rollout` | Samples per prompt in rollout | `4` |

--- a/docs/algorithms/grpo.md
+++ b/docs/algorithms/grpo.md
@@ -51,7 +51,8 @@ Both `grpo.py` and `grpo_fast.py` share the same config classes and accept the s
 | | `--clip_lower` | Lower clip range | `0.2` |
 | | `--clip_higher` | Higher clip range (see DAPO) | `0.2` |
 | | `--loss_fn` | Loss function: `dapo`, `cispo`, or `dppo` | `dapo` |
-| | `--rho_divergence_type` | Divergence for the ρ token-drop mask: `rho`, `tv` (VACO), `dppo_tv`, or `dppo_kl` (DPPO) | `rho` |
+| | `--rho_divergence_algo` | Algorithm for the ρ token-drop mask: `icepop` (simple clipping), `vaco`, or `dppo` | `icepop` |
+| | `--rho_divergence_type` | Divergence measure for `vaco`/`dppo` masking: `tv` or `kl` | `tv` |
 | | `--load_ref_policy` | Load and use reference policy for KL | `True` |
 | **Rollout / Sampling** | `--num_unique_prompts_rollout` | Unique prompts per rollout | `16` |
 | | `--num_samples_per_prompt_rollout` | Samples per prompt in rollout | `4` |

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -699,23 +699,18 @@ class PolicyTrainerRayProcess(RayProcess):
                     )
 
                     # Calculate the policy's loss
-                    logprobs_diff_BT = new_logprobs_BT - old_logprob_BT
-                    ratio_BT = torch.exp(logprobs_diff_BT)
-                    rho_BT = grpo_utils.compute_rho_correction(
-                        old_logprob_BT, vllm_logprobs_BT, response_mask_BT, data_BT.advantages[i][:, 1:], self.args
-                    )
-                    grpo_utils.accumulate_rho_histograms(rho_histograms, rho_BT)
-
-                    pg_loss_BT, clipfrac_BT, kl_BT = grpo_utils.compute_grpo_loss(
+                    loss_output_BT = grpo_utils.compute_grpo_loss(
                         new_logprobs=new_logprobs_BT,
-                        ratio=ratio_BT,
+                        old_logprobs=old_logprob_BT,
+                        vllm_logprobs=vllm_logprobs_BT,
                         advantages=data_BT.advantages[i][:, 1:],
                         ref_logprobs=ref_logprobs_BT[i] if self.args.load_ref_policy else None,
+                        response_mask=response_mask_BT,
                         config=self.args,
-                        rho_weights=rho_BT.weights,
                     )
+                    grpo_utils.accumulate_rho_histograms(rho_histograms, loss_output_BT.rho)
 
-                    per_token_loss_BT = pg_loss_BT + self.args.beta * kl_BT
+                    per_token_loss_BT = loss_output_BT.pg_loss + self.args.beta * loss_output_BT.kl
                     loss = masked_mean(per_token_loss_BT, response_mask_BT, None, loss_denominator)
 
                     # we already took world size into account via the tokens
@@ -736,16 +731,13 @@ class PolicyTrainerRayProcess(RayProcess):
                     grpo_utils.populate_sample_loss_stats(
                         loss_stats_B,
                         i,
-                        pg_loss_BT,
-                        clipfrac_BT,
-                        ratio_BT,
+                        loss_output_BT,
                         loss,
                         response_mask_BT,
                         new_logprobs_BT,
                         ref_logprobs_BT[i] if self.args.load_ref_policy else None,
                         entropy_BT,
                         self.args,
-                        rho_metrics=rho_BT.metrics,
                     )
 
             batch_metrics = batch_data["metrics"]

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -73,24 +73,36 @@ class GRPOLossType(enum.StrEnum):
 
 
 class RhoDivergenceType(enum.StrEnum):
-    """Which divergence drives the token-drop mask in :func:`compute_rho_correction`.
+    """Which divergence measure the masking algorithm uses (see :class:`RhoDivergenceAlgo`).
 
-    ``rho``: threshold ρ = π^train_old / π^infer_old itself (per token, or per sequence
-    with ``rho_mask_sequence_level``).
-    ``tv``: VACO (https://arxiv.org/abs/2603.01365) — sequence-level total variation
-    mean |ρ - 1|, dropping only tokens whose update would increase the divergence.
-    ``dppo_tv`` / ``dppo_kl``: DPPO (https://arxiv.org/abs/2602.04879) — per-token binary
-    (Bernoulli) TV/KL divergence between the current policy π_θ and the rollout policy μ,
-    dropping only tokens whose update would push π_θ further from μ (Eq. 12).
+    ``tv``: total variation — ``vaco`` uses the ratio-space |ρ - 1|; ``dppo`` uses the
+    binary (Bernoulli) |μ - π| (Eq. 13 of https://arxiv.org/abs/2602.04879).
+    ``kl``: KL — ``vaco`` uses the k3 estimator ρ - 1 - log ρ of KL(μ ‖ π^train_old);
+    ``dppo`` uses the binary (Bernoulli) KL (Eq. 14).
+    Ignored by the ``icepop`` algorithm, which masks on ρ itself.
     """
 
-    rho = "rho"
     tv = "tv"
-    dppo_tv = "dppo_tv"
-    dppo_kl = "dppo_kl"
+    kl = "kl"
 
 
-DPPO_DIVERGENCE_TYPES = (RhoDivergenceType.dppo_tv, RhoDivergenceType.dppo_kl)
+class RhoDivergenceAlgo(enum.StrEnum):
+    """Which algorithm drives the token-drop mask in :func:`compute_rho_correction`.
+
+    ``icepop`` (default): IcePop (https://arxiv.org/abs/2510.18855) — threshold
+    ρ = π^train_old / π^infer_old itself (per token, or per sequence with
+    ``rho_mask_sequence_level``).
+    ``vaco``: VACO (https://arxiv.org/abs/2603.01365) — sequence-level mean of the
+    per-token divergence between π^train_old and the rollout policy μ, dropping only
+    tokens whose update would increase the divergence.
+    ``dppo``: DPPO (https://arxiv.org/abs/2602.04879) — per-token binary (Bernoulli)
+    divergence between the *current* policy π_θ and the rollout policy μ, dropping only
+    tokens whose update would push π_θ further from μ (Eq. 12).
+    """
+
+    icepop = "icepop"
+    vaco = "vaco"
+    dppo = "dppo"
 
 
 @dataclass
@@ -132,7 +144,7 @@ class GRPOExperimentConfig(
     use_rho_correction: bool = True
     """Master switch for the train/infer ratio ρ = π^train_old / π^infer_old correction.
     When True, ρ is clamped to [rho_clamp_lower_bound, rho_clamp_upper_bound] and tokens
-    whose masking statistic (ρ by default; see `rho_divergence_type`) falls outside
+    whose masking statistic (ρ by default; see `rho_divergence_algo`) falls outside
     [rho_mask_lower_bound, rho_mask_upper_bound] have their per-token policy loss zeroed
     out. This unifies truncated importance sampling
     (https://fengyao.notion.site/off-policy-rl) and IcePop (https://arxiv.org/abs/2510.18855)."""
@@ -141,29 +153,31 @@ class GRPOExperimentConfig(
     rho_clamp_upper_bound: float = 2.0
     """Upper bound for clamping ρ before reweighting the policy loss (0 disables)."""
     rho_mask_lower_bound: float = 0.0
-    """Tokens whose masking statistic (see `rho_divergence_type`) falls below this value are
-    dropped (0 disables). For `rho`, the statistic is ρ itself; for divergence types it is
-    the divergence value."""
+    """Tokens whose masking statistic (see `rho_divergence_algo`) falls below this value are
+    dropped (0 disables). For `icepop`, the statistic is ρ itself; for `vaco` it is the
+    sequence-level divergence. Unused by `dppo`."""
     rho_mask_upper_bound: float = 0.0
-    """Tokens whose masking statistic (see `rho_divergence_type`) exceeds this value are
-    dropped (0 disables). For `rho`, the statistic is ρ itself; for `tv` it is the
-    sequence-level TV divergence; for `dppo_tv`/`dppo_kl` it is the DPPO trust-region
-    threshold δ on the per-token binary divergence."""
+    """Tokens whose masking statistic (see `rho_divergence_algo`) exceeds this value are
+    dropped (0 disables). For `icepop`, the statistic is ρ itself; for `vaco` it is the
+    sequence-level divergence; for `dppo` it is the trust-region threshold δ on the
+    per-token binary divergence."""
     rho_mask_sequence_level: bool = False
     """If True, apply the rho mask at the sequence level (DeepSeek-V3.2 style):
     compute the mean log-ratio (1/|o_i|) Σ_t log(π_old / π_θ) per response sequence,
     exponentiate to get a per-sequence ρ, and broadcast the keep/drop decision to every
     token in that sequence. If False (default), the mask is applied per token.
-    Only used with `rho_divergence_type=rho`."""
-    rho_divergence_type: RhoDivergenceType = RhoDivergenceType.rho
-    """Which divergence the token-drop mask thresholds against `rho_mask_*_bound`:
-    `rho` (default) masks on ρ itself; `tv` applies the VACO sequence-level TV divergence
-    masking (https://arxiv.org/abs/2603.01365); `dppo_tv`/`dppo_kl` apply the DPPO
-    trust-region masking (https://arxiv.org/abs/2602.04879) on the per-token binary
-    TV/KL divergence between the current policy and the rollout policy. The `tv` and
-    `dppo_*` types are directional: tokens whose update would *decrease* the divergence
-    are never masked. The ρ clamp/reweighting (truncated importance sampling) is
-    unaffected by this choice."""
+    Only used with `rho_divergence_algo=icepop`."""
+    rho_divergence_algo: RhoDivergenceAlgo = RhoDivergenceAlgo.icepop
+    """Which masking algorithm the token-drop mask uses with `rho_mask_*_bound`:
+    `icepop` (default) masks on ρ itself (simple clipping); `vaco` applies sequence-level
+    divergence masking (https://arxiv.org/abs/2603.01365); `dppo` applies trust-region
+    masking (https://arxiv.org/abs/2602.04879) on the per-token binary divergence between
+    the current policy and the rollout policy. `vaco` and `dppo` are directional: tokens
+    whose update would *decrease* the divergence are never masked. The ρ clamp/reweighting
+    (truncated importance sampling) is unaffected by this choice."""
+    rho_divergence_type: RhoDivergenceType = RhoDivergenceType.tv
+    """Which divergence measure `rho_divergence_algo` thresholds: `tv` or `kl`.
+    See :class:`RhoDivergenceType` for the per-algorithm definitions. Ignored by `icepop`."""
     kl_estimator: Literal[0, 1, 2, 3] = 2
     """the KL estimator to use"""
     loss_denominator: str = "token"
@@ -362,7 +376,7 @@ class GRPOExperimentConfig(
                 )
             if self.rho_clamp_upper_bound > 0.0 and self.rho_clamp_upper_bound <= 1.0:
                 raise ValueError(f"rho_clamp_upper_bound must be > 1 when set, got {self.rho_clamp_upper_bound}.")
-        if self.rho_divergence_type == RhoDivergenceType.rho:
+        if self.rho_divergence_algo == RhoDivergenceAlgo.icepop:
             # The masking statistic is ρ itself, which is centered at 1.
             if self.use_rho_correction:
                 if self.rho_mask_lower_bound > 0.0 and not (0.0 < self.rho_mask_lower_bound < 1.0):
@@ -375,7 +389,7 @@ class GRPOExperimentConfig(
             # The masking statistic is a divergence, which is >= 0 and typically < 1.
             if self.rho_mask_lower_bound < 0.0 or self.rho_mask_upper_bound < 0.0:
                 raise ValueError(
-                    f"rho_mask bounds must be >= 0 with rho_divergence_type={self.rho_divergence_type}, got "
+                    f"rho_mask bounds must be >= 0 with rho_divergence_algo={self.rho_divergence_algo}, got "
                     f"lower={self.rho_mask_lower_bound}, upper={self.rho_mask_upper_bound}."
                 )
             if (
@@ -387,7 +401,7 @@ class GRPOExperimentConfig(
                     f"rho_mask_lower_bound ({self.rho_mask_lower_bound}) must be < rho_mask_upper_bound "
                     f"({self.rho_mask_upper_bound}) when both are set."
                 )
-        if self.rho_divergence_type in DPPO_DIVERGENCE_TYPES:
+        if self.rho_divergence_algo == RhoDivergenceAlgo.dppo:
             if self.rho_mask_upper_bound <= 0.0:
                 raise ValueError(
                     "DPPO divergence masking requires `rho_mask_upper_bound` (the trust-region "
@@ -407,13 +421,13 @@ class GRPOExperimentConfig(
                     "rollout policy μ: set `use_rho_correction=True` (truncated importance sampling) "
                     "or `use_vllm_logprobs=True`."
                 )
-        elif self.rho_divergence_type != RhoDivergenceType.rho and not self.use_rho_correction:
-            raise ValueError(f"rho_divergence_type={self.rho_divergence_type} requires `use_rho_correction=True`.")
-        if self.loss_fn == GRPOLossType.dppo and self.rho_divergence_type not in DPPO_DIVERGENCE_TYPES:
+        elif self.rho_divergence_algo == RhoDivergenceAlgo.vaco and not self.use_rho_correction:
+            raise ValueError(f"rho_divergence_algo={self.rho_divergence_algo} requires `use_rho_correction=True`.")
+        if self.loss_fn == GRPOLossType.dppo and self.rho_divergence_algo != RhoDivergenceAlgo.dppo:
             raise ValueError(
                 "The DPPO loss has no ratio clipping; its trust region is enforced entirely by the "
-                "divergence mask. Set `rho_divergence_type` to 'dppo_tv' or 'dppo_kl' (and "
-                "`rho_mask_upper_bound` to the threshold δ) when using `loss_fn=dppo`."
+                "divergence mask. Set `rho_divergence_algo=dppo` (and `rho_mask_upper_bound` to the "
+                "threshold δ) when using `loss_fn=dppo`."
             )
 
 
@@ -505,7 +519,7 @@ def compute_binary_divergence(
         behavior_logprobs: log μ(a_t|s_t), the rollout (vLLM) policy.
         policy_logprobs:   log π(a_t|s_t), the current trainer policy.
         response_mask:     bool mask selecting valid response positions.
-        divergence_type:   ``dppo_tv`` for total variation or ``dppo_kl`` for KL.
+        divergence_type:   ``tv`` for total variation or ``kl`` for KL.
 
     Returns:
         Float tensor of the same shape as ``policy_logprobs``; entries outside
@@ -519,9 +533,9 @@ def compute_binary_divergence(
     # (see ``mask_logprobs`` / INVALID_LOGPROB). Clamp so exp() stays in [eps, 1].
     mu = torch.exp(behavior_logprobs.clamp(min=-30.0, max=0.0))
     pi = torch.exp(policy_logprobs.clamp(min=-30.0, max=0.0))
-    if divergence_type == RhoDivergenceType.dppo_tv:
+    if divergence_type == RhoDivergenceType.tv:
         divergence = (mu - pi).abs()
-    elif divergence_type == RhoDivergenceType.dppo_kl:
+    elif divergence_type == RhoDivergenceType.kl:
         mu_clip = mu.clamp(eps, 1.0 - eps)
         pi_clip = pi.clamp(eps, 1.0 - eps)
         divergence = mu_clip * (mu_clip.log() - pi_clip.log()) + (1.0 - mu_clip) * (
@@ -529,7 +543,7 @@ def compute_binary_divergence(
         )
     else:
         raise ValueError(
-            f"Unknown binary divergence type: {divergence_type}. Expected one of {DPPO_DIVERGENCE_TYPES}."
+            f"Unknown binary divergence type: {divergence_type}. Expected one of {list(RhoDivergenceType)}."
         )
     return torch.where(response_mask, divergence, torch.zeros_like(divergence)).to(orig_dtype)
 
@@ -547,17 +561,18 @@ def compute_rho_correction(
     ρ = π^train_old / π^infer_old corrects the train/infer engine mismatch; when
     ``use_rho_correction`` is on, in-range tokens are reweighted by clamped ρ
     (truncated importance sampling). The drop mask is controlled by
-    ``rho_divergence_type`` (see :class:`RhoDivergenceType`); the DPPO types compare
-    the *current* policy (``new_logprobs``, detached here) against the rollout policy
-    and therefore also apply when ``use_vllm_logprobs`` is on.
+    ``rho_divergence_algo`` (see :class:`RhoDivergenceAlgo`) using the divergence
+    measure ``rho_divergence_type``; the ``dppo`` algorithm compares the *current*
+    policy (``new_logprobs``, detached here) against the rollout policy and therefore
+    also applies when ``use_vllm_logprobs`` is on.
     """
     logprob_diff = torch.where(
         response_mask, (old_logprob - vllm_logprobs).clamp(-10.0, 10.0), torch.zeros_like(old_logprob)
     )
     rho = torch.exp(logprob_diff)
     rho_hist = {"val/rho_hist": rho[response_mask].detach().float()}
-    is_dppo_divergence = config.rho_divergence_type in DPPO_DIVERGENCE_TYPES
-    if not config.use_rho_correction and not is_dppo_divergence:
+    is_dppo_algo = config.rho_divergence_algo == RhoDivergenceAlgo.dppo
+    if not config.use_rho_correction and not is_dppo_algo:
         return RhoCorrection(weights=torch.ones_like(rho), metrics={}, histogram_metrics=rho_hist)
 
     rho_effective = (
@@ -565,20 +580,25 @@ def compute_rho_correction(
     )
 
     metrics: dict[str, torch.Tensor] = {}
-    if config.rho_divergence_type == RhoDivergenceType.tv:
+    if config.rho_divergence_algo == RhoDivergenceAlgo.vaco:
         # VACO: keep rho_effective for the truncated importance sampling weights, but mask
-        # on the sequence-level TV divergence mean |ρ - 1|, dropping only tokens whose
-        # update would increase it: advantage * logprob_diff > 0.
-        tv_divergence = torch.abs(rho - 1.0)
-        tv_sequence_level = _sequence_level_mean(tv_divergence, response_mask)
-        tv_dropped_low, tv_dropped_high = _rho_drop_masks(
-            tv_sequence_level, response_mask, config.rho_mask_lower_bound, config.rho_mask_upper_bound
+        # on the sequence-level mean of a per-token divergence between π^train_old and μ,
+        # dropping only tokens whose update would increase it: advantage * logprob_diff > 0.
+        if config.rho_divergence_type == RhoDivergenceType.tv:
+            token_divergence = torch.abs(rho - 1.0)
+        else:
+            # k3 estimator of KL(μ ‖ π^train_old): ρ - 1 - log ρ >= 0 (Schulman,
+            # http://joschu.net/blog/kl-approx.html), with tokens sampled from μ.
+            token_divergence = rho - 1.0 - logprob_diff
+        sequence_divergence = _sequence_level_mean(token_divergence, response_mask)
+        divergence_dropped_low, divergence_dropped_high = _rho_drop_masks(
+            sequence_divergence, response_mask, config.rho_mask_lower_bound, config.rho_mask_upper_bound
         )
-        tokens_increase_tv = torch.sign(logprob_diff) * advantages > 0
-        dropped_low = tv_dropped_low & tokens_increase_tv
-        dropped_high = tv_dropped_high & tokens_increase_tv
-        metrics["val/rho_divergence"] = tv_sequence_level.detach().float()
-    elif is_dppo_divergence:
+        tokens_increase_divergence = torch.sign(logprob_diff) * advantages > 0
+        dropped_low = divergence_dropped_low & tokens_increase_divergence
+        dropped_high = divergence_dropped_high & tokens_increase_divergence
+        metrics["val/rho_divergence"] = sequence_divergence.detach().float()
+    elif is_dppo_algo:
         # DPPO (Eq. 12): drop tokens outside the trust region δ on the binary divergence
         # between the current policy π_θ and the rollout policy μ, but only when the update
         # would push π_θ further from μ: A>0 with π_θ>μ, or A<0 with π_θ<μ.
@@ -708,7 +728,7 @@ def compute_grpo_loss(
     elif config.loss_fn == GRPOLossType.dppo:
         # DPPO (https://arxiv.org/abs/2602.04879) Eq. 11: L = E[Σ_t M_t · r_t · A_t].
         # No symmetric clipping; the trust-region mask M_t is enforced through the ρ
-        # weights via rho_divergence_type=dppo_tv/dppo_kl (validated in __post_init__).
+        # weights via rho_divergence_algo=dppo (validated in __post_init__).
         pg_loss = -advantages * ratio
         clipfrac = torch.zeros_like(pg_loss)
     else:

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -69,6 +69,28 @@ def compute_pass_at_k_metrics(correct_per_prompt: np.ndarray) -> dict[str, float
 class GRPOLossType(enum.StrEnum):
     dapo = "dapo"
     cispo = "cispo"
+    dppo = "dppo"
+
+
+class RhoDivergenceType(enum.StrEnum):
+    """Which divergence drives the token-drop mask in :func:`compute_rho_correction`.
+
+    ``rho``: threshold ρ = π^train_old / π^infer_old itself (per token, or per sequence
+    with ``rho_mask_sequence_level``).
+    ``tv``: VACO (https://arxiv.org/abs/2603.01365) — sequence-level total variation
+    mean |ρ - 1|, dropping only tokens whose update would increase the divergence.
+    ``dppo_tv`` / ``dppo_kl``: DPPO (https://arxiv.org/abs/2602.04879) — per-token binary
+    (Bernoulli) TV/KL divergence between the current policy π_θ and the rollout policy μ,
+    dropping only tokens whose update would push π_θ further from μ (Eq. 12).
+    """
+
+    rho = "rho"
+    tv = "tv"
+    dppo_tv = "dppo_tv"
+    dppo_kl = "dppo_kl"
+
+
+DPPO_DIVERGENCE_TYPES = (RhoDivergenceType.dppo_tv, RhoDivergenceType.dppo_kl)
 
 
 @dataclass
@@ -110,27 +132,38 @@ class GRPOExperimentConfig(
     use_rho_correction: bool = True
     """Master switch for the train/infer ratio ρ = π^train_old / π^infer_old correction.
     When True, ρ is clamped to [rho_clamp_lower_bound, rho_clamp_upper_bound] and tokens
-    whose ρ falls outside [rho_mask_lower_bound, rho_mask_upper_bound] have their
-    per-token policy loss zeroed out. This unifies truncated importance sampling
+    whose masking statistic (ρ by default; see `rho_divergence_type`) falls outside
+    [rho_mask_lower_bound, rho_mask_upper_bound] have their per-token policy loss zeroed
+    out. This unifies truncated importance sampling
     (https://fengyao.notion.site/off-policy-rl) and IcePop (https://arxiv.org/abs/2510.18855)."""
     rho_clamp_lower_bound: float = 0.0
     """Lower bound for clamping ρ before reweighting the policy loss (0 disables)."""
     rho_clamp_upper_bound: float = 2.0
     """Upper bound for clamping ρ before reweighting the policy loss (0 disables)."""
     rho_mask_lower_bound: float = 0.0
-    """Tokens with ρ below this value are dropped (0 disables)."""
+    """Tokens whose masking statistic (see `rho_divergence_type`) falls below this value are
+    dropped (0 disables). For `rho`, the statistic is ρ itself; for divergence types it is
+    the divergence value."""
     rho_mask_upper_bound: float = 0.0
-    """Tokens with ρ above this value are dropped (0 disables)."""
+    """Tokens whose masking statistic (see `rho_divergence_type`) exceeds this value are
+    dropped (0 disables). For `rho`, the statistic is ρ itself; for `tv` it is the
+    sequence-level TV divergence; for `dppo_tv`/`dppo_kl` it is the DPPO trust-region
+    threshold δ on the per-token binary divergence."""
     rho_mask_sequence_level: bool = False
     """If True, apply the rho mask at the sequence level (DeepSeek-V3.2 style):
     compute the mean log-ratio (1/|o_i|) Σ_t log(π_old / π_θ) per response sequence,
     exponentiate to get a per-sequence ρ, and broadcast the keep/drop decision to every
-    token in that sequence. If False (default), the mask is applied per token."""
-    rho_mask_tv_divergence: bool = False
-    """If True, applies the TV divergence masking from VACO (https://arxiv.org/abs/2603.01365)
-    maintains same rho for correction but masks using bounds and sequence-level TV divergence abs(p_seq - 1)
-    won't mask tokens that purport to decrease TV divergence: advantage * logprob_diff <= 0
-    """
+    token in that sequence. If False (default), the mask is applied per token.
+    Only used with `rho_divergence_type=rho`."""
+    rho_divergence_type: RhoDivergenceType = RhoDivergenceType.rho
+    """Which divergence the token-drop mask thresholds against `rho_mask_*_bound`:
+    `rho` (default) masks on ρ itself; `tv` applies the VACO sequence-level TV divergence
+    masking (https://arxiv.org/abs/2603.01365); `dppo_tv`/`dppo_kl` apply the DPPO
+    trust-region masking (https://arxiv.org/abs/2602.04879) on the per-token binary
+    TV/KL divergence between the current policy and the rollout policy. The `tv` and
+    `dppo_*` types are directional: tokens whose update would *decrease* the divergence
+    are never masked. The ρ clamp/reweighting (truncated importance sampling) is
+    unaffected by this choice."""
     kl_estimator: Literal[0, 1, 2, 3] = 2
     """the KL estimator to use"""
     loss_denominator: str = "token"
@@ -323,18 +356,65 @@ class GRPOExperimentConfig(
         if self.eval_top_p is not None and not (0.0 < self.eval_top_p <= 1.0):
             raise ValueError(f"`eval_top_p` must be in (0, 1], got {self.eval_top_p}")
         if self.use_rho_correction:
-            if self.rho_mask_lower_bound > 0.0 and not (0.0 < self.rho_mask_lower_bound < 1.0):
-                raise ValueError(
-                    f"rho_mask_lower_bound must satisfy 0 < lb < 1 when set, got {self.rho_mask_lower_bound}."
-                )
-            if self.rho_mask_upper_bound > 0.0 and self.rho_mask_upper_bound <= 1.0:
-                raise ValueError(f"rho_mask_upper_bound must be > 1 when set, got {self.rho_mask_upper_bound}.")
             if self.rho_clamp_lower_bound > 0.0 and self.rho_clamp_lower_bound >= 1.0:
                 raise ValueError(
                     f"rho_clamp_lower_bound must satisfy 0 < lb < 1 when set, got {self.rho_clamp_lower_bound}."
                 )
             if self.rho_clamp_upper_bound > 0.0 and self.rho_clamp_upper_bound <= 1.0:
                 raise ValueError(f"rho_clamp_upper_bound must be > 1 when set, got {self.rho_clamp_upper_bound}.")
+        if self.rho_divergence_type == RhoDivergenceType.rho:
+            # The masking statistic is ρ itself, which is centered at 1.
+            if self.use_rho_correction:
+                if self.rho_mask_lower_bound > 0.0 and not (0.0 < self.rho_mask_lower_bound < 1.0):
+                    raise ValueError(
+                        f"rho_mask_lower_bound must satisfy 0 < lb < 1 when set, got {self.rho_mask_lower_bound}."
+                    )
+                if self.rho_mask_upper_bound > 0.0 and self.rho_mask_upper_bound <= 1.0:
+                    raise ValueError(f"rho_mask_upper_bound must be > 1 when set, got {self.rho_mask_upper_bound}.")
+        else:
+            # The masking statistic is a divergence, which is >= 0 and typically < 1.
+            if self.rho_mask_lower_bound < 0.0 or self.rho_mask_upper_bound < 0.0:
+                raise ValueError(
+                    f"rho_mask bounds must be >= 0 with rho_divergence_type={self.rho_divergence_type}, got "
+                    f"lower={self.rho_mask_lower_bound}, upper={self.rho_mask_upper_bound}."
+                )
+            if (
+                self.rho_mask_lower_bound > 0.0
+                and self.rho_mask_upper_bound > 0.0
+                and self.rho_mask_lower_bound >= self.rho_mask_upper_bound
+            ):
+                raise ValueError(
+                    f"rho_mask_lower_bound ({self.rho_mask_lower_bound}) must be < rho_mask_upper_bound "
+                    f"({self.rho_mask_upper_bound}) when both are set."
+                )
+        if self.rho_divergence_type in DPPO_DIVERGENCE_TYPES:
+            if self.rho_mask_upper_bound <= 0.0:
+                raise ValueError(
+                    "DPPO divergence masking requires `rho_mask_upper_bound` (the trust-region "
+                    f"threshold δ) > 0, got {self.rho_mask_upper_bound}."
+                )
+            if self.rho_mask_lower_bound != 0.0:
+                raise ValueError(
+                    "`rho_mask_lower_bound` is not used with DPPO divergence masking; "
+                    f"set it to 0 (got {self.rho_mask_lower_bound})."
+                )
+            # The DPPO trust region is anchored on the rollout policy μ, so the effective
+            # importance ratio must be π_θ / μ: either directly (use_vllm_logprobs) or via
+            # the ρ correction (ratio · ρ = π_θ/π_old · π_old/μ).
+            if not (self.use_rho_correction or self.use_vllm_logprobs):
+                raise ValueError(
+                    "DPPO divergence masking requires the importance ratio to be anchored on the "
+                    "rollout policy μ: set `use_rho_correction=True` (truncated importance sampling) "
+                    "or `use_vllm_logprobs=True`."
+                )
+        elif self.rho_divergence_type != RhoDivergenceType.rho and not self.use_rho_correction:
+            raise ValueError(f"rho_divergence_type={self.rho_divergence_type} requires `use_rho_correction=True`.")
+        if self.loss_fn == GRPOLossType.dppo and self.rho_divergence_type not in DPPO_DIVERGENCE_TYPES:
+            raise ValueError(
+                "The DPPO loss has no ratio clipping; its trust region is enforced entirely by the "
+                "divergence mask. Set `rho_divergence_type` to 'dppo_tv' or 'dppo_kl' (and "
+                "`rho_mask_upper_bound` to the threshold δ) when using `loss_fn=dppo`."
+            )
 
 
 def mask_logprobs(vllm_logprobs: torch.Tensor, response_mask: torch.Tensor) -> torch.Tensor:
@@ -407,30 +487,88 @@ class RhoCorrection:
     histogram_metrics: dict[str, torch.Tensor] = field(default_factory=dict)
 
 
+def compute_binary_divergence(
+    behavior_logprobs: torch.Tensor,
+    policy_logprobs: torch.Tensor,
+    response_mask: torch.Tensor,
+    divergence_type: RhoDivergenceType,
+) -> torch.Tensor:
+    """Per-token binary (Bernoulli) divergence between behavior and policy.
+
+    Implements the binary approximation from Eqs. 13/14 of the DPPO paper
+    (https://arxiv.org/abs/2602.04879): collapse the categorical distribution
+    over the vocabulary into a Bernoulli over ``{sampled_token, all_others}``
+    using only the per-token logprobs. This is a memory-cheap lower bound on
+    the true policy divergence that requires no extra forward passes.
+
+    Args:
+        behavior_logprobs: log μ(a_t|s_t), the rollout (vLLM) policy.
+        policy_logprobs:   log π(a_t|s_t), the current trainer policy.
+        response_mask:     bool mask selecting valid response positions.
+        divergence_type:   ``dppo_tv`` for total variation or ``dppo_kl`` for KL.
+
+    Returns:
+        Float tensor of the same shape as ``policy_logprobs``; entries outside
+        ``response_mask`` are zeroed.
+    """
+    orig_dtype = policy_logprobs.dtype
+    behavior_logprobs = behavior_logprobs.to(torch.float32)
+    policy_logprobs = policy_logprobs.to(torch.float32)
+    eps = 1e-6
+    # Real logprobs are <= 0; non-response sentinel positions can be > 0
+    # (see ``mask_logprobs`` / INVALID_LOGPROB). Clamp so exp() stays in [eps, 1].
+    mu = torch.exp(behavior_logprobs.clamp(min=-30.0, max=0.0))
+    pi = torch.exp(policy_logprobs.clamp(min=-30.0, max=0.0))
+    if divergence_type == RhoDivergenceType.dppo_tv:
+        divergence = (mu - pi).abs()
+    elif divergence_type == RhoDivergenceType.dppo_kl:
+        mu_clip = mu.clamp(eps, 1.0 - eps)
+        pi_clip = pi.clamp(eps, 1.0 - eps)
+        divergence = mu_clip * (mu_clip.log() - pi_clip.log()) + (1.0 - mu_clip) * (
+            torch.log1p(-mu_clip) - torch.log1p(-pi_clip)
+        )
+    else:
+        raise ValueError(
+            f"Unknown binary divergence type: {divergence_type}. Expected one of {DPPO_DIVERGENCE_TYPES}."
+        )
+    return torch.where(response_mask, divergence, torch.zeros_like(divergence)).to(orig_dtype)
+
+
 def compute_rho_correction(
     old_logprob: torch.Tensor,
     vllm_logprobs: torch.Tensor,
+    new_logprobs: torch.Tensor,
     response_mask: torch.Tensor,
     advantages: torch.Tensor,
     config: GRPOExperimentConfig,
 ) -> RhoCorrection:
-    """Compute the unified ρ = π^train_old / π^infer_old correction (clamp + mask)."""
+    """Compute the unified per-token loss weights: ρ correction (clamp) x divergence drop mask.
+
+    ρ = π^train_old / π^infer_old corrects the train/infer engine mismatch; when
+    ``use_rho_correction`` is on, in-range tokens are reweighted by clamped ρ
+    (truncated importance sampling). The drop mask is controlled by
+    ``rho_divergence_type`` (see :class:`RhoDivergenceType`); the DPPO types compare
+    the *current* policy (``new_logprobs``, detached here) against the rollout policy
+    and therefore also apply when ``use_vllm_logprobs`` is on.
+    """
     logprob_diff = torch.where(
         response_mask, (old_logprob - vllm_logprobs).clamp(-10.0, 10.0), torch.zeros_like(old_logprob)
     )
     rho = torch.exp(logprob_diff)
     rho_hist = {"val/rho_hist": rho[response_mask].detach().float()}
-    if not config.use_rho_correction:
+    is_dppo_divergence = config.rho_divergence_type in DPPO_DIVERGENCE_TYPES
+    if not config.use_rho_correction and not is_dppo_divergence:
         return RhoCorrection(weights=torch.ones_like(rho), metrics={}, histogram_metrics=rho_hist)
 
     rho_effective = (
         torch.exp(_sequence_level_mean(logprob_diff, response_mask)) if config.rho_mask_sequence_level else rho
     )
 
-    if config.rho_mask_tv_divergence:
-        # don't change rho_effective as it is our truncated importance sampling
-        # calculate sequence-level TV divergence with abs(rho - 1)
-        # filter if TV divergence > delta and advantage * logprob_diff > 0
+    metrics: dict[str, torch.Tensor] = {}
+    if config.rho_divergence_type == RhoDivergenceType.tv:
+        # VACO: keep rho_effective for the truncated importance sampling weights, but mask
+        # on the sequence-level TV divergence mean |ρ - 1|, dropping only tokens whose
+        # update would increase it: advantage * logprob_diff > 0.
         tv_divergence = torch.abs(rho - 1.0)
         tv_sequence_level = _sequence_level_mean(tv_divergence, response_mask)
         tv_dropped_low, tv_dropped_high = _rho_drop_masks(
@@ -439,6 +577,26 @@ def compute_rho_correction(
         tokens_increase_tv = torch.sign(logprob_diff) * advantages > 0
         dropped_low = tv_dropped_low & tokens_increase_tv
         dropped_high = tv_dropped_high & tokens_increase_tv
+        metrics["val/rho_divergence"] = tv_sequence_level.detach().float()
+    elif is_dppo_divergence:
+        # DPPO (Eq. 12): drop tokens outside the trust region δ on the binary divergence
+        # between the current policy π_θ and the rollout policy μ, but only when the update
+        # would push π_θ further from μ: A>0 with π_θ>μ, or A<0 with π_θ<μ.
+        with torch.no_grad():
+            policy_logprobs = new_logprobs.detach()
+            divergence = compute_binary_divergence(
+                behavior_logprobs=vllm_logprobs,
+                policy_logprobs=policy_logprobs,
+                response_mask=response_mask,
+                divergence_type=config.rho_divergence_type,
+            )
+            outside_region = (divergence > config.rho_mask_upper_bound) & response_mask
+            policy_log_ratio = torch.where(
+                response_mask, policy_logprobs - vllm_logprobs, torch.zeros_like(policy_logprobs)
+            )
+            dropped_high = outside_region & (advantages > 0) & (policy_log_ratio > 0)
+            dropped_low = outside_region & (advantages < 0) & (policy_log_ratio < 0)
+            metrics["val/rho_divergence"] = divergence.float()
     else:
         dropped_low, dropped_high = _rho_drop_masks(
             rho_effective, response_mask, config.rho_mask_lower_bound, config.rho_mask_upper_bound
@@ -452,8 +610,10 @@ def compute_rho_correction(
     if config.rho_clamp_upper_bound > 0.0:
         rho_clamped = torch.clamp(rho_clamped, max=config.rho_clamp_upper_bound)
 
-    weights = torch.where(in_range, rho_clamped, torch.zeros_like(rho_clamped))
-    metrics = {
+    # Without the ρ correction (e.g. DPPO with use_vllm_logprobs), kept tokens keep weight 1.
+    kept_weights = rho_clamped if config.use_rho_correction else torch.ones_like(rho_clamped)
+    weights = torch.where(in_range, kept_weights, torch.zeros_like(kept_weights))
+    metrics |= {
         "val/rho_drop_frac": (dropped_low | dropped_high).float(),
         "val/rho_drop_low_frac": dropped_low.float(),
         "val/rho_drop_high_frac": dropped_high.float(),
@@ -501,14 +661,40 @@ def resolve_old_logprob(
     return result
 
 
+@dataclass
+class GRPOLossOutput:
+    """Per-token loss terms plus the intermediates the training loops log.
+
+    ``pg_loss``, ``clipfrac``, and ``kl`` are per-token [B, T] tensors; the total loss is
+    ``pg_loss + beta * kl`` reduced by ``masked_mean``. ``ratio`` is π_θ / π_old and ``rho``
+    carries the ρ-correction weights/metrics that were already folded into ``pg_loss``.
+    """
+
+    pg_loss: torch.Tensor
+    clipfrac: torch.Tensor
+    kl: torch.Tensor
+    ratio: torch.Tensor
+    rho: RhoCorrection
+
+
 def compute_grpo_loss(
     new_logprobs: torch.Tensor,
-    ratio: torch.Tensor,
+    old_logprobs: torch.Tensor,
+    vllm_logprobs: torch.Tensor,
     advantages: torch.Tensor,
     ref_logprobs: torch.Tensor | None,
+    response_mask: torch.Tensor,
     config: GRPOExperimentConfig,
-    rho_weights: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> GRPOLossOutput:
+    """Compute the per-token policy loss: pg objective (``loss_fn``) x ρ correction + KL.
+
+    The importance ratio is π_θ / π_old (``new_logprobs`` - ``old_logprobs``); the ρ
+    correction (:func:`compute_rho_correction`) reweights and drop-masks tokens based on
+    the rollout policy ``vllm_logprobs``.
+    """
+    ratio = torch.exp(new_logprobs - old_logprobs)
+    rho = compute_rho_correction(old_logprobs, vllm_logprobs, new_logprobs, response_mask, advantages, config)
+
     if config.loss_fn == GRPOLossType.dapo:
         pg_losses = -advantages * ratio
         pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - config.clip_lower, 1.0 + config.clip_higher)
@@ -519,11 +705,17 @@ def compute_grpo_loss(
         # reinforce loss, so multiply by new logprobs
         clipfrac = (ratio > 1.0 + config.clip_higher).float()
         pg_loss = -advantages * torch.clamp(ratio.detach(), max=1.0 + config.clip_higher) * new_logprobs
+    elif config.loss_fn == GRPOLossType.dppo:
+        # DPPO (https://arxiv.org/abs/2602.04879) Eq. 11: L = E[Σ_t M_t · r_t · A_t].
+        # No symmetric clipping; the trust-region mask M_t is enforced through the ρ
+        # weights via rho_divergence_type=dppo_tv/dppo_kl (validated in __post_init__).
+        pg_loss = -advantages * ratio
+        clipfrac = torch.zeros_like(pg_loss)
     else:
         raise ValueError(f"Invalid loss function: {config.loss_fn}")
 
-    pg_loss *= rho_weights
-    clipfrac *= (rho_weights != 0).float()
+    pg_loss *= rho.weights
+    clipfrac *= (rho.weights != 0).float()
 
     if ref_logprobs is not None:
         # We want the KL loss to backpropagate through the model.
@@ -535,7 +727,7 @@ def compute_grpo_loss(
     else:
         kl = torch.zeros_like(pg_loss)
 
-    return pg_loss, clipfrac, kl
+    return GRPOLossOutput(pg_loss=pg_loss, clipfrac=clipfrac, kl=kl, ratio=ratio, rho=rho)
 
 
 def forward_for_logprobs(
@@ -682,6 +874,7 @@ _SCALAR_LOSS_STAT_KEYS = [
     "policy/clipfrac_avg",
     "val/ratio",
     "val/rho_clipfrac",
+    "val/rho_divergence",
     "val/rho_weight",
     "val/rho_drop_frac",
     "val/rho_drop_low_frac",
@@ -699,32 +892,28 @@ def create_loss_stats(num_samples: int, device: torch.device, record_entropy: bo
 def populate_sample_loss_stats(
     loss_stats_B: dict[str, torch.Tensor],
     sample_idx: int,
-    pg_loss: torch.Tensor,
-    clipfrac: torch.Tensor,
-    ratio: torch.Tensor,
+    loss_output: GRPOLossOutput,
     loss: torch.Tensor,
     response_mask: torch.Tensor,
     new_logprobs: torch.Tensor,
     ref_logprobs: torch.Tensor | None,
     entropy: torch.Tensor | None,
     config: GRPOExperimentConfig,
-    rho_metrics: dict[str, torch.Tensor] | None = None,
 ) -> None:
     with torch.no_grad():
         if config.load_ref_policy and ref_logprobs is not None:
             ref_logprobs_diff = (new_logprobs - ref_logprobs).clamp(-40.0, 40.0)
-            kl_4BT = model_utils.estimate_kl(ref_logprobs_diff, ratio)
+            kl_4BT = model_utils.estimate_kl(ref_logprobs_diff, loss_output.ratio)
             kl_values = masked_mean(kl_4BT, response_mask).float()
             for j in range(4):
                 loss_stats_B[f"objective/kl{j}_avg"][sample_idx] = kl_values[j]
             loss_stats_B["loss/kl_avg"][sample_idx] = kl_values[config.kl_estimator] * config.beta
-        if rho_metrics is not None:
-            for key, value in rho_metrics.items():
-                loss_stats_B[key][sample_idx] = masked_mean(value, response_mask)
-        loss_stats_B["policy/clipfrac_avg"][sample_idx] = masked_mean(clipfrac, response_mask)
-        loss_stats_B["loss/policy_avg"][sample_idx] = masked_mean(pg_loss, response_mask)
+        for key, value in loss_output.rho.metrics.items():
+            loss_stats_B[key][sample_idx] = masked_mean(value, response_mask)
+        loss_stats_B["policy/clipfrac_avg"][sample_idx] = masked_mean(loss_output.clipfrac, response_mask)
+        loss_stats_B["loss/policy_avg"][sample_idx] = masked_mean(loss_output.pg_loss, response_mask)
         loss_stats_B["loss/total_avg"][sample_idx] = loss
-        loss_stats_B["val/ratio"][sample_idx] = masked_mean(ratio, response_mask)
+        loss_stats_B["val/ratio"][sample_idx] = masked_mean(loss_output.ratio, response_mask)
         if entropy is not None:
             loss_stats_B["policy/entropy_avg"][sample_idx] = masked_mean(entropy, response_mask).float()
 

--- a/open_instruct/grpo_utils.py
+++ b/open_instruct/grpo_utils.py
@@ -73,13 +73,12 @@ class GRPOLossType(enum.StrEnum):
 
 
 class RhoDivergenceType(enum.StrEnum):
-    """Which divergence measure the masking algorithm uses (see :class:`RhoDivergenceAlgo`).
+    """Which binary (Bernoulli) divergence measure the masking algorithm uses.
 
-    ``tv``: total variation — ``vaco`` uses the ratio-space |ρ - 1|; ``dppo`` uses the
-    binary (Bernoulli) |μ - π| (Eq. 13 of https://arxiv.org/abs/2602.04879).
-    ``kl``: KL — ``vaco`` uses the k3 estimator ρ - 1 - log ρ of KL(μ ‖ π^train_old);
-    ``dppo`` uses the binary (Bernoulli) KL (Eq. 14).
-    Ignored by the ``icepop`` algorithm, which masks on ρ itself.
+    ``tv``: total variation |μ - π| (Eq. 13 of https://arxiv.org/abs/2602.04879);
+    ``kl``: KL of the Bernoulli collapse over {sampled token, all others} (Eq. 14).
+    Computed by :func:`compute_binary_divergence`. Ignored by the ``icepop``
+    algorithm, which masks on ρ itself.
     """
 
     tv = "tv"
@@ -93,11 +92,11 @@ class RhoDivergenceAlgo(enum.StrEnum):
     ρ = π^train_old / π^infer_old itself (per token, or per sequence with
     ``rho_mask_sequence_level``).
     ``vaco``: VACO (https://arxiv.org/abs/2603.01365) — sequence-level mean of the
-    per-token divergence between π^train_old and the rollout policy μ, dropping only
-    tokens whose update would increase the divergence.
-    ``dppo``: DPPO (https://arxiv.org/abs/2602.04879) — per-token binary (Bernoulli)
-    divergence between the *current* policy π_θ and the rollout policy μ, dropping only
-    tokens whose update would push π_θ further from μ (Eq. 12).
+    per-token binary divergence between π^train_old and the rollout policy μ, dropping
+    only tokens whose update would increase the divergence.
+    ``dppo``: DPPO (https://arxiv.org/abs/2602.04879) — per-token binary divergence
+    between the *current* policy π_θ and the rollout policy μ, dropping only tokens
+    whose update would push π_θ further from μ (Eq. 12).
     """
 
     icepop = "icepop"
@@ -176,8 +175,8 @@ class GRPOExperimentConfig(
     whose update would *decrease* the divergence are never masked. The ρ clamp/reweighting
     (truncated importance sampling) is unaffected by this choice."""
     rho_divergence_type: RhoDivergenceType = RhoDivergenceType.tv
-    """Which divergence measure `rho_divergence_algo` thresholds: `tv` or `kl`.
-    See :class:`RhoDivergenceType` for the per-algorithm definitions. Ignored by `icepop`."""
+    """Which binary (Bernoulli) divergence measure `rho_divergence_algo` thresholds:
+    `tv` or `kl` (Eqs. 13/14 of https://arxiv.org/abs/2602.04879). Ignored by `icepop`."""
     kl_estimator: Literal[0, 1, 2, 3] = 2
     """the KL estimator to use"""
     loss_denominator: str = "token"
@@ -195,7 +194,9 @@ class GRPOExperimentConfig(
     load_ref_policy: bool = True
     """Whether to load and use a reference policy for KL penalty calculation."""
     loss_fn: GRPOLossType = GRPOLossType.dapo
-    """Whether to use DAPO or CISPO loss function."""
+    """Which policy-loss function to use: `dapo`, `cispo`, or `dppo`. `dppo` is `dapo`
+    with the symmetric ratio clipping disabled; its trust region comes entirely from the
+    `rho_divergence_algo=dppo` drop mask."""
     record_entropy: bool = False
     """whether to record the entropy of the policy during training. Uses extra memory."""
     use_vllm_logprobs: bool = False
@@ -513,7 +514,9 @@ def compute_binary_divergence(
     (https://arxiv.org/abs/2602.04879): collapse the categorical distribution
     over the vocabulary into a Bernoulli over ``{sampled_token, all_others}``
     using only the per-token logprobs. This is a memory-cheap lower bound on
-    the true policy divergence that requires no extra forward passes.
+    the true policy divergence that requires no extra forward passes. It is the
+    shared divergence measure behind both the ``vaco`` and ``dppo`` masking
+    algorithms in :func:`compute_rho_correction`.
 
     Args:
         behavior_logprobs: log μ(a_t|s_t), the rollout (vLLM) policy.
@@ -561,66 +564,59 @@ def compute_rho_correction(
     ρ = π^train_old / π^infer_old corrects the train/infer engine mismatch; when
     ``use_rho_correction`` is on, in-range tokens are reweighted by clamped ρ
     (truncated importance sampling). The drop mask is controlled by
-    ``rho_divergence_algo`` (see :class:`RhoDivergenceAlgo`) using the divergence
+    ``rho_divergence_algo`` (see :class:`RhoDivergenceAlgo`) using the binary divergence
     measure ``rho_divergence_type``; the ``dppo`` algorithm compares the *current*
     policy (``new_logprobs``, detached here) against the rollout policy and therefore
     also applies when ``use_vllm_logprobs`` is on.
     """
+    orig_dtype = old_logprob.dtype
+    # Upcast to float32 and clamp to the valid logprob range before exponentiating.
+    # Real logprobs are <= 0; non-response sentinel positions and NaN replacements can
+    # be > 0 (see ``mask_logprobs`` / INVALID_LOGPROB).
+    old_logprob_f = old_logprob.to(torch.float32).clamp(min=-30.0, max=0.0)
+    vllm_logprobs_f = vllm_logprobs.to(torch.float32).clamp(min=-30.0, max=0.0)
     logprob_diff = torch.where(
-        response_mask, (old_logprob - vllm_logprobs).clamp(-10.0, 10.0), torch.zeros_like(old_logprob)
+        response_mask, (old_logprob_f - vllm_logprobs_f).clamp(-10.0, 10.0), torch.zeros_like(old_logprob_f)
     )
     rho = torch.exp(logprob_diff)
-    rho_hist = {"val/rho_hist": rho[response_mask].detach().float()}
+    rho_hist = {"val/rho_hist": rho[response_mask].detach()}
     is_dppo_algo = config.rho_divergence_algo == RhoDivergenceAlgo.dppo
     if not config.use_rho_correction and not is_dppo_algo:
-        return RhoCorrection(weights=torch.ones_like(rho), metrics={}, histogram_metrics=rho_hist)
+        return RhoCorrection(weights=torch.ones_like(old_logprob), metrics={}, histogram_metrics=rho_hist)
 
     rho_effective = (
         torch.exp(_sequence_level_mean(logprob_diff, response_mask)) if config.rho_mask_sequence_level else rho
     )
 
     metrics: dict[str, torch.Tensor] = {}
-    if config.rho_divergence_algo == RhoDivergenceAlgo.vaco:
-        # VACO: keep rho_effective for the truncated importance sampling weights, but mask
-        # on the sequence-level mean of a per-token divergence between π^train_old and μ,
-        # dropping only tokens whose update would increase it: advantage * logprob_diff > 0.
-        if config.rho_divergence_type == RhoDivergenceType.tv:
-            token_divergence = torch.abs(rho - 1.0)
-        else:
-            # k3 estimator of KL(μ ‖ π^train_old): ρ - 1 - log ρ >= 0 (Schulman,
-            # http://joschu.net/blog/kl-approx.html), with tokens sampled from μ.
-            token_divergence = rho - 1.0 - logprob_diff
-        sequence_divergence = _sequence_level_mean(token_divergence, response_mask)
-        divergence_dropped_low, divergence_dropped_high = _rho_drop_masks(
-            sequence_divergence, response_mask, config.rho_mask_lower_bound, config.rho_mask_upper_bound
+    if config.rho_divergence_algo == RhoDivergenceAlgo.icepop:
+        dropped_low, dropped_high = _rho_drop_masks(
+            rho_effective, response_mask, config.rho_mask_lower_bound, config.rho_mask_upper_bound
         )
-        tokens_increase_divergence = torch.sign(logprob_diff) * advantages > 0
-        dropped_low = divergence_dropped_low & tokens_increase_divergence
-        dropped_high = divergence_dropped_high & tokens_increase_divergence
-        metrics["val/rho_divergence"] = sequence_divergence.detach().float()
-    elif is_dppo_algo:
-        # DPPO (Eq. 12): drop tokens outside the trust region δ on the binary divergence
-        # between the current policy π_θ and the rollout policy μ, but only when the update
-        # would push π_θ further from μ: A>0 with π_θ>μ, or A<0 with π_θ<μ.
+    else:
+        # VACO and DPPO share the same structure: a binary divergence against the rollout
+        # policy μ is thresholded by the mask bounds, dropping only tokens whose update
+        # would *increase* the divergence: sign(log(π/μ)) * advantage > 0. They differ in
+        # the compared policy π and the aggregation level: VACO uses π^train_old at the
+        # sequence level; DPPO uses the current π_θ per token (Eq. 12).
         with torch.no_grad():
-            policy_logprobs = new_logprobs.detach()
+            policy_logprobs = new_logprobs.detach() if is_dppo_algo else old_logprob
             divergence = compute_binary_divergence(
                 behavior_logprobs=vllm_logprobs,
                 policy_logprobs=policy_logprobs,
                 response_mask=response_mask,
                 divergence_type=config.rho_divergence_type,
             )
-            outside_region = (divergence > config.rho_mask_upper_bound) & response_mask
-            policy_log_ratio = torch.where(
-                response_mask, policy_logprobs - vllm_logprobs, torch.zeros_like(policy_logprobs)
+            if config.rho_divergence_algo == RhoDivergenceAlgo.vaco:
+                divergence = _sequence_level_mean(divergence, response_mask)
+            divergence_low, divergence_high = _rho_drop_masks(
+                divergence, response_mask, config.rho_mask_lower_bound, config.rho_mask_upper_bound
             )
-            dropped_high = outside_region & (advantages > 0) & (policy_log_ratio > 0)
-            dropped_low = outside_region & (advantages < 0) & (policy_log_ratio < 0)
+            policy_log_ratio = policy_logprobs.to(torch.float32).clamp(min=-30.0, max=0.0) - vllm_logprobs_f
+            moving_away = torch.sign(policy_log_ratio) * advantages > 0
+            dropped_low = divergence_low & moving_away
+            dropped_high = divergence_high & moving_away
             metrics["val/rho_divergence"] = divergence.float()
-    else:
-        dropped_low, dropped_high = _rho_drop_masks(
-            rho_effective, response_mask, config.rho_mask_lower_bound, config.rho_mask_upper_bound
-        )
 
     in_range = response_mask & ~dropped_low & ~dropped_high
 
@@ -632,7 +628,7 @@ def compute_rho_correction(
 
     # Without the ρ correction (e.g. DPPO with use_vllm_logprobs), kept tokens keep weight 1.
     kept_weights = rho_clamped if config.use_rho_correction else torch.ones_like(rho_clamped)
-    weights = torch.where(in_range, kept_weights, torch.zeros_like(kept_weights))
+    weights = torch.where(in_range, kept_weights, torch.zeros_like(kept_weights)).to(orig_dtype)
     metrics |= {
         "val/rho_drop_frac": (dropped_low | dropped_high).float(),
         "val/rho_drop_low_frac": dropped_low.float(),
@@ -715,9 +711,17 @@ def compute_grpo_loss(
     ratio = torch.exp(new_logprobs - old_logprobs)
     rho = compute_rho_correction(old_logprobs, vllm_logprobs, new_logprobs, response_mask, advantages, config)
 
-    if config.loss_fn == GRPOLossType.dapo:
+    if config.loss_fn in (GRPOLossType.dapo, GRPOLossType.dppo):
+        # DPPO (https://arxiv.org/abs/2602.04879) Eq. 11 (L = E[Σ_t M_t · r_t · A_t]) is
+        # DAPO with the symmetric ratio clipping disabled: its trust-region mask M_t is
+        # enforced through the ρ weights via rho_divergence_algo=dppo (validated in
+        # __post_init__), so the clamp is widened to a no-op.
+        if config.loss_fn == GRPOLossType.dapo:
+            clip_lower, clip_higher = config.clip_lower, config.clip_higher
+        else:
+            clip_lower, clip_higher = math.inf, math.inf
         pg_losses = -advantages * ratio
-        pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - config.clip_lower, 1.0 + config.clip_higher)
+        pg_losses2 = -advantages * torch.clamp(ratio, 1.0 - clip_lower, 1.0 + clip_higher)
         clipfrac = (pg_losses2 > pg_losses).float()
         pg_loss = torch.max(pg_losses, pg_losses2)
     elif config.loss_fn == GRPOLossType.cispo:
@@ -725,12 +729,6 @@ def compute_grpo_loss(
         # reinforce loss, so multiply by new logprobs
         clipfrac = (ratio > 1.0 + config.clip_higher).float()
         pg_loss = -advantages * torch.clamp(ratio.detach(), max=1.0 + config.clip_higher) * new_logprobs
-    elif config.loss_fn == GRPOLossType.dppo:
-        # DPPO (https://arxiv.org/abs/2602.04879) Eq. 11: L = E[Σ_t M_t · r_t · A_t].
-        # No symmetric clipping; the trust-region mask M_t is enforced through the ρ
-        # weights via rho_divergence_algo=dppo (validated in __post_init__).
-        pg_loss = -advantages * ratio
-        clipfrac = torch.zeros_like(pg_loss)
     else:
         raise ValueError(f"Invalid loss function: {config.loss_fn}")
 

--- a/open_instruct/olmo_core_train_modules.py
+++ b/open_instruct/olmo_core_train_modules.py
@@ -544,26 +544,22 @@ class GRPOTrainModule(TransformerTrainModule):
 
                 advantages = data_BT.advantages[sample_idx]
 
-                log_ratio = new_logprobs - old_logprob
-                ratio = torch.exp(log_ratio)
-
-                rho = grpo_utils.compute_rho_correction(
-                    old_logprob, vllm_logprobs, response_mask, advantages[:, 1:], self.grpo_config
-                )
-                grpo_utils.accumulate_rho_histograms(rho_histograms, rho)
-
-                pg_loss, clipfrac, kl = grpo_utils.compute_grpo_loss(
+                loss_output = grpo_utils.compute_grpo_loss(
                     new_logprobs=new_logprobs,
-                    ratio=ratio,
+                    old_logprobs=old_logprob,
+                    vllm_logprobs=vllm_logprobs,
                     advantages=advantages[:, 1:],
                     ref_logprobs=ref_logprobs_BT[sample_idx] if ref_logprobs_BT is not None else None,
+                    response_mask=response_mask,
                     config=self.grpo_config,
-                    rho_weights=rho.weights,
                 )
+                grpo_utils.accumulate_rho_histograms(rho_histograms, loss_output.rho)
 
                 batch_start = (sample_idx // accumulation_steps) * accumulation_steps
                 loss_denominator = accumulation_token_counts[batch_start]
-                loss = masked_mean(pg_loss + self.grpo_config.beta * kl, response_mask, None, loss_denominator)
+                loss = masked_mean(
+                    loss_output.pg_loss + self.grpo_config.beta * loss_output.kl, response_mask, None, loss_denominator
+                )
 
                 loss = loss * dp_world_size
                 loss.backward()
@@ -571,16 +567,13 @@ class GRPOTrainModule(TransformerTrainModule):
                 grpo_utils.populate_sample_loss_stats(
                     loss_stats_B,
                     sample_idx,
-                    pg_loss,
-                    clipfrac,
-                    ratio,
+                    loss_output,
                     loss,
                     response_mask,
                     new_logprobs,
                     ref_logprobs_BT[sample_idx] if ref_logprobs_BT is not None else None,
                     entropy,
                     self.grpo_config,
-                    rho_metrics=rho.metrics,
                 )
 
                 num_steps += 1

--- a/open_instruct/test_olmo_core_train_modules.py
+++ b/open_instruct/test_olmo_core_train_modules.py
@@ -298,7 +298,7 @@ class TestComputeGRPOLoss(unittest.TestCase):
         # ρ = π_old / μ = 2 everywhere; with clamps disabled the kept tokens are reweighted by 2.
         config = _make_grpo_config(use_rho_correction=True)
         new_logprobs = torch.randn(2, 4)
-        old_logprobs = torch.randn(2, 4)
+        old_logprobs = -torch.rand(2, 4) - 0.1
         vllm_logprobs = old_logprobs - torch.log(torch.tensor(2.0))
         advantages = torch.randn(2, 4)
         response_mask = torch.ones(2, 4, dtype=torch.bool)
@@ -322,8 +322,8 @@ class TestComputeGRPOLoss(unittest.TestCase):
         response_mask = torch.tensor([[True, True, True, True, True]])
         # ρ values: 0.25 (drop, < lower=0.5), 0.5 (keep), 1.0 (keep), 2.0 (keep), 4.0 (drop, > upper=2.0).
         # In-range tokens are reweighted by ρ, not gated to 1.
-        old_logprob = torch.log(torch.tensor([[0.25, 0.5, 1.0, 2.0, 4.0]]))
-        vllm_logprobs = torch.zeros_like(old_logprob)
+        vllm_logprobs = torch.log(torch.full((1, 5), 0.2))
+        old_logprob = vllm_logprobs + torch.log(torch.tensor([[0.25, 0.5, 1.0, 2.0, 4.0]]))
         advantages = torch.ones_like(old_logprob)
         correction = grpo_utils.compute_rho_correction(
             old_logprob, vllm_logprobs, old_logprob, response_mask, advantages, config
@@ -352,8 +352,8 @@ class TestComputeGRPOLoss(unittest.TestCase):
         # Row 0: per-token ρ = [0.25, 1.0, 4.0]; mean log ρ = 0 → ρ_seq = 1 (kept).
         # Row 1: per-token ρ = [4.0, 4.0, 4.0]; mean log ρ = log 4 → ρ_seq = 4 (drop high).
         # Row 2: per-token ρ = [0.25, 0.25, 0.25]; ρ_seq = 0.25 (drop low).
-        old_logprob = torch.log(torch.tensor([[0.25, 1.0, 4.0], [4.0, 4.0, 4.0], [0.25, 0.25, 0.25]]))
-        vllm_logprobs = torch.zeros_like(old_logprob)
+        vllm_logprobs = torch.log(torch.full((3, 3), 0.2))
+        old_logprob = vllm_logprobs + torch.log(torch.tensor([[0.25, 1.0, 4.0], [4.0, 4.0, 4.0], [0.25, 0.25, 0.25]]))
         response_mask = torch.ones_like(old_logprob, dtype=torch.bool)
         advantages = torch.ones_like(old_logprob)
         correction = grpo_utils.compute_rho_correction(
@@ -375,26 +375,28 @@ class TestComputeGRPOLoss(unittest.TestCase):
         config = _make_grpo_config(
             use_rho_correction=True,
             rho_mask_lower_bound=0.0,
-            rho_mask_upper_bound=2.0,
+            rho_mask_upper_bound=0.3,
             rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.vaco,
         )
-        # Row 0: mean |ρ - 1| = 1.25, below upper=2.0, so it is kept.
-        # Row 1: mean |ρ - 1| = 3.0, above upper=2.0, so TV-increasing tokens are dropped.
-        old_logprob = torch.log(torch.tensor([[0.25, 1.0, 4.0], [4.0, 4.0, 4.0]]))
-        vllm_logprobs = torch.zeros_like(old_logprob)
+        # Sequence-level mean binary TV |μ - π_old| per row:
+        # Row 0: |0.5 - 0.4| = 0.1 < 0.3 → kept, reweighted by ρ = 0.4/0.5 = 0.8.
+        # Row 1: |0.1 - 0.6| = 0.5 > 0.3 and A>0 with π_old>μ increases it → dropped.
+        # Row 2: same divergence but A<0 with π_old>μ *decreases* it → kept, ρ = 6.
+        vllm_logprobs = torch.log(torch.tensor([[0.5] * 3, [0.1] * 3, [0.1] * 3]))
+        old_logprob = torch.log(torch.tensor([[0.4] * 3, [0.6] * 3, [0.6] * 3]))
         response_mask = torch.ones_like(old_logprob, dtype=torch.bool)
-        advantages = torch.ones_like(old_logprob)
+        advantages = torch.tensor([[1.0] * 3, [1.0] * 3, [-1.0] * 3])
 
         correction = grpo_utils.compute_rho_correction(
             old_logprob, vllm_logprobs, old_logprob, response_mask, advantages, config
         )
 
-        torch.testing.assert_close(correction.weights, torch.tensor([[0.25, 1.0, 4.0], [0.0, 0.0, 0.0]]))
+        torch.testing.assert_close(correction.weights, torch.tensor([[0.8] * 3, [0.0] * 3, [6.0] * 3]))
         torch.testing.assert_close(
-            correction.metrics["val/rho_drop_high_frac"], torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+            correction.metrics["val/rho_drop_high_frac"], torch.tensor([[0.0] * 3, [1.0] * 3, [0.0] * 3])
         )
         torch.testing.assert_close(
-            correction.metrics["val/rho_divergence"], torch.tensor([[1.25, 1.25, 1.25], [3.0, 3.0, 3.0]])
+            correction.metrics["val/rho_divergence"], torch.tensor([[0.1] * 3, [0.5] * 3, [0.5] * 3])
         )
 
     def test_vaco_kl_divergence(self):
@@ -405,10 +407,11 @@ class TestComputeGRPOLoss(unittest.TestCase):
             rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.vaco,
             rho_divergence_type=grpo_utils.RhoDivergenceType.kl,
         )
-        # k3 = ρ - 1 - log ρ. Row 0: ρ = 1 everywhere → divergence 0 (kept).
-        # Row 1: ρ = 4 everywhere → k3 = 3 - log 4 ≈ 1.614 > 1.0 (dropped).
-        old_logprob = torch.log(torch.tensor([[1.0, 1.0, 1.0], [4.0, 4.0, 4.0]]))
-        vllm_logprobs = torch.zeros_like(old_logprob)
+        # Sequence-level mean binary KL(μ ‖ π_old) per row:
+        # Row 0: μ = π_old → 0 (kept, ρ = 1).
+        # Row 1: μ=0.1, π_old=0.9 → 0.8·log(9) ≈ 1.76 > 1.0, and A>0 with π_old>μ → dropped.
+        vllm_logprobs = torch.log(torch.tensor([[0.5, 0.5], [0.1, 0.1]]))
+        old_logprob = torch.log(torch.tensor([[0.5, 0.5], [0.9, 0.9]]))
         response_mask = torch.ones_like(old_logprob, dtype=torch.bool)
         advantages = torch.ones_like(old_logprob)
 
@@ -416,17 +419,20 @@ class TestComputeGRPOLoss(unittest.TestCase):
             old_logprob, vllm_logprobs, old_logprob, response_mask, advantages, config
         )
 
-        torch.testing.assert_close(correction.weights, torch.tensor([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]]))
-        expected_divergence = 3.0 - torch.log(torch.tensor(4.0))
+        torch.testing.assert_close(correction.weights, torch.tensor([[1.0, 1.0], [0.0, 0.0]]))
+        expected_divergence = 0.8 * torch.log(torch.tensor(9.0))
         torch.testing.assert_close(
-            correction.metrics["val/rho_divergence"], torch.stack([torch.zeros(3), expected_divergence.expand(3)])
+            correction.metrics["val/rho_divergence"],
+            torch.stack([torch.zeros(2), expected_divergence.expand(2)]),
+            atol=1e-4,
+            rtol=1e-4,
         )
 
     def test_rho_mask_zeroes_loss(self):
         # ρ values [1.0, 4.0, 1.0] with mask bounds (0.5, 2.0): the middle token is dropped.
         config = _make_grpo_config(use_rho_correction=True, rho_mask_lower_bound=0.5, rho_mask_upper_bound=2.0)
         new_logprobs = torch.randn(1, 3)
-        old_logprobs = torch.randn(1, 3)
+        old_logprobs = -torch.rand(1, 3) - 0.1
         vllm_logprobs = old_logprobs - torch.log(torch.tensor([[1.0, 4.0, 1.0]]))
         advantages = torch.randn(1, 3)
 
@@ -571,7 +577,7 @@ class TestDPPODivergenceMask(unittest.TestCase):
         )
 
         torch.testing.assert_close(correction.weights, torch.tensor([[0.0, 1.0]]))
-        torch.testing.assert_close(correction.metrics["val/rho_drop_low_frac"], torch.tensor([[1.0, 0.0]]))
+        torch.testing.assert_close(correction.metrics["val/rho_drop_high_frac"], torch.tensor([[1.0, 0.0]]))
 
     def test_padding_positions_zeroed(self):
         config = _make_dppo_config()

--- a/open_instruct/test_olmo_core_train_modules.py
+++ b/open_instruct/test_olmo_core_train_modules.py
@@ -165,7 +165,7 @@ def _make_grpo_config(**kwargs) -> grpo_utils.GRPOExperimentConfig:
         "rho_clamp_upper_bound": 0.0,
         "rho_mask_lower_bound": 0.0,
         "rho_mask_upper_bound": 0.0,
-        "rho_mask_tv_divergence": False,
+        "rho_divergence_type": grpo_utils.RhoDivergenceType.rho,
         "use_rho_correction": False,
     }
     defaults.update(kwargs)
@@ -175,132 +175,146 @@ def _make_grpo_config(**kwargs) -> grpo_utils.GRPOExperimentConfig:
     return config
 
 
+def _old_logprobs_for_ratio(new_logprobs: torch.Tensor, ratio: torch.Tensor) -> torch.Tensor:
+    """Old logprobs such that exp(new - old) equals ``ratio``."""
+    return new_logprobs.detach() - torch.log(ratio)
+
+
 class TestComputeGRPOLoss(unittest.TestCase):
-    @parameterized.expand([("dapo", grpo_utils.GRPOLossType.dapo), ("cispo", grpo_utils.GRPOLossType.cispo)])
+    @parameterized.expand(
+        [
+            ("dapo", grpo_utils.GRPOLossType.dapo),
+            ("cispo", grpo_utils.GRPOLossType.cispo),
+            ("dppo", grpo_utils.GRPOLossType.dppo),
+        ]
+    )
     def test_output_shapes(self, _name, loss_type):
         batch_size, seq_len = 2, 4
         config = _make_grpo_config(loss_fn=loss_type)
         new_logprobs = torch.randn(batch_size, seq_len)
-        ratio = torch.exp(torch.randn(batch_size, seq_len))
+        old_logprobs = torch.randn(batch_size, seq_len)
         advantages = torch.randn(batch_size, seq_len)
 
-        pg_loss, clipfrac, kl = grpo_utils.compute_grpo_loss(
+        output = grpo_utils.compute_grpo_loss(
             new_logprobs=new_logprobs,
-            ratio=ratio,
+            old_logprobs=old_logprobs,
+            vllm_logprobs=old_logprobs,
             advantages=advantages,
             ref_logprobs=None,
+            response_mask=torch.ones(batch_size, seq_len, dtype=torch.bool),
             config=config,
-            rho_weights=torch.ones_like(ratio),
         )
 
-        self.assertEqual(pg_loss.shape, (batch_size, seq_len))
-        self.assertEqual(clipfrac.shape, (batch_size, seq_len))
-        self.assertEqual(kl.shape, (batch_size, seq_len))
+        self.assertEqual(output.pg_loss.shape, (batch_size, seq_len))
+        self.assertEqual(output.clipfrac.shape, (batch_size, seq_len))
+        self.assertEqual(output.kl.shape, (batch_size, seq_len))
+        self.assertEqual(output.ratio.shape, (batch_size, seq_len))
 
     def test_dapo_clipping(self):
         config = _make_grpo_config(clip_lower=0.2, clip_higher=0.2)
         ratio = torch.tensor([[1.5, 0.5, 1.0]])
         new_logprobs = torch.randn(1, 3)
+        old_logprobs = _old_logprobs_for_ratio(new_logprobs, ratio)
         advantages = torch.ones(1, 3)
 
-        pg_loss, clipfrac, _ = grpo_utils.compute_grpo_loss(
+        output = grpo_utils.compute_grpo_loss(
             new_logprobs=new_logprobs,
-            ratio=ratio,
+            old_logprobs=old_logprobs,
+            vllm_logprobs=old_logprobs,
             advantages=advantages,
             ref_logprobs=None,
+            response_mask=torch.ones(1, 3, dtype=torch.bool),
             config=config,
-            rho_weights=torch.ones_like(ratio),
         )
 
         expected_clamped = torch.clamp(ratio, 0.8, 1.2)
         expected_unclipped = -advantages * ratio
         expected_clipped = -advantages * expected_clamped
-        torch.testing.assert_close(pg_loss, torch.max(expected_unclipped, expected_clipped))
-        torch.testing.assert_close(clipfrac, (expected_clipped > expected_unclipped).float())
+        torch.testing.assert_close(output.pg_loss, torch.max(expected_unclipped, expected_clipped))
+        torch.testing.assert_close(output.clipfrac, (expected_clipped > expected_unclipped).float())
 
     def test_cispo_uses_detached_ratio(self):
         config = _make_grpo_config(loss_fn=grpo_utils.GRPOLossType.cispo, clip_higher=0.2)
-        ratio = torch.tensor([[1.5, 0.5, 1.0]], requires_grad=True)
+        ratio = torch.tensor([[1.5, 0.5, 1.0]])
         new_logprobs = torch.randn(1, 3, requires_grad=True)
+        old_logprobs = _old_logprobs_for_ratio(new_logprobs, ratio)
         advantages = torch.ones(1, 3)
 
-        pg_loss, clipfrac, _ = grpo_utils.compute_grpo_loss(
+        output = grpo_utils.compute_grpo_loss(
             new_logprobs=new_logprobs,
-            ratio=ratio,
+            old_logprobs=old_logprobs,
+            vllm_logprobs=old_logprobs,
             advantages=advantages,
             ref_logprobs=None,
+            response_mask=torch.ones(1, 3, dtype=torch.bool),
             config=config,
-            rho_weights=torch.ones_like(ratio),
         )
 
-        pg_loss.sum().backward()
-        self.assertIsNone(ratio.grad)
-        self.assertIsNotNone(new_logprobs.grad)
-        torch.testing.assert_close(clipfrac, torch.tensor([[1.0, 0.0, 0.0]]))
+        output.pg_loss.sum().backward()
+        # The clipped ratio is detached, so the only gradient path is the REINFORCE term.
+        torch.testing.assert_close(new_logprobs.grad, -advantages * torch.clamp(ratio, max=1.2))
+        torch.testing.assert_close(output.clipfrac, torch.tensor([[1.0, 0.0, 0.0]]))
 
     def test_with_ref_logprobs(self):
         config = _make_grpo_config(beta=0.05, kl_estimator=2)
         batch_size, seq_len = 2, 4
         new_logprobs = torch.randn(batch_size, seq_len)
-        ratio = torch.exp(torch.randn(batch_size, seq_len))
+        old_logprobs = torch.randn(batch_size, seq_len)
         advantages = torch.randn(batch_size, seq_len)
         ref_logprobs = torch.randn(batch_size, seq_len)
 
-        _, _, kl = grpo_utils.compute_grpo_loss(
+        output = grpo_utils.compute_grpo_loss(
             new_logprobs=new_logprobs,
-            ratio=ratio,
+            old_logprobs=old_logprobs,
+            vllm_logprobs=old_logprobs,
             advantages=advantages,
             ref_logprobs=ref_logprobs,
+            response_mask=torch.ones(batch_size, seq_len, dtype=torch.bool),
             config=config,
-            rho_weights=torch.ones_like(ratio),
         )
 
-        self.assertFalse(torch.all(kl == 0))
+        self.assertFalse(torch.all(output.kl == 0))
 
     def test_without_ref_logprobs(self):
         config = _make_grpo_config()
         new_logprobs = torch.randn(2, 4)
-        ratio = torch.exp(torch.randn(2, 4))
+        old_logprobs = torch.randn(2, 4)
         advantages = torch.randn(2, 4)
 
-        _, _, kl = grpo_utils.compute_grpo_loss(
+        output = grpo_utils.compute_grpo_loss(
             new_logprobs=new_logprobs,
-            ratio=ratio,
+            old_logprobs=old_logprobs,
+            vllm_logprobs=old_logprobs,
             advantages=advantages,
             ref_logprobs=None,
+            response_mask=torch.ones(2, 4, dtype=torch.bool),
             config=config,
-            rho_weights=torch.ones_like(ratio),
         )
 
-        torch.testing.assert_close(kl, torch.zeros_like(kl))
+        torch.testing.assert_close(output.kl, torch.zeros_like(output.kl))
 
-    def test_rho_weights(self):
-        config = _make_grpo_config()
+    def test_rho_weights_scale_loss(self):
+        # ρ = π_old / μ = 2 everywhere; with clamps disabled the kept tokens are reweighted by 2.
+        config = _make_grpo_config(use_rho_correction=True)
         new_logprobs = torch.randn(2, 4)
-        ratio = torch.exp(torch.randn(2, 4))
+        old_logprobs = torch.randn(2, 4)
+        vllm_logprobs = old_logprobs - torch.log(torch.tensor(2.0))
         advantages = torch.randn(2, 4)
-        rho_weights = torch.full((2, 4), 2.0)
+        response_mask = torch.ones(2, 4, dtype=torch.bool)
 
-        pg_no_rho, clipfrac_no_rho, _ = grpo_utils.compute_grpo_loss(
+        common = dict(
             new_logprobs=new_logprobs,
-            ratio=ratio,
+            old_logprobs=old_logprobs,
             advantages=advantages,
             ref_logprobs=None,
+            response_mask=response_mask,
             config=config,
-            rho_weights=torch.ones_like(new_logprobs),
         )
+        output_no_rho = grpo_utils.compute_grpo_loss(vllm_logprobs=old_logprobs, **common)
+        output_rho = grpo_utils.compute_grpo_loss(vllm_logprobs=vllm_logprobs, **common)
 
-        pg_rho, clipfrac_rho, _ = grpo_utils.compute_grpo_loss(
-            new_logprobs=new_logprobs,
-            ratio=ratio,
-            advantages=advantages,
-            ref_logprobs=None,
-            config=config,
-            rho_weights=rho_weights,
-        )
-
-        torch.testing.assert_close(pg_rho, pg_no_rho * 2.0)
-        torch.testing.assert_close(clipfrac_rho, clipfrac_no_rho)
+        torch.testing.assert_close(output_rho.pg_loss, output_no_rho.pg_loss * 2.0)
+        torch.testing.assert_close(output_rho.clipfrac, output_no_rho.clipfrac)
 
     def test_rho_mask(self):
         config = _make_grpo_config(use_rho_correction=True, rho_mask_lower_bound=0.5, rho_mask_upper_bound=2.0)
@@ -310,7 +324,9 @@ class TestComputeGRPOLoss(unittest.TestCase):
         old_logprob = torch.log(torch.tensor([[0.25, 0.5, 1.0, 2.0, 4.0]]))
         vllm_logprobs = torch.zeros_like(old_logprob)
         advantages = torch.ones_like(old_logprob)
-        correction = grpo_utils.compute_rho_correction(old_logprob, vllm_logprobs, response_mask, advantages, config)
+        correction = grpo_utils.compute_rho_correction(
+            old_logprob, vllm_logprobs, old_logprob, response_mask, advantages, config
+        )
         torch.testing.assert_close(correction.weights, torch.tensor([[0.0, 0.5, 1.0, 2.0, 0.0]]))
         torch.testing.assert_close(
             correction.metrics["val/rho_drop_low_frac"], torch.tensor([[1.0, 0.0, 0.0, 0.0, 0.0]])
@@ -322,7 +338,7 @@ class TestComputeGRPOLoss(unittest.TestCase):
         # Padding tokens (response_mask=False) should always be 0 / not counted as dropped.
         response_mask_with_pad = torch.tensor([[False, True, True, True, False]])
         correction_pad = grpo_utils.compute_rho_correction(
-            old_logprob, vllm_logprobs, response_mask_with_pad, advantages, config
+            old_logprob, vllm_logprobs, old_logprob, response_mask_with_pad, advantages, config
         )
         torch.testing.assert_close(correction_pad.weights, torch.tensor([[0.0, 0.5, 1.0, 2.0, 0.0]]))
         torch.testing.assert_close(correction_pad.metrics["val/rho_drop_low_frac"], torch.zeros((1, 5)))
@@ -339,7 +355,9 @@ class TestComputeGRPOLoss(unittest.TestCase):
         vllm_logprobs = torch.zeros_like(old_logprob)
         response_mask = torch.ones_like(old_logprob, dtype=torch.bool)
         advantages = torch.ones_like(old_logprob)
-        correction = grpo_utils.compute_rho_correction(old_logprob, vllm_logprobs, response_mask, advantages, config)
+        correction = grpo_utils.compute_rho_correction(
+            old_logprob, vllm_logprobs, old_logprob, response_mask, advantages, config
+        )
         torch.testing.assert_close(
             correction.weights, torch.tensor([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
         )
@@ -354,7 +372,10 @@ class TestComputeGRPOLoss(unittest.TestCase):
 
     def test_rho_mask_tv_divergence(self):
         config = _make_grpo_config(
-            use_rho_correction=True, rho_mask_lower_bound=0.0, rho_mask_upper_bound=2.0, rho_mask_tv_divergence=True
+            use_rho_correction=True,
+            rho_mask_lower_bound=0.0,
+            rho_mask_upper_bound=2.0,
+            rho_divergence_type=grpo_utils.RhoDivergenceType.tv,
         )
         # Row 0: mean |ρ - 1| = 1.25, below upper=2.0, so it is kept.
         # Row 1: mean |ρ - 1| = 3.0, above upper=2.0, so TV-increasing tokens are dropped.
@@ -363,43 +384,273 @@ class TestComputeGRPOLoss(unittest.TestCase):
         response_mask = torch.ones_like(old_logprob, dtype=torch.bool)
         advantages = torch.ones_like(old_logprob)
 
-        correction = grpo_utils.compute_rho_correction(old_logprob, vllm_logprobs, response_mask, advantages, config)
+        correction = grpo_utils.compute_rho_correction(
+            old_logprob, vllm_logprobs, old_logprob, response_mask, advantages, config
+        )
 
         torch.testing.assert_close(correction.weights, torch.tensor([[0.25, 1.0, 4.0], [0.0, 0.0, 0.0]]))
         torch.testing.assert_close(
             correction.metrics["val/rho_drop_high_frac"], torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
         )
+        torch.testing.assert_close(
+            correction.metrics["val/rho_divergence"], torch.tensor([[1.25, 1.25, 1.25], [3.0, 3.0, 3.0]])
+        )
 
     def test_rho_mask_zeroes_loss(self):
-        config = _make_grpo_config()
+        # ρ values [1.0, 4.0, 1.0] with mask bounds (0.5, 2.0): the middle token is dropped.
+        config = _make_grpo_config(use_rho_correction=True, rho_mask_lower_bound=0.5, rho_mask_upper_bound=2.0)
         new_logprobs = torch.randn(1, 3)
-        ratio = torch.exp(torch.randn(1, 3))
+        old_logprobs = torch.randn(1, 3)
+        vllm_logprobs = old_logprobs - torch.log(torch.tensor([[1.0, 4.0, 1.0]]))
         advantages = torch.randn(1, 3)
-        rho_mask = torch.tensor([[1.0, 0.0, 1.0]])
 
-        pg_loss, clipfrac, _ = grpo_utils.compute_grpo_loss(
+        output = grpo_utils.compute_grpo_loss(
             new_logprobs=new_logprobs,
-            ratio=ratio,
+            old_logprobs=old_logprobs,
+            vllm_logprobs=vllm_logprobs,
             advantages=advantages,
             ref_logprobs=None,
+            response_mask=torch.ones(1, 3, dtype=torch.bool),
             config=config,
-            rho_weights=rho_mask,
         )
-        self.assertEqual(pg_loss[0, 1].item(), 0.0)
-        self.assertEqual(clipfrac[0, 1].item(), 0.0)
-        self.assertNotEqual(pg_loss[0, 0].item(), 0.0)
+        self.assertEqual(output.pg_loss[0, 1].item(), 0.0)
+        self.assertEqual(output.clipfrac[0, 1].item(), 0.0)
+        self.assertNotEqual(output.pg_loss[0, 0].item(), 0.0)
 
     def test_invalid_loss_fn(self):
         config = _make_grpo_config(loss_fn="invalid")
         with self.assertRaises(ValueError):
             grpo_utils.compute_grpo_loss(
                 new_logprobs=torch.randn(2, 4),
-                ratio=torch.exp(torch.randn(2, 4)),
+                old_logprobs=torch.randn(2, 4),
+                vllm_logprobs=torch.randn(2, 4),
                 advantages=torch.randn(2, 4),
                 ref_logprobs=None,
+                response_mask=torch.ones(2, 4, dtype=torch.bool),
                 config=config,
-                rho_weights=torch.ones(2, 4),
             )
+
+
+class TestComputeBinaryDivergence(unittest.TestCase):
+    def test_tv_matches_definition(self):
+        # Eq. 13 in arXiv:2602.04879: D_TV^Bin = |μ - π|.
+        behavior_logprobs = torch.log(torch.tensor([[0.1, 0.5, 0.9]]))
+        policy_logprobs = torch.log(torch.tensor([[0.2, 0.5, 0.3]]))
+        response_mask = torch.ones_like(behavior_logprobs, dtype=torch.bool)
+
+        divergence = grpo_utils.compute_binary_divergence(
+            behavior_logprobs=behavior_logprobs,
+            policy_logprobs=policy_logprobs,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.RhoDivergenceType.dppo_tv,
+        )
+
+        torch.testing.assert_close(divergence, torch.tensor([[0.1, 0.0, 0.6]]), atol=1e-5, rtol=1e-5)
+
+    def test_kl_zero_when_distributions_match(self):
+        logprobs = torch.log(torch.tensor([[0.3, 0.7]]))
+        response_mask = torch.ones_like(logprobs, dtype=torch.bool)
+
+        divergence = grpo_utils.compute_binary_divergence(
+            behavior_logprobs=logprobs,
+            policy_logprobs=logprobs,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.RhoDivergenceType.dppo_kl,
+        )
+
+        torch.testing.assert_close(divergence, torch.zeros_like(divergence), atol=1e-5, rtol=1e-5)
+
+    def test_response_mask_zeroes_invalid_positions(self):
+        behavior_logprobs = torch.tensor([[INVALID_LOGPROB, -0.1]])
+        policy_logprobs = torch.tensor([[INVALID_LOGPROB, -2.0]])
+        response_mask = torch.tensor([[False, True]])
+
+        divergence = grpo_utils.compute_binary_divergence(
+            behavior_logprobs=behavior_logprobs,
+            policy_logprobs=policy_logprobs,
+            response_mask=response_mask,
+            divergence_type=grpo_utils.RhoDivergenceType.dppo_tv,
+        )
+
+        self.assertEqual(float(divergence[0, 0]), 0.0)
+        self.assertGreater(float(divergence[0, 1]), 0.0)
+
+    def test_non_dppo_divergence_type_raises(self):
+        with self.assertRaises(ValueError):
+            grpo_utils.compute_binary_divergence(
+                behavior_logprobs=torch.zeros(1, 1),
+                policy_logprobs=torch.zeros(1, 1),
+                response_mask=torch.ones(1, 1, dtype=torch.bool),
+                divergence_type=grpo_utils.RhoDivergenceType.tv,
+            )
+
+
+def _make_dppo_config(**kwargs) -> grpo_utils.GRPOExperimentConfig:
+    defaults = {
+        "use_rho_correction": False,
+        "rho_divergence_type": grpo_utils.RhoDivergenceType.dppo_tv,
+        "rho_mask_upper_bound": 0.05,
+        "rho_mask_lower_bound": 0.0,
+    }
+    defaults.update(kwargs)
+    return _make_grpo_config(**defaults)
+
+
+class TestDPPODivergenceMask(unittest.TestCase):
+    def test_blocks_only_unsafe_directions(self):
+        config = _make_dppo_config()
+        # μ = 0.1, π_θ = 0.5 → binary TV = 0.4 > δ = 0.05 everywhere; ratio > 1.
+        # Per Eq. 12: A>0 with π_θ>μ is masked; A<0 with π_θ>μ moves back towards μ
+        # (safe), and A=0 contributes no update — neither is masked.
+        vllm_logprobs = torch.log(torch.tensor([[0.1, 0.1, 0.1]]))
+        new_logprobs = torch.log(torch.tensor([[0.5, 0.5, 0.5]]))
+        response_mask = torch.ones_like(new_logprobs, dtype=torch.bool)
+        advantages = torch.tensor([[1.0, -1.0, 0.0]])
+
+        correction = grpo_utils.compute_rho_correction(
+            vllm_logprobs, vllm_logprobs, new_logprobs, response_mask, advantages, config
+        )
+
+        torch.testing.assert_close(correction.weights, torch.tensor([[0.0, 1.0, 1.0]]))
+        torch.testing.assert_close(correction.metrics["val/rho_drop_high_frac"], torch.tensor([[1.0, 0.0, 0.0]]))
+        torch.testing.assert_close(correction.metrics["val/rho_drop_low_frac"], torch.zeros(1, 3))
+        torch.testing.assert_close(
+            correction.metrics["val/rho_divergence"], torch.full((1, 3), 0.4), atol=1e-5, rtol=1e-5
+        )
+
+    def test_below_threshold_keeps_all_tokens(self):
+        config = _make_dppo_config(rho_mask_upper_bound=0.5)
+        vllm_logprobs = torch.log(torch.tensor([[0.4, 0.6]]))
+        new_logprobs = torch.log(torch.tensor([[0.5, 0.5]]))
+        response_mask = torch.ones_like(new_logprobs, dtype=torch.bool)
+        advantages = torch.tensor([[1.0, -1.0]])
+
+        correction = grpo_utils.compute_rho_correction(
+            vllm_logprobs, vllm_logprobs, new_logprobs, response_mask, advantages, config
+        )
+
+        torch.testing.assert_close(correction.weights, torch.ones(1, 2))
+
+    def test_negative_advantage_masked_when_ratio_below_one(self):
+        config = _make_dppo_config()
+        # μ = 0.5, π_θ = 0.1 → TV = 0.4 > δ; ratio < 1, so A<0 is the unsafe direction.
+        vllm_logprobs = torch.log(torch.tensor([[0.5, 0.5]]))
+        new_logprobs = torch.log(torch.tensor([[0.1, 0.1]]))
+        response_mask = torch.ones_like(new_logprobs, dtype=torch.bool)
+        advantages = torch.tensor([[-1.0, 1.0]])
+
+        correction = grpo_utils.compute_rho_correction(
+            vllm_logprobs, vllm_logprobs, new_logprobs, response_mask, advantages, config
+        )
+
+        torch.testing.assert_close(correction.weights, torch.tensor([[0.0, 1.0]]))
+        torch.testing.assert_close(correction.metrics["val/rho_drop_low_frac"], torch.tensor([[1.0, 0.0]]))
+
+    def test_padding_positions_zeroed(self):
+        config = _make_dppo_config()
+        vllm_logprobs = torch.log(torch.tensor([[0.1, 0.1, 0.1]]))
+        new_logprobs = torch.log(torch.tensor([[0.5, 0.5, 0.5]]))
+        response_mask = torch.tensor([[False, True, False]])
+        advantages = torch.full((1, 3), -1.0)
+
+        correction = grpo_utils.compute_rho_correction(
+            vllm_logprobs, vllm_logprobs, new_logprobs, response_mask, advantages, config
+        )
+
+        # A<0 with π_θ>μ is the safe direction, so the middle token is kept; padding is 0.
+        torch.testing.assert_close(correction.weights, torch.tensor([[0.0, 1.0, 0.0]]))
+
+    def test_mask_does_not_propagate_gradients(self):
+        config = _make_dppo_config()
+        vllm_logprobs = torch.log(torch.tensor([[0.1]]))
+        new_logprobs = torch.log(torch.tensor([[0.5]])).requires_grad_(True)
+        response_mask = torch.ones(1, 1, dtype=torch.bool)
+        advantages = torch.ones(1, 1)
+
+        correction = grpo_utils.compute_rho_correction(
+            vllm_logprobs, vllm_logprobs, new_logprobs, response_mask, advantages, config
+        )
+
+        self.assertFalse(correction.weights.requires_grad)
+
+    def test_composes_with_rho_correction(self):
+        # With use_rho_correction, kept tokens are still reweighted by ρ = π_old / μ
+        # while the DPPO mask drops unsafe out-of-region tokens.
+        config = _make_dppo_config(use_rho_correction=True)
+        vllm_logprobs = torch.log(torch.tensor([[0.1, 0.1]]))
+        old_logprobs = vllm_logprobs + torch.log(torch.tensor(2.0))
+        new_logprobs = torch.log(torch.tensor([[0.5, 0.5]]))
+        response_mask = torch.ones_like(new_logprobs, dtype=torch.bool)
+        advantages = torch.tensor([[1.0, -1.0]])
+
+        correction = grpo_utils.compute_rho_correction(
+            old_logprobs, vllm_logprobs, new_logprobs, response_mask, advantages, config
+        )
+
+        torch.testing.assert_close(correction.weights, torch.tensor([[0.0, 2.0]]))
+
+
+class TestDPPOLoss(unittest.TestCase):
+    def test_dppo_loss_masks_and_has_no_symmetric_clip(self):
+        config = _make_dppo_config(loss_fn=grpo_utils.GRPOLossType.dppo, rho_mask_upper_bound=0.1)
+        vllm_logprobs = torch.log(torch.tensor([[0.1, 0.1]]))
+        new_logprobs = torch.log(torch.tensor([[0.5, 0.5]]))
+        advantages = torch.tensor([[1.0, -1.0]])
+        response_mask = torch.ones_like(new_logprobs, dtype=torch.bool)
+
+        output = grpo_utils.compute_grpo_loss(
+            new_logprobs=new_logprobs,
+            old_logprobs=vllm_logprobs,
+            vllm_logprobs=vllm_logprobs,
+            advantages=advantages,
+            ref_logprobs=None,
+            response_mask=response_mask,
+            config=config,
+        )
+
+        # ratio = π_θ / μ = 5 for both tokens; only the A>0 token is masked (Eq. 12),
+        # and the kept A<0 token is unclipped despite ratio 5 (Eq. 11).
+        expected_mask = torch.tensor([[0.0, 1.0]])
+        torch.testing.assert_close(output.pg_loss, -advantages * output.ratio * expected_mask)
+        torch.testing.assert_close(output.clipfrac, torch.zeros_like(output.clipfrac))
+        torch.testing.assert_close(output.kl, torch.zeros_like(output.kl))
+
+
+class TestDPPOConfigValidation(unittest.TestCase):
+    def test_dppo_loss_requires_dppo_divergence_type(self):
+        with self.assertRaisesRegex(ValueError, "rho_divergence_type"):
+            grpo_utils.GRPOExperimentConfig(loss_fn=grpo_utils.GRPOLossType.dppo)
+
+    def test_dppo_divergence_requires_threshold(self):
+        with self.assertRaisesRegex(ValueError, "rho_mask_upper_bound"):
+            grpo_utils.GRPOExperimentConfig(rho_divergence_type=grpo_utils.RhoDivergenceType.dppo_tv)
+
+    def test_dppo_divergence_requires_rollout_anchoring(self):
+        with self.assertRaisesRegex(ValueError, "rollout policy"):
+            grpo_utils.GRPOExperimentConfig(
+                rho_divergence_type=grpo_utils.RhoDivergenceType.dppo_tv,
+                rho_mask_upper_bound=0.1,
+                use_rho_correction=False,
+            )
+
+    def test_dppo_with_rho_correction_is_valid(self):
+        grpo_utils.GRPOExperimentConfig(
+            loss_fn=grpo_utils.GRPOLossType.dppo,
+            rho_divergence_type=grpo_utils.RhoDivergenceType.dppo_kl,
+            rho_mask_upper_bound=0.1,
+        )
+
+    def test_dppo_with_vllm_logprobs_is_valid(self):
+        grpo_utils.GRPOExperimentConfig(
+            loss_fn=grpo_utils.GRPOLossType.dppo,
+            rho_divergence_type=grpo_utils.RhoDivergenceType.dppo_tv,
+            rho_mask_upper_bound=0.1,
+            use_rho_correction=False,
+            use_vllm_logprobs=True,
+        )
+
+    def test_tv_divergence_allows_sub_one_threshold(self):
+        grpo_utils.GRPOExperimentConfig(rho_divergence_type=grpo_utils.RhoDivergenceType.tv, rho_mask_upper_bound=0.5)
 
 
 if __name__ == "__main__":

--- a/open_instruct/test_olmo_core_train_modules.py
+++ b/open_instruct/test_olmo_core_train_modules.py
@@ -165,7 +165,8 @@ def _make_grpo_config(**kwargs) -> grpo_utils.GRPOExperimentConfig:
         "rho_clamp_upper_bound": 0.0,
         "rho_mask_lower_bound": 0.0,
         "rho_mask_upper_bound": 0.0,
-        "rho_divergence_type": grpo_utils.RhoDivergenceType.rho,
+        "rho_divergence_algo": grpo_utils.RhoDivergenceAlgo.icepop,
+        "rho_divergence_type": grpo_utils.RhoDivergenceType.tv,
         "use_rho_correction": False,
     }
     defaults.update(kwargs)
@@ -370,12 +371,12 @@ class TestComputeGRPOLoss(unittest.TestCase):
             torch.tensor([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [0.0, 0.0, 0.0]]),
         )
 
-    def test_rho_mask_tv_divergence(self):
+    def test_vaco_tv_divergence(self):
         config = _make_grpo_config(
             use_rho_correction=True,
             rho_mask_lower_bound=0.0,
             rho_mask_upper_bound=2.0,
-            rho_divergence_type=grpo_utils.RhoDivergenceType.tv,
+            rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.vaco,
         )
         # Row 0: mean |ρ - 1| = 1.25, below upper=2.0, so it is kept.
         # Row 1: mean |ρ - 1| = 3.0, above upper=2.0, so TV-increasing tokens are dropped.
@@ -394,6 +395,31 @@ class TestComputeGRPOLoss(unittest.TestCase):
         )
         torch.testing.assert_close(
             correction.metrics["val/rho_divergence"], torch.tensor([[1.25, 1.25, 1.25], [3.0, 3.0, 3.0]])
+        )
+
+    def test_vaco_kl_divergence(self):
+        config = _make_grpo_config(
+            use_rho_correction=True,
+            rho_mask_lower_bound=0.0,
+            rho_mask_upper_bound=1.0,
+            rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.vaco,
+            rho_divergence_type=grpo_utils.RhoDivergenceType.kl,
+        )
+        # k3 = ρ - 1 - log ρ. Row 0: ρ = 1 everywhere → divergence 0 (kept).
+        # Row 1: ρ = 4 everywhere → k3 = 3 - log 4 ≈ 1.614 > 1.0 (dropped).
+        old_logprob = torch.log(torch.tensor([[1.0, 1.0, 1.0], [4.0, 4.0, 4.0]]))
+        vllm_logprobs = torch.zeros_like(old_logprob)
+        response_mask = torch.ones_like(old_logprob, dtype=torch.bool)
+        advantages = torch.ones_like(old_logprob)
+
+        correction = grpo_utils.compute_rho_correction(
+            old_logprob, vllm_logprobs, old_logprob, response_mask, advantages, config
+        )
+
+        torch.testing.assert_close(correction.weights, torch.tensor([[1.0, 1.0, 1.0], [0.0, 0.0, 0.0]]))
+        expected_divergence = 3.0 - torch.log(torch.tensor(4.0))
+        torch.testing.assert_close(
+            correction.metrics["val/rho_divergence"], torch.stack([torch.zeros(3), expected_divergence.expand(3)])
         )
 
     def test_rho_mask_zeroes_loss(self):
@@ -442,7 +468,7 @@ class TestComputeBinaryDivergence(unittest.TestCase):
             behavior_logprobs=behavior_logprobs,
             policy_logprobs=policy_logprobs,
             response_mask=response_mask,
-            divergence_type=grpo_utils.RhoDivergenceType.dppo_tv,
+            divergence_type=grpo_utils.RhoDivergenceType.tv,
         )
 
         torch.testing.assert_close(divergence, torch.tensor([[0.1, 0.0, 0.6]]), atol=1e-5, rtol=1e-5)
@@ -455,7 +481,7 @@ class TestComputeBinaryDivergence(unittest.TestCase):
             behavior_logprobs=logprobs,
             policy_logprobs=logprobs,
             response_mask=response_mask,
-            divergence_type=grpo_utils.RhoDivergenceType.dppo_kl,
+            divergence_type=grpo_utils.RhoDivergenceType.kl,
         )
 
         torch.testing.assert_close(divergence, torch.zeros_like(divergence), atol=1e-5, rtol=1e-5)
@@ -469,26 +495,27 @@ class TestComputeBinaryDivergence(unittest.TestCase):
             behavior_logprobs=behavior_logprobs,
             policy_logprobs=policy_logprobs,
             response_mask=response_mask,
-            divergence_type=grpo_utils.RhoDivergenceType.dppo_tv,
+            divergence_type=grpo_utils.RhoDivergenceType.tv,
         )
 
         self.assertEqual(float(divergence[0, 0]), 0.0)
         self.assertGreater(float(divergence[0, 1]), 0.0)
 
-    def test_non_dppo_divergence_type_raises(self):
+    def test_unknown_divergence_type_raises(self):
         with self.assertRaises(ValueError):
             grpo_utils.compute_binary_divergence(
                 behavior_logprobs=torch.zeros(1, 1),
                 policy_logprobs=torch.zeros(1, 1),
                 response_mask=torch.ones(1, 1, dtype=torch.bool),
-                divergence_type=grpo_utils.RhoDivergenceType.tv,
+                divergence_type="not_a_divergence",
             )
 
 
 def _make_dppo_config(**kwargs) -> grpo_utils.GRPOExperimentConfig:
     defaults = {
         "use_rho_correction": False,
-        "rho_divergence_type": grpo_utils.RhoDivergenceType.dppo_tv,
+        "rho_divergence_algo": grpo_utils.RhoDivergenceAlgo.dppo,
+        "rho_divergence_type": grpo_utils.RhoDivergenceType.tv,
         "rho_mask_upper_bound": 0.05,
         "rho_mask_lower_bound": 0.0,
     }
@@ -617,18 +644,18 @@ class TestDPPOLoss(unittest.TestCase):
 
 
 class TestDPPOConfigValidation(unittest.TestCase):
-    def test_dppo_loss_requires_dppo_divergence_type(self):
-        with self.assertRaisesRegex(ValueError, "rho_divergence_type"):
+    def test_dppo_loss_requires_dppo_divergence_algo(self):
+        with self.assertRaisesRegex(ValueError, "rho_divergence_algo"):
             grpo_utils.GRPOExperimentConfig(loss_fn=grpo_utils.GRPOLossType.dppo)
 
-    def test_dppo_divergence_requires_threshold(self):
+    def test_dppo_algo_requires_threshold(self):
         with self.assertRaisesRegex(ValueError, "rho_mask_upper_bound"):
-            grpo_utils.GRPOExperimentConfig(rho_divergence_type=grpo_utils.RhoDivergenceType.dppo_tv)
+            grpo_utils.GRPOExperimentConfig(rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.dppo)
 
-    def test_dppo_divergence_requires_rollout_anchoring(self):
+    def test_dppo_algo_requires_rollout_anchoring(self):
         with self.assertRaisesRegex(ValueError, "rollout policy"):
             grpo_utils.GRPOExperimentConfig(
-                rho_divergence_type=grpo_utils.RhoDivergenceType.dppo_tv,
+                rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.dppo,
                 rho_mask_upper_bound=0.1,
                 use_rho_correction=False,
             )
@@ -636,21 +663,32 @@ class TestDPPOConfigValidation(unittest.TestCase):
     def test_dppo_with_rho_correction_is_valid(self):
         grpo_utils.GRPOExperimentConfig(
             loss_fn=grpo_utils.GRPOLossType.dppo,
-            rho_divergence_type=grpo_utils.RhoDivergenceType.dppo_kl,
+            rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.dppo,
+            rho_divergence_type=grpo_utils.RhoDivergenceType.kl,
             rho_mask_upper_bound=0.1,
         )
 
     def test_dppo_with_vllm_logprobs_is_valid(self):
         grpo_utils.GRPOExperimentConfig(
             loss_fn=grpo_utils.GRPOLossType.dppo,
-            rho_divergence_type=grpo_utils.RhoDivergenceType.dppo_tv,
+            rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.dppo,
             rho_mask_upper_bound=0.1,
             use_rho_correction=False,
             use_vllm_logprobs=True,
         )
 
-    def test_tv_divergence_allows_sub_one_threshold(self):
-        grpo_utils.GRPOExperimentConfig(rho_divergence_type=grpo_utils.RhoDivergenceType.tv, rho_mask_upper_bound=0.5)
+    def test_vaco_allows_sub_one_threshold(self):
+        grpo_utils.GRPOExperimentConfig(
+            rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.vaco, rho_mask_upper_bound=0.5
+        )
+
+    def test_vaco_requires_rho_correction(self):
+        with self.assertRaisesRegex(ValueError, "use_rho_correction"):
+            grpo_utils.GRPOExperimentConfig(
+                rho_divergence_algo=grpo_utils.RhoDivergenceAlgo.vaco,
+                rho_mask_upper_bound=0.5,
+                use_rho_correction=False,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Alternative to #1745 that implements DPPO through the existing ρ-correction machinery instead of a special-cased mask, and makes the RL loss path more modular along the way.

## Summary

Three orthogonal axes now describe the policy loss:

1. **`--loss_fn`** — the policy-gradient objective: `dapo` (clipped), `cispo`, and new **`dppo`** ([DPPO paper](https://arxiv.org/abs/2602.04879), Eq. 11: `L = E[Σ_t M_t · r_t · A_t]`). In code, `dppo` *is* the `dapo` objective with the symmetric ratio clamp widened to a no-op — its trust region comes entirely from the drop mask below.
2. **`--rho_divergence_algo`** (replaces the `rho_mask_tv_divergence` bool) — which algorithm drives the token-drop mask inside `compute_rho_correction`:
   - `icepop` (default): existing behavior — simple clipping on ρ itself (per-token or sequence-level);
   - `vaco` ([arXiv:2603.01365](https://arxiv.org/abs/2603.01365)): sequence-level mean binary divergence between π_old and the rollout policy μ, directional;
   - **`dppo`**: per-token binary divergence between the *current* policy π_θ and μ, directional (Eq. 12). The trust-region threshold δ is `--rho_mask_upper_bound`.
3. **`--rho_divergence_type`** — the binary (Bernoulli) divergence measure (`tv` or `kl`, Eqs. 13/14), computed by the shared `compute_binary_divergence` util (fp32 upcast + logprob clamping). Ignored by `icepop`.

`vaco` and `dppo` are the same mechanism with two knobs flipped: which policy is compared against μ (π_old vs π_θ) and the aggregation level (sequence vs token); both only mask tokens whose update would *increase* the divergence (`sign(log(π/μ))·A > 0`). The ρ computation itself now uses the same fp32-upcast + logprob-clamp hygiene.

### DPPO composes with the ρ correction

DPPO needs the importance ratio anchored on the rollout policy (π_θ/μ). #1745 forced `--use_vllm_logprobs` for this; here it falls out of the ρ paradigm: with `--use_rho_correction` (the default), the effective per-token weight is `ratio · ρ = (π_θ/π_old)·(π_old/μ) = π_θ/μ`, so DPPO composes with truncated importance sampling for free. `--use_vllm_logprobs` also works (exactly reproducing #1745, where ρ ≡ 1). `__post_init__` validates that one of the two is active.

A typical DPPO run: `--loss_fn dppo --rho_divergence_algo dppo --rho_divergence_type tv --rho_mask_upper_bound 0.1`.

### Modularity refactor

`compute_grpo_loss` now takes new/old/vllm logprobs and computes the ratio and ρ correction internally, returning a `GRPOLossOutput` dataclass (`pg_loss`, `clipfrac`, `kl`, `ratio`, `rho`). The previously duplicated ratio → `compute_rho_correction` → `compute_grpo_loss` → `populate_sample_loss_stats` plumbing in `grpo_fast.py` (DeepSpeed) and `olmo_core_train_modules.py` (OLMo-core, used by `grpo.py`) collapses to a single call each, so any new loss function or masking algorithm lands on both trainers at once.

New `val/rho_divergence` metric logs the mean masking divergence for the `vaco` and `dppo` algorithms.

**Note**: `vaco` masking thresholds change scale vs the old `rho_mask_tv_divergence` implementation — the divergence is now the prob-space binary TV/KL (per-token TV in [0, 1]) rather than the ratio-space mean |ρ−1|, so previous thresholds like 2.0 should be re-tuned to sub-1 values.

## Test plan

- New CPU unit tests in `test_olmo_core_train_modules.py`: binary TV/KL divergence math, the asymmetric trust-region mask (directions, threshold, padding, gradient detachment, composition with ρ reweighting), VACO TV and KL variants (including the directional keep), the `dppo` loss branch, and config validation.
- Existing `compute_grpo_loss` / rho tests reworked for the new signature and physical (≤ 0) logprobs; IcePop behavior unchanged.
- `uv run pytest open_instruct/test_grpo_utils.py open_instruct/test_olmo_core_train_modules.py open_instruct/test_grpo_fast.py` all pass; `make style && make quality` clean.

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)