### PR TITLE
fix: make validate_end strip and case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Make `validate_end` strip/case-insensitive like IFEvalG (https://github.com/allenai/open-instruct/pull/1770).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -438,8 +438,10 @@ def validate_frequency_capital_words(text: str, N: int, quantifier: str) -> bool
 
 # End Checker: Finish your response with this exact phrase {end phrase}. No other words should follow this phrase.
 def validate_end(text: str, end_phrase: str) -> bool:
-    # Check if the response ends with the end phrase
-    return bool(text.endswith(end_phrase))
+    """Match IFEvalG EndChecker: strip, drop wrapping quotes, case-insensitive."""
+    text = text.strip().strip('"').lower()
+    end_phrase = end_phrase.strip().lower()
+    return text.endswith(end_phrase)
 
 
 # Quotation: Wrap your entire response with double quotation marks.

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,19 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+class TestValidateEnd(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("exact", "Done.", "Done.", True),
+            ("trailing_newline", "Done.\n", "Done.", True),
+            ("case", "done.", "Done.", True),
+            ("wrapped_quotes", '"Done."', "Done.", True),
+            ("missing", "Almost Done", "Done.", False),
+        ]
+    )
+    def test_validate_end(self, _name, text, phrase, expected):
+        self.assertEqual(if_functions.validate_end(text, phrase), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `validate_end` now strips whitespace/wrapping quotes and compares case-insensitively (IFEvalG `EndChecker`).

## Test plan
- [x] Unit tests for newline, case, and quoted endings
- GPU_TESTS=bypass