### PR TITLE
Exclude nested virtualenvs from the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,10 +17,14 @@ local_dataset_cache/
 
 
 # Virtual environments
-.venv/
-venv/
-ENV/
-env/
+# Use **/ so nested venvs are excluded too: patterns are matched relative to the
+# context root, so a bare `.venv/` misses `oe-eval-internal/.venv/`. That matters
+# because uv builds venvs whose bin/python symlinks to the host interpreter, and
+# the dangling symlink fails the COPY checksum ("... .venv/bin/python: not found").
+**/.venv/
+**/venv/
+**/ENV/
+**/env/
 
 # IDE and editor files
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Fixed
+- Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).


### PR DESCRIPTION
## Summary
`.dockerignore` patterns are matched relative to the context root, so the bare `.venv/` entry only excludes the top-level virtualenv and misses `oe-eval-internal/.venv/`. Widen the virtualenv patterns to `**/` so nested ones are excluded too.

## Why
uv builds virtualenvs whose `bin/python` is a symlink to the *host* interpreter, e.g.

    oe-eval-internal/.venv/bin/python -> /Users/<user>/.local/share/uv/python/cpython-3.12-macos-aarch64-none/bin/python3.12

That symlink dangles inside the build. BuildKit stats it while checksumming `COPY oe-eval-interna[l] oe-eval-internal/` (Dockerfile:87) and the build dies:

    failed to compute cache key: failed to calculate checksum of ref ...: "/oe-eval-internal/.venv/bin/python": not found

Anyone who has run `uv sync` inside their `oe-eval-internal` clone hits this on every local `scripts/train/build_image_and_launch.sh` run. It's easy to end up in that state — CLAUDE.md tells you to clone `oe-eval-internal`, and it's a full Python repo. CI is unaffected because it clones fresh with no venv, which is why this has stayed invisible.

## Safety
- No build stage consumes a `.venv` from the context; the image creates its own at `/stage/.venv` (`PATH=/stage/.venv/bin:$PATH`, Dockerfile:94).
- No tracked files live under a nested `env`/`ENV`/`venv` directory (verified with `git ls-files`), so widening those patterns cannot drop anything the image needs.
- Net effect is a strictly smaller build context.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
