### PR TITLE
fix: align bullet and paragraph IFEval checks with IFEvalG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Align `verify_bullet_points` and `verify_paragraph_count` with IFEvalG (exclude bold `**` lines; split paragraphs on `***`) (https://github.com/allenai/open-instruct/pull/1765).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -142,44 +142,37 @@ def validate_response_language(text, language):
 
 
 # Number Paragraphs: Your response should contain {N} paragraphs. You separate paragraphs using the markdown divider:
-# * * *
+# ***
 def verify_paragraph_count(text: str, N: int) -> bool:
     """
     Verifies that a text contains the expected number of paragraphs,
-    where paragraphs are separated by markdown dividers '* * *'
+    where paragraphs are separated by the markdown divider ``***``
+    (matching IFEvalG ``ParagraphChecker``).
 
     Args:
         text (str): The text to analyze
-        expected_count (int): Expected number of paragraphs
+        N (int): Expected number of paragraphs
 
     Returns:
         bool: True if the text contains exactly the expected number of paragraphs,
               False otherwise
 
     Example:
-         text = "First paragraph\n* * *\nSecond paragraph"
+         text = "First paragraph\\n***\\nSecond paragraph"
          verify_paragraph_count(text, 2)
         True
     """
+    paragraphs = re.split(r"\s?\*\*\*\s?", text)
+    num_paragraphs = len(paragraphs)
 
-    def clean_text(text: str) -> str:
-        """Remove extra whitespace and normalize line endings"""
-        return "\n".join(line.strip() for line in text.splitlines()).strip()
+    for index, paragraph in enumerate(paragraphs):
+        if not paragraph.strip():
+            if index == 0 or index == len(paragraphs) - 1:
+                num_paragraphs -= 1
+            else:
+                return False
 
-    # Clean the input text
-    text = clean_text(text)
-
-    # Split text by markdown divider
-    # Add 1 to count since n dividers create n+1 paragraphs
-    paragraphs = text.split("* * *")
-    actual_count = len(paragraphs)
-
-    # Verify each split resulted in non-empty content
-    valid_paragraphs = [p.strip() for p in paragraphs if p.strip()]
-    if len(valid_paragraphs) != actual_count:
-        return False
-
-    return actual_count == N
+    return num_paragraphs == N
 
 
 # Number Words: Answer with at least / around / at most {N} words
@@ -332,6 +325,9 @@ def verify_bullet_points(text: str, N: int) -> bool:
     """
     Verifies if a text contains exactly N bullet points in markdown format.
 
+    Matches IFEvalG ``BulletListChecker``: ``*`` bullets must not be bold
+    (``**...``), and ``-`` bullets are counted separately.
+
     Args:
         text (str): The text to check
         N (int): The expected number of bullet points
@@ -339,12 +335,9 @@ def verify_bullet_points(text: str, N: int) -> bool:
     Returns:
         bool: True if the text contains exactly N bullet points, False otherwise.
     """
-    # Split text into lines and count lines starting with * or -
-    lines = text.split("\n")
-    bullet_points = [line.strip() for line in lines if line.strip().startswith(("*", "-"))]
-    actual_count = len(bullet_points)
-
-    return actual_count == N
+    star_bullets = re.findall(r"^\s*\*[^\*].*$", text, flags=re.MULTILINE)
+    dash_bullets = re.findall(r"^\s*-.*$", text, flags=re.MULTILINE)
+    return len(star_bullets) + len(dash_bullets) == N
 
 
 # Title: Your answer must contain a title, wrapped in double angular brackets, such as <<poem of joy>>.

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -335,7 +335,7 @@ def verify_bullet_points(text: str, N: int) -> bool:
     Returns:
         bool: True if the text contains exactly N bullet points, False otherwise.
     """
-    star_bullets = re.findall(r"^\s*\*[^\*].*$", text, flags=re.MULTILINE)
+    star_bullets = re.findall(r"^\s*\*(?!\*).*$", text, flags=re.MULTILINE)
     dash_bullets = re.findall(r"^\s*-.*$", text, flags=re.MULTILINE)
     return len(star_bullets) + len(dash_bullets) == N
 

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -41,3 +41,30 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestVerifyBulletPoints(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("exact_stars", "* one\n* two", 2, True),
+            ("bold_not_bullet", "**Introduction**\n* one\n* two", 2, True),
+            ("bold_false_positive_old", "**Introduction**\n* one\n* two", 3, False),
+            ("dash_bullets", "- a\n- b\n- c", 3, True),
+            ("mixed", "* a\n- b", 2, True),
+        ]
+    )
+    def test_verify_bullet_points(self, _name, text, n, expected):
+        self.assertEqual(if_functions.verify_bullet_points(text, n), expected)
+
+
+class TestVerifyParagraphCount(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("triple_star", "Para1\n***\nPara2\n***\nPara3", 3, True),
+            ("spaced_stars_not_divider", "Para1\n* * *\nPara2\n* * *\nPara3", 3, False),
+            ("inline", "a***b", 2, True),
+            ("wrong_count", "only one", 2, False),
+        ]
+    )
+    def test_verify_paragraph_count(self, _name, text, n, expected):
+        self.assertEqual(if_functions.verify_paragraph_count(text, n), expected)

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -51,6 +51,7 @@ class TestVerifyBulletPoints(unittest.TestCase):
             ("bold_false_positive_old", "**Introduction**\n* one\n* two", 3, False),
             ("dash_bullets", "- a\n- b\n- c", 3, True),
             ("mixed", "* a\n- b", 2, True),
+            ("lone_star", "*", 1, True),
         ]
     )
     def test_verify_bullet_points(self, _name, text, n, expected):


### PR DESCRIPTION
## Summary
- `verify_bullet_points` no longer counts `**bold**` lines as `*` bullets.
- `verify_paragraph_count` splits on `***` like IFEvalG `ParagraphChecker`.

## Test plan
- [x] Unit tests for bold titles, dash bullets, and `***` vs `* * *`
- GPU_TESTS=bypass