### PR TITLE
fix: count numbered section headers in validate_sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Count numbered section headers in `validate_sections` (IFEvalG `SectionChecker`) (https://github.com/allenai/open-instruct/pull/1767).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -381,7 +381,7 @@ def validate_sections(text: str, N: int, section_splitter: str) -> bool:
     bare splitter string alone.
     """
     pattern = r"\s?" + re.escape(section_splitter) + r"\s?\d+\s?"
-    sections = re.split(pattern, text)
+    sections = re.split(pattern, text, flags=re.IGNORECASE)
     return len(sections) - 1 >= N
 
 

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -375,11 +375,14 @@ def validate_highlighted_sections(text: str, N: int) -> bool:
 
 
 def validate_sections(text: str, N: int, section_splitter: str) -> bool:
-    sections = text.split(section_splitter)
-    # The first section might not start with the splitter, so we adjust for this
-    if sections[0] == "":
-        sections.pop(0)
-    return len(sections) == N
+    """Require at least N numbered sections (IFEvalG SectionChecker).
+
+    Headers look like ``Section 1`` / ``SECTION 2``: splitter + number, not the
+    bare splitter string alone.
+    """
+    pattern = r"\s?" + re.escape(section_splitter) + r"\s?\d+\s?"
+    sections = re.split(pattern, text)
+    return len(sections) - 1 >= N
 
 
 # JSON Format : Entire output should be wrapped in JSON format.

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,18 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+class TestValidateSections(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("numbered_with_intro", "Intro\nSection 1\nHello\nSection 2\nWorld", 2, "Section", True),
+            ("bare_splitter_not_enough", "Intro\nSection\nHello\nSection\nWorld", 2, "Section", False),
+            ("at_least_n", "Section 1\na\nSection 2\nb\nSection 3\nc", 2, "Section", True),
+            ("too_few", "Section 1\nonly one", 2, "Section", False),
+        ]
+    )
+    def test_validate_sections(self, _name, text, n, splitter, expected):
+        self.assertEqual(if_functions.validate_sections(text, n, splitter), expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -46,6 +46,7 @@ class TestValidateSections(unittest.TestCase):
             ("bare_splitter_not_enough", "Intro\nSection\nHello\nSection\nWorld", 2, "Section", False),
             ("at_least_n", "Section 1\na\nSection 2\nb\nSection 3\nc", 2, "Section", True),
             ("too_few", "Section 1\nonly one", 2, "Section", False),
+            ("case_insensitive", "SECTION 1\na\nSECTION 2\nb", 2, "Section", True),
         ]
     )
     def test_validate_sections(self, _name, text, n, splitter, expected):


### PR DESCRIPTION
## Summary
- `validate_sections` now requires `Section N`-style headers and `>= N` sections, matching IFEvalG.

## Test plan
- [x] Unit tests for intro + numbered headers vs bare splitter
- GPU_TESTS=bypass