### PR TITLE
Fix the olmo-core to HF checkpoint converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Fixed
+- `scripts/train/convert_olmo_core_to_hf.py` now runs: it used `torch.distributed.checkpoint.state_dict.load_state_dict`, which no longer exists, and torch's generic DCP reader cannot read olmo-core's storage layout (`'_StorageInfo' object has no attribute 'transform_descriptors'`). Loads through `olmo_core.distributed.checkpoint.load_model_and_optim_state` instead (https://github.com/allenai/open-instruct/pull/1809).
 - Raise a `ValueError` naming the packed instance count, global batch size, and epoch count when `olmo_core_finetune.py` computes fewer than one training step, instead of letting an undersized dataset surface as a bare `ZeroDivisionError` from olmo-core's LR scheduler (https://github.com/allenai/open-instruct/pull/1796).
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).

--- a/scripts/train/convert_olmo_core_to_hf.py
+++ b/scripts/train/convert_olmo_core_to_hf.py
@@ -9,8 +9,8 @@ Example usage:
 
 import argparse
 
-import olmo_core.distributed.checkpoint as olmo_core_checkpoint
 import transformers
+from olmo_core.distributed import checkpoint as olmo_core_checkpoint
 
 from open_instruct import logger_utils, olmo_core_utils
 

--- a/scripts/train/convert_olmo_core_to_hf.py
+++ b/scripts/train/convert_olmo_core_to_hf.py
@@ -9,8 +9,7 @@ Example usage:
 
 import argparse
 
-import torch
-import torch.distributed.checkpoint.state_dict as dcp_state_dict
+import olmo_core.distributed.checkpoint as olmo_core_checkpoint
 import transformers
 
 from open_instruct import logger_utils, olmo_core_utils
@@ -34,8 +33,14 @@ def main():
     model_config = olmo_core_utils.get_transformer_config(args.model_name, vocab_size, attn_backend="torch")
     model = model_config.build(init_device="cpu")
 
+    # Load through olmo-core rather than torch's own DCP reader. olmo-core writes
+    # these checkpoints with its own storage layout, and torch 2.10's filesystem
+    # reader fails on them with `'_StorageInfo' object has no attribute
+    # 'transform_descriptors'`. (The previously used
+    # `torch.distributed.checkpoint.state_dict.load_state_dict` no longer exists at
+    # all.) Loads in place, so read the state dict back off the model afterwards.
+    olmo_core_checkpoint.load_model_and_optim_state(args.checkpoint_dir, model)
     state_dict = {"model": model.state_dict()}
-    dcp_state_dict.load_state_dict(state_dict, checkpoint_id=args.checkpoint_dir)
 
     tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer_name)
     olmo_core_utils.save_state_dict_as_hf(state_dict["model"], args.output_dir, args.model_name, tokenizer)


### PR DESCRIPTION
`scripts/train/convert_olmo_core_to_hf.py` could not run at all.

1. `torch.distributed.checkpoint.state_dict.load_state_dict` no longer exists — immediate `AttributeError` on torch 2.10.
2. Switching to `torch.distributed.checkpoint.load` then fails with `'_StorageInfo' object has no attribute 'transform_descriptors'`. olmo-core writes checkpoints with its own storage layout, which torch's generic DCP reader cannot read.

Fixed by loading through `olmo_core.distributed.checkpoint.load_model_and_optim_state`, the counterpart to the save path that produced the checkpoint. It loads in place, so the state dict is read back off the model. `torch` is no longer referenced, so the import is dropped.

This path matters because olmo-eval's `olmo_core` provider also rejects open-instruct checkpoints (`config.json missing required field 'tokenizer'`), making HF conversion the only way to evaluate them.

Verified end to end: converted five Olmo-3-7B olmo-core SFT checkpoints and evaluated each on IFBench and GSM8K.

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfGd3gqhva8Stpgf4os7sn