### PR TITLE
Validate effective_steps before building the LR scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,5 +23,6 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Fixed
+- Raise a `ValueError` naming the packed instance count, global batch size, and epoch count when `olmo_core_finetune.py` computes fewer than one training step, instead of letting an undersized dataset surface as a bare `ZeroDivisionError` from olmo-core's LR scheduler (https://github.com/allenai/open-instruct/pull/1796).
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).

--- a/open_instruct/olmo_core_finetune.py
+++ b/open_instruct/olmo_core_finetune.py
@@ -226,17 +226,9 @@ def main(args: SFTArguments, tc: dataset_transformation.TokenizerConfig) -> None
     logger.info(f"Total training steps: {effective_steps} (epochs={args.training.num_epochs})")
     if effective_steps < 1:
         raise ValueError(
-            f"Computed {effective_steps} training steps, so there is nothing to train on.\n"
-            f"  packed instances:       {len(np_dataset)}\n"
-            f"  global batch (seqs):    {global_batch_size_seqs} "
-            f"= per_device({args.training.per_device_train_batch_size}) "
-            f"* grad_accum({args.training.gradient_accumulation_steps}) * dp_world({dp_world_size})\n"
-            f"  num_epochs:             {args.training.num_epochs}\n\n"
-            "The dataset must yield at least one global batch: "
-            "len(dataset) // global_batch_size_seqs * num_epochs must be >= 1.\n"
-            "Note that dp_world scales with GPU count, so a dataset sized for a smaller job can "
-            "fall below one global batch when you add nodes. Either use more data, or lower "
-            "--gradient_accumulation_steps / --per_device_train_batch_size."
+            f"Computed {effective_steps} training steps from {len(np_dataset)} packed instances "
+            f"// global batch {global_batch_size_seqs} * {args.training.num_epochs} epochs. "
+            "Use more data, or lower --gradient_accumulation_steps / --per_device_train_batch_size."
         )
     scheduler = olmo_core_utils.build_scheduler(
         args.training.lr_scheduler_type, args.training.warmup_ratio, effective_steps

--- a/open_instruct/olmo_core_finetune.py
+++ b/open_instruct/olmo_core_finetune.py
@@ -224,6 +224,20 @@ def main(args: SFTArguments, tc: dataset_transformation.TokenizerConfig) -> None
         args.training.max_train_steps if args.training.max_train_steps is not None else num_training_steps
     )
     logger.info(f"Total training steps: {effective_steps} (epochs={args.training.num_epochs})")
+    if effective_steps < 1:
+        raise ValueError(
+            f"Computed {effective_steps} training steps, so there is nothing to train on.\n"
+            f"  packed instances:       {len(np_dataset)}\n"
+            f"  global batch (seqs):    {global_batch_size_seqs} "
+            f"= per_device({args.training.per_device_train_batch_size}) "
+            f"* grad_accum({args.training.gradient_accumulation_steps}) * dp_world({dp_world_size})\n"
+            f"  num_epochs:             {args.training.num_epochs}\n\n"
+            "The dataset must yield at least one global batch: "
+            "len(dataset) // global_batch_size_seqs * num_epochs must be >= 1.\n"
+            "Note that dp_world scales with GPU count, so a dataset sized for a smaller job can "
+            "fall below one global batch when you add nodes. Either use more data, or lower "
+            "--gradient_accumulation_steps / --per_device_train_batch_size."
+        )
     scheduler = olmo_core_utils.build_scheduler(
         args.training.lr_scheduler_type, args.training.warmup_ratio, effective_steps
     )


### PR DESCRIPTION
Follow-up to #1795 per @farhatkevin's review: that PR fixed `oc_sft_multinode.sh`, but any undersized dataset still floored `num_training_steps` to 0 and surfaced a bare `ZeroDivisionError` from olmo-core's scheduler.

Raise a `ValueError` before the scheduler is built:

```
Computed 0 training steps from 26 packed instances // global batch 64 * 2 epochs.
Use more data, or lower --gradient_accumulation_steps / --per_device_train_batch_size.
```

Only fires when `effective_steps < 1`, which previously always crashed, so normal training is unaffected.

## Verification

Original failure, 100-example mixer at seq 4096 (26 packed instances): `ZeroDivisionError` — [01KZ4BQDCWGQ98ZFWE4P7GKRM1](https://beaker.org/ex/01KZ4BQDCWGQ98ZFWE4P7GKRM1).

Same config against this branch: [01KZ7GY7E0K863P6YJKMDRGAF3](https://beaker.org/ex/01KZ7GY7E0K863P6YJKMDRGAF3) — queued at time of writing, will update with the result.

Evidence was built at `b0282a6f4`; the only change since is shortening the error string.

GPU_TESTS=[01KZ7CWKYZZXBCY476C7DVHE0J](https://beaker.org/ex/01KZ7CWKYZZXBCY476C7DVHE0J)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
