### PR TITLE
fix: make validate_repeat_prompt strip/case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Make `validate_repeat_prompt` strip/case-insensitive (https://github.com/allenai/open-instruct/pull/1774).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -394,7 +394,8 @@ def validate_json_format(text: str) -> bool:
 # Repeat Prompt: First, repeat the request without change, then give your answer (do not say anything before
 # repeating the request; the request you need to repeat does not include this sentence)
 def validate_repeat_prompt(text: str, original_prompt: str) -> bool:
-    return bool(text.startswith(original_prompt))
+    """Match IFEvalG: strip and compare case-insensitively."""
+    return bool(text.strip().lower().startswith(original_prompt.strip().lower()))
 
 
 # Two Responses: Give two different responses. Responses and only responses should be separated by 6 asterisk

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -395,7 +395,7 @@ def validate_json_format(text: str) -> bool:
 # repeating the request; the request you need to repeat does not include this sentence)
 def validate_repeat_prompt(text: str, original_prompt: str) -> bool:
     """Match IFEvalG: strip and compare case-insensitively."""
-    return bool(text.strip().lower().startswith(original_prompt.strip().lower()))
+    return text.strip().lower().startswith(original_prompt.strip().lower())
 
 
 # Two Responses: Give two different responses. Responses and only responses should be separated by 6 asterisk

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -45,6 +45,7 @@ class TestValidateRepeatPrompt(unittest.TestCase):
             ("exact", "Hello world answer", "Hello world", True),
             ("leading_space", "  Hello world answer", "Hello world", True),
             ("case", "HELLO world answer", "Hello world", True),
+            ("prompt_whitespace", "Hello world answer", " Hello world  ", True),
             ("missing", "Something else", "Hello world", False),
         ]
     )

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,18 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+class TestValidateRepeatPrompt(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("exact", "Hello world answer", "Hello world", True),
+            ("leading_space", "  Hello world answer", "Hello world", True),
+            ("case", "HELLO world answer", "Hello world", True),
+            ("missing", "Something else", "Hello world", False),
+        ]
+    )
+    def test_validate_repeat_prompt(self, _name, text, prompt, expected):
+        self.assertEqual(if_functions.validate_repeat_prompt(text, prompt), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Strip and lower both sides before `startswith`, matching IFEvalG.

## Test plan
- [x] Unit tests for leading space and case
- GPU_TESTS=bypass