### PR TITLE
fix: align validate_paragraphs with IFEvalG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Align `validate_paragraphs` with IFEvalG (case-insensitive first word; skip empty paragraphs) (https://github.com/allenai/open-instruct/pull/1778).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -254,8 +254,9 @@ def validate_paragraphs(text, N, first_word, i):
     Validates that a text contains the expected number of paragraphs and that the i-th paragraph starts with a specific
     word.
 
-    Aligns with IFEvalG ``ParagraphFirstWordCheck``: empty paragraphs are ignored in
-    the count, and the first-word check is case-insensitive (punctuation stripped).
+    Aligns with IFEvalG ``ParagraphFirstWordCheck`` for case-insensitive first-word
+    checks (punctuation stripped). Empty paragraphs are filtered before both counting
+    and indexing so the i-th paragraph is the i-th non-empty paragraph.
 
     Args:
         text (str): The text to analyze
@@ -266,20 +267,16 @@ def validate_paragraphs(text, N, first_word, i):
     Returns:
         bool: True if the text meets the paragraph and first word requirements, False otherwise
     """
-    paragraphs = re.split(r"\n\n", text)
+    # Filter empties before counting/indexing so the i-th paragraph is the
+    # i-th non-empty paragraph (IFEvalG counts empties out of N but still
+    # indexes the unfiltered list; that shifts later indices incorrectly).
+    paragraphs = [p.strip() for p in re.split(r"\n\n", text) if p.strip()]
     num_paragraphs = len(paragraphs)
 
-    for paragraph in paragraphs:
-        if not paragraph.strip():
-            num_paragraphs -= 1
-
-    if i > num_paragraphs:
+    if i <= 0 or i > num_paragraphs:
         return False
 
-    paragraph = paragraphs[i - 1].strip()
-    if not paragraph:
-        return False
-
+    paragraph = paragraphs[i - 1]
     expected = first_word.lower()
     word = paragraph.split()[0].strip().lstrip("'").lstrip('"')
     punctuation = {".", ",", "?", "!", "'", '"'}

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -254,6 +254,9 @@ def validate_paragraphs(text, N, first_word, i):
     Validates that a text contains the expected number of paragraphs and that the i-th paragraph starts with a specific
     word.
 
+    Aligns with IFEvalG ``ParagraphFirstWordCheck``: empty paragraphs are ignored in
+    the count, and the first-word check is case-insensitive (punctuation stripped).
+
     Args:
         text (str): The text to analyze
         N (int): The expected number of paragraphs
@@ -263,15 +266,31 @@ def validate_paragraphs(text, N, first_word, i):
     Returns:
         bool: True if the text meets the paragraph and first word requirements, False otherwise
     """
-    # Split the text into paragraphs
-    paragraphs = text.split("\n\n")
+    paragraphs = re.split(r"\n\n", text)
+    num_paragraphs = len(paragraphs)
 
-    # Check if the number of paragraphs is as expected
-    if len(paragraphs) != N:
+    for paragraph in paragraphs:
+        if not paragraph.strip():
+            num_paragraphs -= 1
+
+    if i > num_paragraphs:
         return False
 
-    # Check if the i-th paragraph starts with the specified first word
-    return bool(paragraphs[i - 1].strip().startswith(first_word))
+    paragraph = paragraphs[i - 1].strip()
+    if not paragraph:
+        return False
+
+    expected = first_word.lower()
+    word = paragraph.split()[0].strip().lstrip("'").lstrip('"')
+    punctuation = {".", ",", "?", "!", "'", '"'}
+    actual = ""
+    for letter in word:
+        if letter in punctuation:
+            break
+        actual += letter.lower()
+
+    return num_paragraphs == N and actual == expected
+
 
 
 # Postscript: At the end of your response, please explicitly add a postscript starting with {postscript marker}

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,20 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+
+
+class TestValidateParagraphs(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("case_insensitive", "Hello world\n\nSecond para", 2, "hello", 1, True),
+            ("exact_case", "Hello world\n\nSecond para", 2, "Hello", 1, True),
+            ("wrong_count", "Only one", 2, "Only", 1, False),
+            ("punct_prefix", '"Hello", there\n\nNext', 2, "hello", 1, True),
+        ]
+    )
+    def test_validate_paragraphs(self, _name, text, n, first, i, expected):
+        self.assertEqual(if_functions.validate_paragraphs(text, n, first, i), expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -48,6 +48,8 @@ class TestValidateParagraphs(unittest.TestCase):
             ("exact_case", "Hello world\n\nSecond para", 2, "Hello", 1, True),
             ("wrong_count", "Only one", 2, "Only", 1, False),
             ("punct_prefix", '"Hello", there\n\nNext', 2, "hello", 1, True),
+            # Empty middle paragraph must not shift the 2nd non-empty index.
+            ("empty_paragraph", "Hello world\n\n\n\nSecond para", 2, "second", 2, True),
         ]
     )
     def test_validate_paragraphs(self, _name, text, n, first, i, expected):


### PR DESCRIPTION
## Summary
- First-word check was case-sensitive and ignored punctuation stripping.
- Match IFEvalG: lowercase compare, strip quotes/punct, ignore empty paragraphs.

## Test plan
- [x] `TestValidateParagraphs`

GPU_TESTS=bypass
CHANGELOG=