### PR TITLE
fix: ignore empty trailing pieces in sentence count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,3 +25,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).
+- Ignore empty pieces in `verify_sentence_constraint` after a trailing terminator. (https://github.com/allenai/open-instruct/pull/1780).

--- a/open_instruct/if_functions.py
+++ b/open_instruct/if_functions.py
@@ -230,8 +230,8 @@ def verify_sentence_constraint(text: str, N: int, quantifier: str) -> bool:
     Returns:
         bool: True if the text contains the expected number of sentences, False otherwise
     """
-    # Split the text into sentences
-    sentences = re.split(r"(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?|!)\s", text)
+    # Split the text into sentences; drop empty trailing pieces from a final terminator.
+    sentences = [s for s in re.split(r"(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?|!)\s", text) if s.strip()]
 
     # Count the number of sentences
     actual_count = len(sentences)

--- a/open_instruct/test_if_functions.py
+++ b/open_instruct/test_if_functions.py
@@ -39,5 +39,19 @@ class TestValidateFrequencyCapitalWords(unittest.TestCase):
         self.assertEqual(if_functions.validate_frequency_capital_words(text, n, quantifier), expected)
 
 
+
+class TestVerifySentenceConstraint(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("two_sentences", "One. Two.", 2, "at least", True),
+            ("trailing_space", "One. Two. ", 2, "at most", True),
+            ("trailing_was_three", "One. Two. ", 3, "at least", False),
+            ("empty", "", 1, "at least", False),
+        ]
+    )
+    def test_verify_sentence_constraint(self, _name, text, n, quantifier, expected):
+        self.assertEqual(if_functions.verify_sentence_constraint(text, n, quantifier), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Trailing terminators left an empty split, inflating the sentence count.
- Drop empty pieces after the split.

## Test plan
- [x] `TestVerifySentenceConstraint`

GPU_TESTS=bypass
CHANGELOG=