### PR TITLE
Fix ZeroDivisionError in multinode SFT debug script

### DIFF
--- a/scripts/train/debug/oc_sft_multinode.sh
+++ b/scripts/train/debug/oc_sft_multinode.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
+#
+# The dataset must be large enough to form at least one global batch, or
+# num_training_steps floors to 0 and the LR scheduler raises ZeroDivisionError.
+#
+#   global_batch_size_seqs = per_device(1) * grad_accum(4) * dp_world(16) = 64
+#   1000 examples -> ~257 packed instances -> 257 // 64 * 2 epochs = 8 steps
+#
+# Keep this comfortably above the global batch size: dp_world scales with node
+# count, so a value tuned to the current 2-node layout breaks on wider runs.
 
 BEAKER_IMAGE="${1:-${BEAKER_USER}/open-instruct-integration-test}"
 
@@ -33,7 +42,7 @@ uv run python mason.py \
     --num_epochs 2 \
     --ephemeral_save_interval 100 \
     --logging_steps 1 \
-    --mixer_list allenai/tulu-3-sft-personas-algebra 100 \
+    --mixer_list allenai/tulu-3-sft-personas-algebra 1000 \
     --seed 123 \
     --compile_model true \
     --with_tracking \

--- a/scripts/train/debug/oc_sft_multinode.sh
+++ b/scripts/train/debug/oc_sft_multinode.sh
@@ -1,13 +1,5 @@
 #!/bin/bash
-#
-# The dataset must be large enough to form at least one global batch, or
-# num_training_steps floors to 0 and the LR scheduler raises ZeroDivisionError.
-#
-#   global_batch_size_seqs = per_device(1) * grad_accum(4) * dp_world(16) = 64
-#   1000 examples -> ~257 packed instances -> 257 // 64 * 2 epochs = 8 steps
-#
-# Keep this comfortably above the global batch size: dp_world scales with node
-# count, so a value tuned to the current 2-node layout breaks on wider runs.
+# Mixer size must yield at least one global batch (64 seqs here), or num_training_steps floors to 0.
 
 BEAKER_IMAGE="${1:-${BEAKER_USER}/open-instruct-integration-test}"
 


### PR DESCRIPTION
`scripts/train/debug/oc_sft_multinode.sh` default arguments fail, because it requests a global batch larger than its own dataset, so `num_training_steps` floors to 0 and the LR scheduler raises `ZeroDivisionError`. 

```
global_batch_size_seqs = per_device(1) * grad_accum(4) * dp_world(16) = 64
100 examples -> 26 packed instances @ seq 4096
26 // 64 * 2 epochs = 0 steps
```
## Fix

Bump the mixer from 100 to 1000 examples (~257 instances -> 8 steps) and document the constraint in a header comment.

## Verification

Both runs are `oc_sft_multinode.sh` on 2 nodes x 8 GPUs, Qwen3-0.6B, seq 4096 — identical apart from this diff.

| | Before | After |
|---|---|---|
| Experiment | [01KZ4BQDCWGQ98ZFWE4P7GKRM1](https://beaker.org/ex/01KZ4BQDCWGQ98ZFWE4P7GKRM1) | [01KZ4FA2QX1FWRRJVXAVT1A530](https://beaker.org/ex/01KZ4FA2QX1FWRRJVXAVT1A530) |
| Packed instances | 26 | 257 |
| `Total training steps` | **0** | **8** |
| Result | `ZeroDivisionError` | exit 0, loss 0.7518 -> 0.4248 |

Before:
```
Packed 104,785 tokens ... into 26 instances of sequence length 4,096
Total training steps: 0 (epochs=2)
ERROR [olmo_core.train.trainer:1344] division by zero
```

After:
```
Packed 1,046,714 tokens ... into 257 instances of sequence length 4,096
Total training steps: 8 (epochs=2)
Applied FSDP to the model with 2D device mesh with shape (dp_replicate=2, dp_shard=8)
Training complete
```

## Notes

`GPU_TESTS=bypass` — this changes one shell script and no Python; the merge queue runs GPU tests regardless.


GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
