### PR TITLE
fix: write CSV headers before opening append streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Write CSV headers before opening append streams in `benchmark_generators` (https://github.com/allenai/open-instruct/pull/1762).

--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -54,10 +54,12 @@ def save_completion_lengths(batch_results: list[dict], timestamp: int, batch_idx
     """
     csv_path = DATA_DIR / f"completion_lengths_{timestamp}.csv"
 
+    write_header = not csv_path.exists()
     with open(csv_path, "a", newline="") as csvfile:
         fieldnames = ["batch_num", "prompt_num", "completion_length"]
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-        writer.writeheader()
+        if write_header:
+            writer.writeheader()
 
         for batch_result in batch_results:
             response_lengths = batch_result["response_lengths"]
@@ -140,9 +142,10 @@ def save_benchmark_results_to_csv(
     csv_dir = csv_path.parent
     csv_dir.mkdir(parents=True, exist_ok=True)
 
+    write_header = not csv_path.exists()
     with csv_path.open("a", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=list(row_data.keys()))
-        if not csv_path.exists():
+        if write_header:
             writer.writeheader()
         writer.writerow(row_data)
     logger.info(f"Saved benchmark results to {csv_path}")

--- a/open_instruct/benchmark_generators.py
+++ b/open_instruct/benchmark_generators.py
@@ -54,7 +54,7 @@ def save_completion_lengths(batch_results: list[dict], timestamp: int, batch_idx
     """
     csv_path = DATA_DIR / f"completion_lengths_{timestamp}.csv"
 
-    write_header = not csv_path.exists()
+    write_header = not csv_path.exists() or csv_path.stat().st_size == 0
     with open(csv_path, "a", newline="") as csvfile:
         fieldnames = ["batch_num", "prompt_num", "completion_length"]
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
@@ -142,7 +142,7 @@ def save_benchmark_results_to_csv(
     csv_dir = csv_path.parent
     csv_dir.mkdir(parents=True, exist_ok=True)
 
-    write_header = not csv_path.exists()
+    write_header = not csv_path.exists() or csv_path.stat().st_size == 0
     with csv_path.open("a", newline="") as csvfile:
         writer = csv.DictWriter(csvfile, fieldnames=list(row_data.keys()))
         if write_header:


### PR DESCRIPTION
## Summary
- `open("a")` creates the file, so `exists()` inside the with-block never wrote headers.
- Same for `save_completion_lengths` which always rewrote the header on every call.

GPU_TESTS=bypass

## Test plan
- [ ] First append creates a header row; second append does not duplicate it

Made with [Cursor](https://cursor.com)