### PR TITLE
fix: accept markdown-fenced JSON in validate_json_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Strip markdown fences before parsing in `validate_json_format` (https://github.com/allenai/open-instruct/pull/1768).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -385,15 +385,11 @@ def validate_sections(text: str, N: int, section_splitter: str) -> bool:
 # JSON Format : Entire output should be wrapped in JSON format.
 def validate_json_format(text: str) -> bool:
     """Accept bare JSON or markdown-fenced JSON (IFEvalG JsonFormat)."""
-    value = (
-        text.strip()
-        .removeprefix("```json")
-        .removeprefix("```Json")
-        .removeprefix("```JSON")
-        .removeprefix("```")
-        .removesuffix("```")
-        .strip()
-    )
+    value = text.strip()
+    # Strip optional ``` / ```json fences case-insensitively.
+    value = re.sub(r"^```(?:json)?\s*", "", value, flags=re.IGNORECASE)
+    value = re.sub(r"\s*```$", "", value)
+    value = value.strip()
     try:
         json.loads(value)
     except ValueError:

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -384,8 +384,18 @@ def validate_sections(text: str, N: int, section_splitter: str) -> bool:
 
 # JSON Format : Entire output should be wrapped in JSON format.
 def validate_json_format(text: str) -> bool:
+    """Accept bare JSON or markdown-fenced JSON (IFEvalG JsonFormat)."""
+    value = (
+        text.strip()
+        .removeprefix("```json")
+        .removeprefix("```Json")
+        .removeprefix("```JSON")
+        .removeprefix("```")
+        .removesuffix("```")
+        .strip()
+    )
     try:
-        json.loads(text)
+        json.loads(value)
     except ValueError:
         return False
     return True

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,19 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+class TestValidateJsonFormat(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("bare", '{"a": 1}', True),
+            ("fenced_json", '```json\n{"a": 1}\n```', True),
+            ("fenced_plain", '```\n{"a": 1}\n```', True),
+            ("invalid", "not json", False),
+            ("fenced_invalid", "```json\nnot json\n```", False),
+        ]
+    )
+    def test_validate_json_format(self, _name, text, expected):
+        self.assertEqual(if_functions.validate_json_format(text), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Strip ```json / ``` fences before `json.loads`, matching IFEvalG.

## Test plan
- [x] Unit tests for bare and fenced JSON
- GPU_TESTS=bypass