### PR TITLE
fix: require non-empty sides in validate_two_responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Require two non-empty sides in `validate_two_responses` (https://github.com/allenai/open-instruct/pull/1772).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -400,13 +400,16 @@ def validate_repeat_prompt(text: str, original_prompt: str) -> bool:
 # Two Responses: Give two different responses. Responses and only responses should be separated by 6 asterisk
 # symbols: ******.
 def validate_two_responses(text: str) -> bool:
-    if text.count("******") == 1:
-        response_list = text.split("******")
-        first_response = response_list[0].strip()
-        second_response = response_list[1].strip()
-        if first_response != second_response:
-            return True
-    return False
+    """Require two non-empty different sides (IFEvalG TwoResponsesChecker)."""
+    valid_responses = []
+    responses = text.split("******")
+    for index, response in enumerate(responses):
+        if not response.strip():
+            if index != 0 and index != len(responses) - 1:
+                return False
+        else:
+            valid_responses.append(response)
+    return len(valid_responses) == 2 and valid_responses[0].strip() != valid_responses[1].strip()
 
 
 # All Uppercase: Your entire response should be in English, capital letters only.

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,19 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+class TestValidateTwoResponses(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("ok", "left******right", True),
+            ("empty_left", "******right", False),
+            ("empty_right", "left******", False),
+            ("same", "same******same", False),
+            ("no_sep", "only one", False),
+        ]
+    )
+    def test_validate_two_responses(self, _name, text, expected):
+        self.assertEqual(if_functions.validate_two_responses(text), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Empty left/right of `******` no longer counts as a second response (IFEvalG).

## Test plan
- [x] Unit tests for empty sides and identical responses
- GPU_TESTS=bypass