### PR TITLE
fix: match forbidden words on word boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Match forbidden words with word boundaries in `validate_forbidden_words` (align with IFEvalG) (https://github.com/allenai/open-instruct/pull/1763).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -62,8 +62,9 @@ def validate_forbidden_words(text, forbidden_words):
     """
     Validates that the text does not contain any of the specified forbidden words.
 
-    Matching is case-insensitive and uses word boundaries, matching IFEvalG's
-    ``ForbiddenWords`` check (so ``bad`` does not match ``badge``).
+    Matching is case-insensitive and whole-token (so ``bad`` does not match
+    ``badge``). Uses ``(?<!\\w)...(?!\\w)`` instead of ``\\b`` so tokens that
+    start/end with non-word characters (e.g. ``$5``) still match.
 
     Args:
         text (str): The text to check for forbidden words
@@ -77,7 +78,10 @@ def validate_forbidden_words(text, forbidden_words):
         forbidden_words = ["bad", "evil", "harmful"]
         result = validate_forbidden_words(text, forbidden_words)
     """
-    return all(not re.search(r"\b" + re.escape(word) + r"\b", text, flags=re.IGNORECASE) for word in forbidden_words)
+    return all(
+        not re.search(r"(?<!\w)" + re.escape(word) + r"(?!\w)", text, flags=re.IGNORECASE)
+        for word in forbidden_words
+    )
 
 
 # Letter Frequency : In your response, the letter {letter} should appear {N} times.

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -62,28 +62,22 @@ def validate_forbidden_words(text, forbidden_words):
     """
     Validates that the text does not contain any of the specified forbidden words.
 
+    Matching is case-insensitive and uses word boundaries, matching IFEvalG's
+    ``ForbiddenWords`` check (so ``bad`` does not match ``badge``).
+
     Args:
         text (str): The text to check for forbidden words
         forbidden_words (list[str]): A list of forbidden words
 
     Returns:
-        tuple[bool, list[str]]: A tuple containing:
-            - Boolean indicating if any forbidden words are present
-            - List of forbidden words found in the text
+        bool: True if no forbidden words are present, False otherwise
 
     Example:
         text = "This is a message that should not contain any bad words"
         forbidden_words = ["bad", "evil", "harmful"]
         result = validate_forbidden_words(text, forbidden_words)
     """
-    # Convert text to lowercase for case-insensitive matching
-    text_lower = text.lower()
-
-    # Check each forbidden word
-    found_words = [word for word in forbidden_words if word.lower() in text_lower]
-
-    # Return results
-    return len(found_words) == 0
+    return all(not re.search(r"\b" + re.escape(word) + r"\b", text, flags=re.IGNORECASE) for word in forbidden_words)
 
 
 # Letter Frequency : In your response, the letter {letter} should appear {N} times.

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,19 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+class TestValidateForbiddenWords(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("absent", "this has a badge", ["bad"], True),
+            ("present", "this is bad", ["bad"], False),
+            ("case_insensitive", "BAD day", ["bad"], False),
+            ("multiple_ok", "all good", ["bad", "evil"], True),
+            ("regex_meta_safe", "costs $5", ["$5"], False),
+        ]
+    )
+    def test_validate_forbidden_words(self, _name, text, words, expected):
+        self.assertEqual(if_functions.validate_forbidden_words(text, words), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Use `\b` word-boundary matching in `validate_forbidden_words` (same as IFEvalG `ForbiddenWords`).
- `"badge"` no longer fails a ban on `"bad"`.

## Test plan
- [x] Unit tests for substring vs whole-word cases
- GPU_TESTS=bypass