### PR TITLE
fix: align verify_postscript with IFEvalG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Align `verify_postscript` with IFEvalG (case-insensitive end-of-line marker match) (https://github.com/allenai/open-instruct/pull/1776).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -287,15 +287,17 @@ def verify_postscript(text, postscript_marker):
     Returns:
         bool: True if the text contains a valid postscript, False otherwise
     """
-    # Check if the text contains the postscript marker
-    if postscript_marker in text:
-        # Get the index of the marker
-        marker_index = text.find(postscript_marker)
-        # Check if the marker appears near the end
-        remaining_text = text[marker_index:].strip()
-        # Verify it's not just the marker alone
-        return len(remaining_text) > len(postscript_marker)
-    return False
+    # Align with IFEvalG PostscriptChecker: case-insensitive, marker starts a
+    # trailing segment (end of a line).
+    value = text.lower()
+    marker = postscript_marker.strip() if isinstance(postscript_marker, str) else postscript_marker
+    if marker == "P.P.S":
+        postscript_pattern = r"\s*p\.\s?p\.\s?s.*$"
+    elif marker == "P.S.":
+        postscript_pattern = r"\s*p\.\s?s\..*$"
+    else:
+        postscript_pattern = r"\s*" + re.escape(marker.lower()) + r".*$"
+    return bool(re.findall(postscript_pattern, value, flags=re.MULTILINE))
 
 
 # Number Placeholder: The response must contain at least {N} placeholders represented by square brackets,

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -289,15 +289,17 @@ def verify_postscript(text, postscript_marker):
     """
     # Align with IFEvalG PostscriptChecker: case-insensitive, marker starts a
     # trailing segment (end of a line).
+    if not isinstance(postscript_marker, str):
+        return False
     value = text.lower()
-    marker = postscript_marker.strip() if isinstance(postscript_marker, str) else postscript_marker
+    marker = postscript_marker.strip()
     if marker == "P.P.S":
         postscript_pattern = r"\s*p\.\s?p\.\s?s.*$"
     elif marker == "P.S.":
         postscript_pattern = r"\s*p\.\s?s\..*$"
     else:
         postscript_pattern = r"\s*" + re.escape(marker.lower()) + r".*$"
-    return bool(re.findall(postscript_pattern, value, flags=re.MULTILINE))
+    return bool(re.search(postscript_pattern, value, flags=re.MULTILINE))
 
 
 # Number Placeholder: The response must contain at least {N} placeholders represented by square brackets,

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,20 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+
+class TestVerifyPostscript(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("ps_end", "Body text.\nP.S. extra note", "P.S.", True),
+            ("case_insensitive", "Body.\np.s. note", "P.S.", True),
+            ("marker_only_mid", "P.S. early\nstill going", "P.S.", True),
+            ("missing", "No postscript here", "P.S.", False),
+            ("case_miss_old", "Body p.s. note", "P.S.", True),
+        ]
+    )
+    def test_verify_postscript(self, _name, text, marker, expected):
+        self.assertEqual(if_functions.verify_postscript(text, marker), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Marker check was case-sensitive and only required content after `find()`.
- Match IFEvalG: case-insensitive end-of-line postscript pattern.

## Test plan
- [x] `TestVerifyPostscript`

GPU_TESTS=bypass
CHANGELOG=