### PR TITLE
fix: reject empty <<>> titles in validate_title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Reject empty `<<>>` titles in `validate_title` (https://github.com/allenai/open-instruct/pull/1769).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -349,9 +349,13 @@ def verify_bullet_points(text: str, N: int) -> bool:
 
 # Title: Your answer must contain a title, wrapped in double angular brackets, such as <<poem of joy>>.
 def validate_title(text: str) -> bool:
-    """Require a non-empty <<title>> (IFEvalG TitleChecker)."""
-    titles = re.findall(r"<<[^\n]+>>", text)
-    return any(title.lstrip("<").rstrip(">").strip() for title in titles)
+    """Require a non-empty <<title>> (IFEvalG TitleChecker).
+
+    Uses a non-greedy capture so adjacent empty ``<<>>`` pairs cannot glue
+    together into a false-positive non-empty match.
+    """
+    titles = re.findall(r"<<(.*?)>>", text)
+    return any(title.strip() for title in titles)
 
 
 # Choose: From Answer with one of the following options: {options}

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -349,10 +349,9 @@ def verify_bullet_points(text: str, N: int) -> bool:
 
 # Title: Your answer must contain a title, wrapped in double angular brackets, such as <<poem of joy>>.
 def validate_title(text: str) -> bool:
-    pattern = r"<<(.*?)>>"
-    matches = re.findall(pattern, text)
-
-    return len(matches) > 0
+    """Require a non-empty <<title>> (IFEvalG TitleChecker)."""
+    titles = re.findall(r"<<[^\n]+>>", text)
+    return any(title.lstrip("<").rstrip(">").strip() for title in titles)
 
 
 # Choose: From Answer with one of the following options: {options}

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -47,6 +47,9 @@ class TestValidateTitle(unittest.TestCase):
             ("whitespace", "<<  >>", False),
             ("missing", "no title here", False),
             ("with_prose", "Here is <<my title>> ok", True),
+            # Greedy <<[^\n]+>> would glue these into a false non-empty title.
+            ("adjacent_empty", "Please read <<>> or <<>>.", False),
+            ("empty_then_trailing", "<<>> and some other text >>", False),
         ]
     )
     def test_validate_title(self, _name, text, expected):

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,19 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+class TestValidateTitle(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("ok", "<<poem of joy>>", True),
+            ("empty", "<<>>", False),
+            ("whitespace", "<<  >>", False),
+            ("missing", "no title here", False),
+            ("with_prose", "Here is <<my title>> ok", True),
+        ]
+    )
+    def test_validate_title(self, _name, text, expected):
+        self.assertEqual(if_functions.validate_title(text), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `validate_title` requires non-empty content inside `<<…>>`, matching IFEvalG.

## Test plan
- [x] Unit tests for empty, whitespace, and valid titles
- GPU_TESTS=bypass