### PR TITLE
fix: ignore empty star spans in highlighted-section check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Count only non-empty `*...*` / `**...**` spans in `validate_highlighted_sections` (https://github.com/allenai/open-instruct/pull/1766).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -365,10 +365,19 @@ def validate_choice(text: str, options: list) -> bool:
 # Minimum Number Highlighted Section: Highlight at least {N} sections in your answer with markdown, i.e. *highlighted
 # section*
 def validate_highlighted_sections(text: str, N: int) -> bool:
-    pattern = r"\*(.*?)\*"
-    matches = re.findall(pattern, text)
+    """Count non-empty *single* and **double** markdown highlights (IFEvalG).
 
-    return len(matches) >= N
+    A naive ``*(.*?) *`` pattern treats ``****`` as two empty highlights and
+    over-counts; require non-empty content between the markers.
+    """
+    num_highlights = 0
+    for highlight in re.findall(r"\*[^\n\*]*\*", text):
+        if highlight.strip("*").strip():
+            num_highlights += 1
+    for highlight in re.findall(r"\*\*[^\n\*]*\*\*", text):
+        if highlight.strip("*").strip():
+            num_highlights += 1
+    return num_highlights >= N
 
 
 # Multiple Sections: Your response must have {N} sections. Mark the beginning of each section with {section splitter} X.

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,19 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+class TestValidateHighlightedSections(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("single_stars", "*one* *two*", 2, True),
+            ("double_star_counts", "**bold**", 1, True),
+            ("empty_stars_not_highlight", "****", 1, False),
+            ("plain_text", "no marks", 1, False),
+            ("single_ok", "*a*", 1, True),
+        ]
+    )
+    def test_validate_highlighted_sections(self, _name, text, n, expected):
+        self.assertEqual(if_functions.validate_highlighted_sections(text, n), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `validate_highlighted_sections` now matches IFEvalG: count non-empty `*...*` and `**...**` only.
- `****` no longer counts as two highlights.

## Test plan
- [x] Unit tests for single/double/empty star cases
- GPU_TESTS=bypass