### PR TITLE
fix: preference filter applies both length limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Preference dataset filter applies both `max_prompt_token_length` and `max_token_length` (was mutually exclusive) (https://github.com/allenai/open-instruct/pull/1761).

--- a/open_instruct/dataset_processor.py
+++ b/open_instruct/dataset_processor.py
@@ -247,16 +247,18 @@ class PreferenceDatasetProcessor(DatasetProcessor):
 
     def filter(self, dataset: Union[Dataset, DatasetDict]):
         def filter_fn(row):
-            return (
-                len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
-                if self.config.max_prompt_token_length is not None
-                else (
+            max_prompt_token_length_ok = True
+            if self.config.max_prompt_token_length is not None:
+                max_prompt_token_length_ok = len(row[INPUT_IDS_PROMPT_KEY]) <= self.config.max_prompt_token_length
+
+            max_token_length_ok = True
+            if self.config.max_token_length is not None:
+                max_token_length_ok = (
                     len(row[INPUT_IDS_CHOSEN_KEY]) <= self.config.max_token_length
                     and len(row[INPUT_IDS_REJECTED_KEY]) <= self.config.max_token_length
-                    if self.config.max_token_length is not None
-                    else True
                 )
-            )
+
+            return max_prompt_token_length_ok and max_token_length_ok
 
         filtered_dataset = dataset.filter(
             filter_fn,


### PR DESCRIPTION
## Summary
- Preference `filter` used a nested ternary: if `max_prompt_token_length` was set, `max_token_length` was never checked.
- Match SFT: AND both checks independently.

GPU_TESTS=bypass

## Test plan
- [ ] Unit: preference row with ok prompt length but oversize chosen/rejected is filtered when both limits set

Made with [Cursor](https://cursor.com)