### PR TITLE
fix: use isupper/islower for case validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Make `validate_uppercase` / `validate_lowercase` use `str.isupper` / `str.islower` so empty and non-letter strings fail (https://github.com/allenai/open-instruct/pull/1775).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -411,15 +411,15 @@ def validate_two_responses(text: str) -> bool:
 
 # All Uppercase: Your entire response should be in English, capital letters only.
 def validate_uppercase(text: str) -> bool:
-    # Check if the response is the same as the uppercase version of the response
-    return text == text.upper()
+    # Match IFEvalG CapitalLettersEnglishChecker: require actual uppercase letters.
+    return text.isupper()
 
 
 # All Lowercase: Your entire response should be in English, and in all lowercase letters. No capital letters are
 # allowed.
 def validate_lowercase(text: str) -> bool:
-    # Check if the response is the same as the lowercase version of the response
-    return text == text.lower()
+    # Match IFEvalG LowercaseLettersEnglishChecker: require actual lowercase letters.
+    return text.islower()
 
 
 # Frequency of All-capital Words: In your response, words with all capital letters should appear at least / around /

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,30 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+
+class TestValidateUpperLower(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("all_upper", "HELLO WORLD", True),
+            ("mixed", "Hello", False),
+            ("empty", "", False),
+            ("digits_only", "123", False),
+        ]
+    )
+    def test_validate_uppercase(self, _name, text, expected):
+        self.assertEqual(if_functions.validate_uppercase(text), expected)
+
+    @parameterized.expand(
+        [
+            ("all_lower", "hello world", True),
+            ("mixed", "Hello", False),
+            ("empty", "", False),
+            ("digits_only", "123", False),
+        ]
+    )
+    def test_validate_lowercase(self, _name, text, expected):
+        self.assertEqual(if_functions.validate_lowercase(text), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `text == text.upper()`/`lower()` accepted empty and digit-only strings.
- Use `str.isupper` / `str.islower` like IFEvalG.

## Test plan
- [x] `TestValidateUpperLower`

GPU_TESTS=bypass
CHANGELOG=