### PR TITLE
fix: tokenize validate_word_constraint like IFEvalG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Tokenize `validate_word_constraint` with word-character tokens like IFEvalG `count_words`. (https://github.com/allenai/open-instruct/pull/1779).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -200,8 +200,8 @@ def validate_word_constraint(text: str, N: int, quantifier: str) -> bool:
     Raises:
         ValueError: If an invalid qualifier is provided
     """
-    # Remove extra whitespace and split into words
-    words = text.strip().split()
+    # Match IFEvalG NumberOfWords / count_words: tokenize on word characters.
+    words = re.findall(r"\w+", text)
     actual_count = len(words)
 
     # Define tolerance for "around" qualifier (±10% of target count)

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,19 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+
+class TestValidateWordConstraint(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("punct_split_diff", "Hello, world! It's a test.", 6, "at least", True),
+            ("punct_old_split_would_be_5", "Hello, world! It's a test.", 5, "at most", False),
+            ("at_most", "one two three", 2, "at most", False),
+            ("around", "one two three", 3, "around", True),
+        ]
+    )
+    def test_validate_word_constraint(self, _name, text, n, quantifier, expected):
+        self.assertEqual(if_functions.validate_word_constraint(text, n, quantifier), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Whitespace `split()` undercounted punctuated text (`It's` as one token).
- Use `\w+` tokens like IFEvalG `count_words`.

## Test plan
- [x] `TestValidateWordConstraint`

GPU_TESTS=bypass
CHANGELOG=