### PR TITLE
Surface sandbox infra failures in wandb; fix OOM scored as success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ### Changed
+- Surface Podman/sandbox infra failures in wandb: split `tools/aggregate/failure_rate` into `..._infra` vs `..._model`, and add `sandbox/oom_rate`, `sandbox/timeout_rate`, `sandbox/reset_failure_rate`, `sandbox/infra_failure_per_rollout`. Also fixes OOM-killed episodes being scored as tool-call successes (invisible in `failure_rate`) by tagging `ToolCallStats.failure_kind`.
 - Fix Qwen3.5 packing logprob mismatch: call `patch_qwen3_5_packing()` inside `PolicyTrainerRayProcess.from_pretrained()` so the GatedDeltaNet sequence-isolation patch is applied in the Ray worker process, not only in the main process. Without this, packed rows leaked state between sub-sequences, causing `vllm_vs_local_logprob_diff_mean` ~0.21 instead of the expected ~0.02.
 - Build FLA CP context per-batch with `fla.ops.cp.build_cp_context` so Qwen3.5 hybrid linear-attention correctly starts fresh state for packed sub-sequences that don't cross Ulysses SP rank boundaries; threads un-sharded `global_position_ids` through `UlyssesSPSplitter` → `CollatedBatchData` → `compute_logprobs` / `forward_for_logprobs`.
 - Pass `attention_mask=None` in GRPO `forward_for_logprobs` calls — HF constructs the correct 3D intra-document mask from `position_ids` internally (https://github.com/allenai/open-instruct/pull/1617).

--- a/open_instruct/data_types.py
+++ b/open_instruct/data_types.py
@@ -26,6 +26,10 @@ class ToolCallStats:
     tool_name: str
     success: bool
     runtime: float
+    failure_kind: str | None = None
+    """Why the call failed, so metrics can split infra failures from model errors.
+    One of: None (success), "oom", "timeout", "infra", "model", "reset". See
+    ``EnvStatistics.compute_metrics`` and ``docs/sandbox_modal_vs_podman.md``."""
 
 
 @dataclass

--- a/open_instruct/environments/tools/tests/test_tools.py
+++ b/open_instruct/environments/tools/tests/test_tools.py
@@ -1346,6 +1346,43 @@ class TestEnvStatistics(unittest.TestCase):
         self.assertEqual(metrics["tools/python/failure_rate"], 0.0)
         self.assertEqual(metrics["tools/aggregate/failure_rate"], 0.0)
 
+    def test_failure_kind_split_and_sandbox_metrics(self):
+        """Infra failures (oom/timeout/reset) are split from model errors and surfaced,
+        and an OOM is counted as a failure rather than a success."""
+        stats = EnvStatistics()
+        # rollout 1: a good call, then an OOM (previously mis-scored success=True).
+        stats.add_rollout(
+            [
+                data_types.ToolCallStats(tool_name="bash", success=True, runtime=1.0),
+                data_types.ToolCallStats(tool_name="bash", success=False, runtime=0.0, failure_kind="oom"),
+            ]
+        )
+        # rollout 2: a model error and a step timeout.
+        stats.add_rollout(
+            [
+                data_types.ToolCallStats(tool_name="bash", success=False, runtime=0.0, failure_kind="model"),
+                data_types.ToolCallStats(tool_name="bash", success=False, runtime=120.0, failure_kind="timeout"),
+            ]
+        )
+        # rollout 3: an env-reset failure.
+        stats.add_rollout(
+            [data_types.ToolCallStats(tool_name="env_reset", success=False, runtime=0.0, failure_kind="reset")]
+        )
+
+        metrics = stats.compute_metrics()
+
+        # 5 calls total; infra = oom+timeout+reset = 3, model = 1.
+        self.assertAlmostEqual(metrics["tools/aggregate/failure_rate_infra"], 3 / 5)
+        self.assertAlmostEqual(metrics["tools/aggregate/failure_rate_model"], 1 / 5)
+        # Per-rollout episode-terminating rates (3 rollouts).
+        self.assertAlmostEqual(metrics["sandbox/oom_rate"], 1 / 3)
+        self.assertAlmostEqual(metrics["sandbox/reset_failure_rate"], 1 / 3)
+        # Per-call timeout rate (5 calls).
+        self.assertAlmostEqual(metrics["sandbox/timeout_rate"], 1 / 5)
+        self.assertAlmostEqual(metrics["sandbox/infra_failure_per_rollout"], 3 / 3)
+        # The OOM is a failure, so the overall failure_rate reflects it (4 of 5).
+        self.assertAlmostEqual(metrics["tools/aggregate/failure_rate"], 4 / 5)
+
 
 class TestEnvsConfig(unittest.TestCase):
     """Tests for EnvsConfig dataclass."""

--- a/open_instruct/environments/tools/utils.py
+++ b/open_instruct/environments/tools/utils.py
@@ -142,6 +142,10 @@ class EnvStatistics:
         self._counts: defaultdict[str, int] = defaultdict(int)
         self._failures: defaultdict[str, int] = defaultdict(int)
         self._runtimes: defaultdict[str, float] = defaultdict(float)
+        # Failed calls bucketed by ToolCallStats.failure_kind, so we can split
+        # infra failures (oom/timeout/infra/reset) from model errors -- which the
+        # single tools/*/failure_rate metric conflates.
+        self._kind_counts: defaultdict[str, int] = defaultdict(int)
 
     def add_rollout(self, tool_call_stats: list[ToolCallStats]) -> None:
         """Add statistics from a single rollout."""
@@ -151,6 +155,8 @@ class EnvStatistics:
             self._counts[s.tool_name] += 1
             self._failures[s.tool_name] += not s.success
             self._runtimes[s.tool_name] += s.runtime
+            if not s.success:
+                self._kind_counts[s.failure_kind or "unknown"] += 1
 
     def compute_metrics(self) -> dict[str, float]:
         """Compute per-tool and aggregate metrics.
@@ -163,6 +169,12 @@ class EnvStatistics:
             - tools/aggregate/avg_calls_per_rollout
             - tools/aggregate/failure_rate
             - tools/aggregate/avg_runtime
+            - tools/aggregate/failure_rate_infra  (oom+timeout+infra+reset, per call)
+            - tools/aggregate/failure_rate_model  (bad tool call / command, per call)
+            - sandbox/oom_rate                    (OOM-killed episodes per rollout)
+            - sandbox/timeout_rate                (tool-step timeouts per call)
+            - sandbox/reset_failure_rate          (env-reset failures per rollout)
+            - sandbox/infra_failure_per_rollout   (all infra failures per rollout)
         """
         if not self.num_rollouts or not self.tool_names:
             return {}
@@ -184,6 +196,18 @@ class EnvStatistics:
         metrics["tools/aggregate/avg_calls_per_rollout"] = total_calls / self.num_rollouts
         metrics["tools/aggregate/failure_rate"] = total_failures / total_calls if total_calls else 0.0
         metrics["tools/aggregate/avg_runtime"] = total_runtime / total_calls if total_calls else 0.0
+
+        # Split infra failures from model errors, and surface the Podman failure
+        # modes that tools/*/failure_rate hides (OOM was scored success before this).
+        infra_failures = sum(self._kind_counts[k] for k in ("oom", "timeout", "infra", "reset"))
+        model_failures = self._kind_counts["model"]
+        if total_calls:
+            metrics["tools/aggregate/failure_rate_infra"] = infra_failures / total_calls
+            metrics["tools/aggregate/failure_rate_model"] = model_failures / total_calls
+            metrics["sandbox/timeout_rate"] = self._kind_counts["timeout"] / total_calls
+        metrics["sandbox/oom_rate"] = self._kind_counts["oom"] / self.num_rollouts
+        metrics["sandbox/reset_failure_rate"] = self._kind_counts["reset"] / self.num_rollouts
+        metrics["sandbox/infra_failure_per_rollout"] = infra_failures / self.num_rollouts
 
         return metrics
 

--- a/open_instruct/vllm_utils.py
+++ b/open_instruct/vllm_utils.py
@@ -1173,7 +1173,9 @@ async def process_request(actor: LLMRayActor, sub_request_id: str, sampling_para
             rollout.done = True
             rollout.rewards.append(0.0)
             rollout.tool_error += error_msg
-            rollout.tool_call_stats.append(ToolCallStats(tool_name="env_reset", success=False, runtime=0.0))
+            rollout.tool_call_stats.append(
+                ToolCallStats(tool_name="env_reset", success=False, runtime=0.0, failure_kind="reset")
+            )
             max_steps = 0
         else:
             add_timing("acquire_reset_pools", phase_start_time)
@@ -1258,7 +1260,9 @@ async def process_request(actor: LLMRayActor, sub_request_id: str, sampling_para
                 rollout.tool_error += feedback
                 rollout.rewards.append(0.0)
                 rollout.tool_call_stats.append(
-                    ToolCallStats(tool_name="tool_call_format_error", success=False, runtime=0.0)
+                    ToolCallStats(
+                        tool_name="tool_call_format_error", success=False, runtime=0.0, failure_kind="model"
+                    )
                 )
 
             for tc in tool_calls:
@@ -1291,11 +1295,23 @@ async def process_request(actor: LLMRayActor, sub_request_id: str, sampling_para
                     rollout.timeout = rollout.timeout or meta.get("timeout", False)
                     rollout.tool_error += meta.get("error", "")
                     rollout.tool_runtime += meta.get("runtime", 0.0)
+                    # OOM returns done=True with no "error"/"timeout" key, so without
+                    # the explicit oom_killed check it is scored success=True and
+                    # vanishes from failure_rate. See docs/sandbox_modal_vs_podman.md.
+                    if meta.get("oom_killed", False):
+                        failure_kind = "oom"
+                    elif meta.get("timeout", False):
+                        failure_kind = "timeout"
+                    elif meta.get("error"):
+                        failure_kind = "model"
+                    else:
+                        failure_kind = None
                     rollout.tool_call_stats.append(
                         ToolCallStats(
                             tool_name=tc.name,
-                            success=not meta.get("error") and not meta.get("timeout", False),
+                            success=failure_kind is None,
                             runtime=meta.get("runtime", 0.0),
+                            failure_kind=failure_kind,
                         )
                     )
                 except asyncio.TimeoutError:
@@ -1307,7 +1323,12 @@ async def process_request(actor: LLMRayActor, sub_request_id: str, sampling_para
                     rollout.timeout = True
                     rollout.rewards.append(0.0)
                     rollout.tool_call_stats.append(
-                        ToolCallStats(tool_name=tc.name, success=False, runtime=actor.tool_call_timeout)
+                        ToolCallStats(
+                            tool_name=tc.name,
+                            success=False,
+                            runtime=actor.tool_call_timeout,
+                            failure_kind="timeout",
+                        )
                     )
                 except Exception as e:
                     add_timing("tool_step", phase_start_time)
@@ -1316,7 +1337,9 @@ async def process_request(actor: LLMRayActor, sub_request_id: str, sampling_para
                     observations.append((error_msg, "tool"))
                     rollout.tool_error += error_msg
                     rollout.rewards.append(0.0)
-                    rollout.tool_call_stats.append(ToolCallStats(tool_name=tc.name, success=False, runtime=0.0))
+                    rollout.tool_call_stats.append(
+                        ToolCallStats(tool_name=tc.name, success=False, runtime=0.0, failure_kind="infra")
+                    )
 
                 if rollout.done:
                     break


### PR DESCRIPTION
 ## What & why

  Podman/sandbox failures were only visible as post-hoc log lines, and the one wandb metric that existed (`tools/aggregate/failure_rate`) **conflated model errors with infra failures** and **scored OOM-killed episodes as successes** (they return `done=True` with no `error`/`timeout` key). This makes infra distress invisible during a run.

  This is the testable first slice of that work.

  ## Changes

  - **`ToolCallStats.failure_kind`** (`oom` / `timeout` / `infra` / `model` / `reset`), set at every construction site in `vllm_utils.py`. Defaulted field → queue-payload round-trip safe.
  - **Bug fix — OOM scored as success:** the normal-step path now checks `meta["oom_killed"]`, so OOM-killed steps count as failures.
  - **New wandb metrics** (`EnvStatistics.compute_metrics`):
    - `tools/aggregate/failure_rate_infra` vs `tools/aggregate/failure_rate_model`
    - `sandbox/oom_rate`, `sandbox/timeout_rate`, `sandbox/reset_failure_rate`, `sandbox/infra_failure_per_rollout`
  - Unit test in `test_tools.py` for the split + OOM-as-failure.

  ## Risk

  Low / metrics-only. `ToolCallStats.success` feeds **only** `EnvStatistics` (metrics); reward/advantage come from `step_result.reward` and `RequestInfo` independently, so training behavior is unchanged.

  ## Follow-ups (need Ray/node/backend plumbing — not locally unit-testable, deliberately deferred)

  - `sandbox/exec_semaphore_wait_s` (p95) — leading saturation signal; already computed in `backends.py`, needs surfacing through env `get_metrics()`.
  - `sandbox/disk_used_frac`, `sandbox/node_mem_used_frac` — per-node sampler (would have caught the disk-exhaustion and pool_size=768 node-death crashes).
  - `sandbox/host_rotation_count` + recovered-retry counters (`pool.py` / `backends.py`) — currently log-only.

  ## Notes

  - GPU_TESTS=bypass — metrics-only change with no training-behavior impact (see Risk). Reviewer can request a GPU run if desired.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)