### PR TITLE
fix: reject lone quote in validate_quotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Reject lone `"` in `validate_quotation` (https://github.com/allenai/open-instruct/pull/1771).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -446,7 +446,7 @@ def validate_end(text: str, end_phrase: str) -> bool:
 def validate_quotation(text: str) -> bool:
     """Require wrapping double quotes (IFEvalG QuotationChecker; rejects a lone `"`)."""
     text = text.strip()
-    return len(text) > 1 and text[0] == '"' and text[-1] == '"'
+    return len(text) > 1 and text.startswith('"') and text.endswith('"')
 
 
 # No Commas: In your entire response, refrain from the use of any commas.

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -444,7 +444,9 @@ def validate_end(text: str, end_phrase: str) -> bool:
 
 # Quotation: Wrap your entire response with double quotation marks.
 def validate_quotation(text: str) -> bool:
-    return bool(text.startswith('"') and text.endswith('"'))
+    """Require wrapping quotes with non-empty content (IFEvalG QuotationChecker)."""
+    text = text.strip()
+    return len(text) > 1 and text[0] == '"' and text[-1] == '"'
 
 
 # No Commas: In your entire response, refrain from the use of any commas.

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -444,7 +444,7 @@ def validate_end(text: str, end_phrase: str) -> bool:
 
 # Quotation: Wrap your entire response with double quotation marks.
 def validate_quotation(text: str) -> bool:
-    """Require wrapping quotes with non-empty content (IFEvalG QuotationChecker)."""
+    """Require wrapping double quotes (IFEvalG QuotationChecker; rejects a lone `"`)."""
     text = text.strip()
     return len(text) > 1 and text[0] == '"' and text[-1] == '"'
 

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,19 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+class TestValidateQuotation(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("wrapped", '"hello"', True),
+            ("lone_quote", '"', False),
+            ("empty_pair", '""', False),
+            ("unquoted", "hello", False),
+            ("trailing_space", '  "ok"  ', True),
+        ]
+    )
+    def test_validate_quotation(self, _name, text, expected):
+        self.assertEqual(if_functions.validate_quotation(text), expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -44,7 +44,7 @@ class TestValidateQuotation(unittest.TestCase):
         [
             ("wrapped", '"hello"', True),
             ("lone_quote", '"', False),
-            ("empty_pair", '""', False),
+            ("empty_pair", '""', True),
             ("unquoted", "hello", False),
             ("trailing_space", '  "ok"  ', True),
         ]


### PR DESCRIPTION
## Summary
- `validate_quotation('"')` no longer passes; match IFEvalG (`len > 1` after strip).

## Test plan
- [x] Unit tests for lone quote vs wrapped text
- GPU_TESTS=bypass