### PR TITLE
Send Beaker debug jobs to ai2/jupiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,5 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Fixed
+- Send Beaker debug/integration jobs to `ai2/jupiter`: `--cluster` is `nargs="+"` in `mason.py`, so repeating the flag overwrote instead of appending and five scripts silently ran on only their last-listed cluster (https://github.com/allenai/open-instruct/pull/1789).
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).

--- a/scripts/train/debug/dpo_integration_test.sh
+++ b/scripts/train/debug/dpo_integration_test.sh
@@ -2,10 +2,7 @@
 BEAKER_IMAGE="${1:-nathanl/open_instruct_auto}"
 
 uv run python mason.py \
-    --cluster ai2/neptune \
-    --cluster ai2/saturn \
     --cluster ai2/jupiter \
-    --cluster ai2/prior \
     --description "Single GPU DPO run, for debugging purposes." \
     --workspace ai2/tulu-thinker \
     --priority high \

--- a/scripts/train/debug/grpo_integration_test.sh
+++ b/scripts/train/debug/grpo_integration_test.sh
@@ -8,7 +8,6 @@ echo "Using Beaker image: $BEAKER_IMAGE"
 
 uv run python mason.py \
        --cluster ai2/jupiter \
-       --cluster ai2/saturn \
        --image "$BEAKER_IMAGE" \
        --description "Single GPU on Beaker integration test." \
        --pure_docker_mode \

--- a/scripts/train/debug/single_gpu_grpo.sh
+++ b/scripts/train/debug/single_gpu_grpo.sh
@@ -8,7 +8,6 @@ echo "Using Beaker image: $BEAKER_IMAGE"
 
 uv run python mason.py \
        --cluster ai2/jupiter \
-       --cluster ai2/saturn \
        --image "$BEAKER_IMAGE" \
        --description "Single GPU OLMo-core GRPO test script." \
        --pure_docker_mode \

--- a/scripts/train/debug/single_gpu_on_beaker.sh
+++ b/scripts/train/debug/single_gpu_on_beaker.sh
@@ -8,7 +8,6 @@ echo "Using Beaker image: $BEAKER_IMAGE"
 
 uv run python mason.py \
        --cluster ai2/jupiter \
-       --cluster ai2/saturn \
        --image "$BEAKER_IMAGE" \
        --description "Single GPU on Beaker test script." \
        --pure_docker_mode \

--- a/scripts/train/debug/tool_grpo.sh
+++ b/scripts/train/debug/tool_grpo.sh
@@ -11,8 +11,6 @@ echo "Using Beaker image: $BEAKER_IMAGE"
 # and then set the search_api_endpoint accordingly.
 uv run python mason.py \
        --cluster ai2/jupiter \
-       --cluster ai2/augusta \
-       --cluster ai2/saturn \
        --image "$BEAKER_IMAGE" \
        --description "Single GPU on Beaker with tool use test script." \
        --pure_docker_mode \


### PR DESCRIPTION
## Summary
`--cluster` is declared `nargs="+"` in [mason.py:113](https://github.com/allenai/open-instruct/blob/main/mason.py#L113), so **repeating the flag overwrites rather than appends** — argparse keeps only the last occurrence. Every one of these scripts listed several clusters but ran on just the last one:

| Script | Clusters listed | Actually used |
|---|---|---|
| `dpo_integration_test.sh` | 4 | `ai2/prior` |
| `grpo_integration_test.sh` | 2 | `ai2/saturn` |
| `tool_grpo.sh` | 3 | `ai2/saturn` |
| `single_gpu_grpo.sh` | 2 | `ai2/saturn` |
| `single_gpu_on_beaker.sh` | 2 | `ai2/saturn` |

Each now names `ai2/jupiter` alone, so what the script says is what runs.

## Why it matters
This is silent — the script reads as if several clusters are eligible, and the job spec ends up with `constraints: {"cluster": ["ai2/saturn"]}`. It bites in practice: a 1-GPU debug job pinned to saturn sat unscheduled for 30+ minutes with

> Job cannot be scheduled because it would exceed the workspace slot limit.

while jupiter had capacity. The `ai2/open-instruct-dev` workspace has a per-cluster slot limit, and the Beaker API does not surface that reason — only the UI does — so it presents as a job that mysteriously never starts.

`grpo_integration_test.sh` is the script the merge-queue Beaker workflow launches, so CI was pinned to saturn as well.

## Notes
- The alternative fix is the space-separated form (`--cluster ai2/jupiter ai2/saturn`), which would keep every listed cluster eligible. Going to jupiter alone instead, since batch jobs should run there.
- **This moves the DPO integration test off `ai2/prior`.**
- All five scripts are `--num_nodes 1`, and `ai2/jupiter` is in `INTERCONNECT_CLUSTERS`, so the multi-node interconnect check in `mason.py` is unaffected either way.

## Test plan
- `pre-commit run shellcheck` on all five — passed.
- `git diff --check` clean.
- Verified against a live launch: the same script with jupiter alone produces `constraints: {"cluster": ["ai2/jupiter"]}` and schedules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)