### PR TITLE
fix: extract last \boxed by last occurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Prefer the last `\boxed` occurrence when extracting math answers, so an earlier `\boxed ` mention does not override a later `\boxed{...}` (https://github.com/allenai/open-instruct/pull/1764).

--- a/open_instruct/math_utils.py
+++ b/open_instruct/math_utils.py
@@ -11,10 +11,17 @@ eval_logger = logger_utils.setup_logger("math_utils")
 
 # from https://github.com/EleutherAI/lm-evaluation-harness/blob/main/lm_eval/tasks/minerva_math/utils.py#L187
 def last_boxed_only_string(string: str) -> str | None:
+    """Return the last \\boxed{...} or \\boxed ...$ span in `string`.
+
+    The space form (``\\boxed answer$``) is used only when the *last* ``\\boxed``
+    occurrence is that form. An earlier ``\\boxed `` mention must not override a
+    later ``\\boxed{...}`` answer.
+    """
     idx = string.rfind("\\boxed")
-    if "\\boxed " in string:
-        return "\\boxed " + string.split("\\boxed ")[-1].split("$")[0]
-    if idx < 0:
+    if idx >= 0:
+        if string.startswith("\\boxed ", idx):
+            return "\\boxed " + string[idx + len("\\boxed ") :].split("$")[0]
+    else:
         idx = string.rfind("\\fbox")
         if idx < 0:
             return None

--- a/open_instruct/test_math_utils.py
+++ b/open_instruct/test_math_utils.py
@@ -24,5 +24,28 @@ class TestStripString(unittest.TestCase):
         self.assertEqual(result, expected_output)
 
 
+class TestLastBoxedOnlyString(unittest.TestCase):
+    def test_brace_form(self):
+        self.assertEqual(math_utils.last_boxed_only_string(r"ans \boxed{42}"), r"\boxed{42}")
+
+    def test_space_form(self):
+        self.assertEqual(math_utils.last_boxed_only_string(r"ans \boxed 7$."), r"\boxed 7")
+
+    def test_earlier_space_mention_does_not_override_later_brace(self):
+        s = r"Hint: write \boxed as a command. The answer is \boxed{42}."
+        self.assertEqual(math_utils.last_boxed_only_string(s), r"\boxed{42}")
+
+    def test_last_space_wins_over_earlier_brace(self):
+        s = r"first \boxed{1} then \boxed 2$ done"
+        self.assertEqual(math_utils.last_boxed_only_string(s), r"\boxed 2")
+
+    def test_nested_braces(self):
+        s = r"\boxed{\frac{1}{2}}"
+        self.assertEqual(math_utils.last_boxed_only_string(s), r"\boxed{\frac{1}{2}}")
+
+    def test_missing_returns_none(self):
+        self.assertIsNone(math_utils.last_boxed_only_string("no box here"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `last_boxed_only_string` only treats the space form when the *last* `\boxed` is `\boxed ...$`.
- An earlier `\boxed ` mention no longer overrides a later `\boxed{...}` answer.

## Test plan
- [x] Unit tests for brace/space forms and mixed orderings
- GPU_TESTS=bypass