### PR TITLE
Fix GRPO activation checkpointing weight sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Fixed
+- Make OLMo-core GRPO honor the legacy `--gradient_checkpointing` option and preserve HF/vLLM parameter names when native activation-checkpoint wrappers are enabled (https://github.com/allenai/open-instruct/pull/1813).
 - Raise a `ValueError` naming the packed instance count, global batch size, and epoch count when `olmo_core_finetune.py` computes fewer than one training step, instead of letting an undersized dataset surface as a bare `ZeroDivisionError` from olmo-core's LR scheduler (https://github.com/allenai/open-instruct/pull/1796).
 - Track the CUDA 12 image suffix in the merge-queue Beaker workflow and allow enough time for the larger image build and upload (https://github.com/allenai/open-instruct/pull/1783).
 - Exclude nested virtualenvs (e.g. `oe-eval-internal/.venv/`) from the Docker build context, so a uv venv inside a nested clone no longer fails the image build on a dangling host-interpreter symlink (https://github.com/allenai/open-instruct/pull/1786).

--- a/open_instruct/grpo.py
+++ b/open_instruct/grpo.py
@@ -114,6 +114,18 @@ def main(
     using Ray actors for both training and inference. The same code path is used for
     single GPU mode and multi-node training.
     """
+    if (
+        model_config.gradient_checkpointing
+        and args.activation_checkpointing_mode == "budget"
+        and args.activation_memory_budget >= 1.0
+    ):
+        logger.warning(
+            "--gradient_checkpointing is a legacy option on the OLMo-core GRPO path; "
+            "enabling native selected_modules activation checkpointing. Prefer "
+            "--activation_checkpointing_mode selected_modules explicitly."
+        )
+        args = dataclasses.replace(args, activation_checkpointing_mode="selected_modules")
+
     tokenizer = grpo_fast.make_tokenizer(tc, model_config)
 
     grpo_fast.setup_runtime_variables(args, streaming_config, tools_config)

--- a/open_instruct/grpo_callbacks.py
+++ b/open_instruct/grpo_callbacks.py
@@ -7,7 +7,6 @@ These callbacks handle:
 """
 
 import contextlib
-import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -26,42 +25,9 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 from open_instruct import data_loader as data_loader_lib
 from open_instruct import grpo_utils, logger_utils, utils, vllm_utils
+from open_instruct.grpo_name_mapping import olmo_core_to_hf_name
 
 logger = logger_utils.setup_logger(__name__)
-
-_BLOCK_PATTERN = re.compile(r"blocks\.(\d+)\.(.*)")
-_OLMO_CORE_TO_HF_LAYER_MAPPINGS = {
-    "attention.w_q.weight": "self_attn.q_proj.weight",
-    "attention.w_k.weight": "self_attn.k_proj.weight",
-    "attention.w_v.weight": "self_attn.v_proj.weight",
-    "attention.w_out.weight": "self_attn.o_proj.weight",
-    "attention.q_norm.weight": "self_attn.q_norm.weight",
-    "attention.k_norm.weight": "self_attn.k_norm.weight",
-    "feed_forward.w1.weight": "mlp.gate_proj.weight",
-    "feed_forward.w2.weight": "mlp.down_proj.weight",
-    "feed_forward.w3.weight": "mlp.up_proj.weight",
-    "attention_norm.weight": "input_layernorm.weight",
-    "feed_forward_norm.weight": "post_attention_layernorm.weight",
-}
-
-
-def olmo_core_to_hf_name(name: str) -> str:
-    """Convert OLMo-core parameter name to HuggingFace format for Qwen3/LLaMA models."""
-    if name == "embeddings.weight":
-        return "model.embed_tokens.weight"
-    if name == "lm_head.norm.weight":
-        return "model.norm.weight"
-    if name == "lm_head.w_out.weight":
-        return "lm_head.weight"
-
-    layer_match = _BLOCK_PATTERN.match(name)
-    if layer_match:
-        layer_idx = layer_match.group(1)
-        rest = layer_match.group(2)
-        if rest in _OLMO_CORE_TO_HF_LAYER_MAPPINGS:
-            return f"model.layers.{layer_idx}.{_OLMO_CORE_TO_HF_LAYER_MAPPINGS[rest]}"
-
-    return name
 
 
 @dataclass

--- a/open_instruct/grpo_callbacks.py
+++ b/open_instruct/grpo_callbacks.py
@@ -25,7 +25,6 @@ from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 from open_instruct import data_loader as data_loader_lib
 from open_instruct import grpo_utils, logger_utils, utils, vllm_utils
-from open_instruct.grpo_name_mapping import olmo_core_to_hf_name
 
 logger = logger_utils.setup_logger(__name__)
 

--- a/open_instruct/grpo_name_mapping.py
+++ b/open_instruct/grpo_name_mapping.py
@@ -16,9 +16,36 @@ _OLMO_CORE_TO_HF_LAYER_MAPPINGS = {
     "attention_norm.weight": "input_layernorm.weight",
     "feed_forward_norm.weight": "post_attention_layernorm.weight",
 }
+_OLMO_CORE_GDN_TO_HF_LAYER_MAPPINGS = {
+    "attention.w_q.weight": "linear_attn.q_proj.weight",
+    "attention.w_k.weight": "linear_attn.k_proj.weight",
+    "attention.w_v.weight": "linear_attn.v_proj.weight",
+    "attention.w_a.weight": "linear_attn.a_proj.weight",
+    "attention.w_b.weight": "linear_attn.b_proj.weight",
+    "attention.w_g.weight": "linear_attn.g_proj.weight",
+    "attention.w_out.weight": "linear_attn.o_proj.weight",
+    "attention.q_conv1d.weight": "linear_attn.q_conv1d.weight",
+    "attention.k_conv1d.weight": "linear_attn.k_conv1d.weight",
+    "attention.v_conv1d.weight": "linear_attn.v_conv1d.weight",
+    "attention.o_norm.weight": "linear_attn.o_norm.weight",
+    "attention.A_log": "linear_attn.A_log",
+    "attention.dt_bias": "linear_attn.dt_bias",
+    # vLLM's Olmo Hybrid implementation uses fused GDN parameters internally. Support
+    # these names as well for OLMo-core configurations that expose the fused layout.
+    "attention.in_proj_qkvg.weight": "linear_attn.in_proj_qkvg.weight",
+    "attention.a_proj.weight": "linear_attn.a_proj.weight",
+    "attention.b_proj.weight": "linear_attn.b_proj.weight",
+    "attention.o_proj.weight": "linear_attn.o_proj.weight",
+    "attention.conv1d.weight": "linear_attn.conv1d.weight",
+    "attention_norm.weight": "input_layernorm.weight",
+    "feed_forward_norm.weight": "post_attention_layernorm.weight",
+    "feed_forward.w1.weight": "mlp.gate_proj.weight",
+    "feed_forward.w2.weight": "mlp.down_proj.weight",
+    "feed_forward.w3.weight": "mlp.up_proj.weight",
+}
 
 
-def olmo_core_to_hf_name(name: str) -> str:
+def olmo_core_to_hf_name(name: str, gdn_layer_indices: frozenset[int] = frozenset()) -> str:
     """Convert OLMo-core parameter name to HuggingFace format for Qwen3/LLaMA models."""
     # PyTorch's checkpoint wrapper stores the wrapped module below this name. Remove it so
     # activation checkpointing is transparent to the vLLM weight-sync name mapping.
@@ -35,7 +62,12 @@ def olmo_core_to_hf_name(name: str) -> str:
     if layer_match:
         layer_idx = layer_match.group(1)
         rest = layer_match.group(2)
-        if rest in _OLMO_CORE_TO_HF_LAYER_MAPPINGS:
-            return f"model.layers.{layer_idx}.{_OLMO_CORE_TO_HF_LAYER_MAPPINGS[rest]}"
+        layer_mappings = (
+            _OLMO_CORE_GDN_TO_HF_LAYER_MAPPINGS
+            if int(layer_idx) in gdn_layer_indices
+            else _OLMO_CORE_TO_HF_LAYER_MAPPINGS
+        )
+        if rest in layer_mappings:
+            return f"model.layers.{layer_idx}.{layer_mappings[rest]}"
 
     return name

--- a/open_instruct/grpo_name_mapping.py
+++ b/open_instruct/grpo_name_mapping.py
@@ -1,0 +1,41 @@
+"""Parameter-name conversion utilities for OLMo-core GRPO weight synchronization."""
+
+import re
+
+_BLOCK_PATTERN = re.compile(r"blocks\.(\d+)\.(.*)")
+_OLMO_CORE_TO_HF_LAYER_MAPPINGS = {
+    "attention.w_q.weight": "self_attn.q_proj.weight",
+    "attention.w_k.weight": "self_attn.k_proj.weight",
+    "attention.w_v.weight": "self_attn.v_proj.weight",
+    "attention.w_out.weight": "self_attn.o_proj.weight",
+    "attention.q_norm.weight": "self_attn.q_norm.weight",
+    "attention.k_norm.weight": "self_attn.k_norm.weight",
+    "feed_forward.w1.weight": "mlp.gate_proj.weight",
+    "feed_forward.w2.weight": "mlp.down_proj.weight",
+    "feed_forward.w3.weight": "mlp.up_proj.weight",
+    "attention_norm.weight": "input_layernorm.weight",
+    "feed_forward_norm.weight": "post_attention_layernorm.weight",
+}
+
+
+def olmo_core_to_hf_name(name: str) -> str:
+    """Convert OLMo-core parameter name to HuggingFace format for Qwen3/LLaMA models."""
+    # PyTorch's checkpoint wrapper stores the wrapped module below this name. Remove it so
+    # activation checkpointing is transparent to the vLLM weight-sync name mapping.
+    name = ".".join(part for part in name.split(".") if part != "_checkpoint_wrapped_module")
+
+    if name == "embeddings.weight":
+        return "model.embed_tokens.weight"
+    if name == "lm_head.norm.weight":
+        return "model.norm.weight"
+    if name == "lm_head.w_out.weight":
+        return "lm_head.weight"
+
+    layer_match = _BLOCK_PATTERN.match(name)
+    if layer_match:
+        layer_idx = layer_match.group(1)
+        rest = layer_match.group(2)
+        if rest in _OLMO_CORE_TO_HF_LAYER_MAPPINGS:
+            return f"model.layers.{layer_idx}.{_OLMO_CORE_TO_HF_LAYER_MAPPINGS[rest]}"
+
+    return name

--- a/open_instruct/grpo_olmo_core_actor.py
+++ b/open_instruct/grpo_olmo_core_actor.py
@@ -7,6 +7,7 @@ allowing distributed GRPO training across multiple GPUs and nodes.
 
 import os
 from datetime import timedelta
+from functools import partial
 from typing import Any
 
 import ray
@@ -15,6 +16,7 @@ import transformers
 from olmo_core import train
 from olmo_core.config import DType
 from olmo_core.distributed.parallel import DataParallelType
+from olmo_core.nn.attention.recurrent import GatedDeltaNetConfig
 from olmo_core.nn.hf.checkpoint import load_hf_model
 from olmo_core.optim import AdamWConfig, ConstantWithWarmup, CosWithWarmup, LinearWithWarmup
 from olmo_core.train import LoadStrategy, callbacks
@@ -129,6 +131,12 @@ class PolicyTrainerOLMoCoreProcess(RayProcess):
         )
         logger.info(f"[Rank {self.rank}] Building OLMo-core model from {self.model_name_or_path}")
         self.model, self.model_config = olmo_core_utils.setup_model(model_config_args)
+        self.gdn_layer_indices = frozenset(
+            idx
+            for idx, block_config in enumerate(self.model_config.resolved_block_configs)
+            if isinstance(block_config.sequence_mixer, GatedDeltaNetConfig)
+        )
+        self.name_mapper = partial(olmo_core_to_hf_name, gdn_layer_indices=self.gdn_layer_indices)
 
         if self.grpo_config.load_ref_policy and self.grpo_config.beta > 0:
             logger.info(f"[Rank {self.rank}] Building reference policy...")
@@ -260,7 +268,7 @@ class PolicyTrainerOLMoCoreProcess(RayProcess):
             vllm_engines=self.vllm_engines,
             model_update_group=self.model_update_group,
             model_step=0,
-            name_mapper=olmo_core_to_hf_name,
+            name_mapper=self.name_mapper,
         )
         if self.rank == 0:
             utils.ray_get_with_progress(refs, desc="Initial vLLM weight sync", enable=False)
@@ -334,7 +342,7 @@ class PolicyTrainerOLMoCoreProcess(RayProcess):
             vllm_engines=self.vllm_engines,
             model_update_group=self.model_update_group,
             actor_manager=self.actor_manager,  # ty: ignore[invalid-argument-type]
-            name_mapper=olmo_core_to_hf_name,
+            name_mapper=self.name_mapper,
         )
 
         if self.ref_policy is not None and self.grpo_config.beta > 0 and self.ref_policy_update_freq is not None:

--- a/open_instruct/grpo_olmo_core_actor.py
+++ b/open_instruct/grpo_olmo_core_actor.py
@@ -35,8 +35,8 @@ from open_instruct.grpo_callbacks import (
     RefPolicyUpdateCallback,
     StepTimingCallback,
     VLLMWeightSyncCallback,
-    olmo_core_to_hf_name,
 )
+from open_instruct.grpo_name_mapping import olmo_core_to_hf_name
 from open_instruct.olmo_core_callbacks import BeakerCallbackV2
 from open_instruct.olmo_core_train_modules import GRPOTrainModule
 from open_instruct.utils import RayProcess, is_beaker_job, ray_get_with_progress

--- a/tests/test_grpo_callbacks.py
+++ b/tests/test_grpo_callbacks.py
@@ -1,0 +1,13 @@
+from open_instruct.grpo_name_mapping import olmo_core_to_hf_name
+
+
+def test_olmo_core_to_hf_name_unwraps_activation_checkpointed_modules() -> None:
+    assert olmo_core_to_hf_name("blocks.7.attention._checkpoint_wrapped_module.w_q.weight") == (
+        "model.layers.7.self_attn.q_proj.weight"
+    )
+
+
+def test_olmo_core_to_hf_name_unwraps_checkpointed_norm_modules() -> None:
+    assert olmo_core_to_hf_name("blocks.7.attention_norm._checkpoint_wrapped_module.weight") == (
+        "model.layers.7.input_layernorm.weight"
+    )

--- a/tests/test_grpo_callbacks.py
+++ b/tests/test_grpo_callbacks.py
@@ -11,3 +11,16 @@ def test_olmo_core_to_hf_name_unwraps_checkpointed_norm_modules() -> None:
     assert olmo_core_to_hf_name("blocks.7.attention_norm._checkpoint_wrapped_module.weight") == (
         "model.layers.7.input_layernorm.weight"
     )
+
+
+def test_olmo_core_to_hf_name_maps_checkpointed_gdn_parameters() -> None:
+    gdn_layers = frozenset({7})
+    assert olmo_core_to_hf_name(
+        "blocks.7.attention._checkpoint_wrapped_module.w_q.weight", gdn_layer_indices=gdn_layers
+    ) == "model.layers.7.linear_attn.q_proj.weight"
+    assert olmo_core_to_hf_name(
+        "blocks.7.attention._checkpoint_wrapped_module.A_log", gdn_layer_indices=gdn_layers
+    ) == "model.layers.7.linear_attn.A_log"
+    assert olmo_core_to_hf_name(
+        "blocks.7.attention._checkpoint_wrapped_module.in_proj_qkvg.weight", gdn_layer_indices=gdn_layers
+    ) == "model.layers.7.linear_attn.in_proj_qkvg.weight"


### PR DESCRIPTION
## Summary
- make legacy `--gradient_checkpointing` enable olmo-core selected-module activation checkpointing when native checkpointing is otherwise disabled
- preserve HF/vLLM parameter name mapping for PyTorch activation-checkpoint wrappers, including GDN/Olmo Hybrid layers
- select the GDN mapping per resolved OLMo-core block, so full-attention layers retain their existing mapping
- add regression coverage for checkpointed standard-attention and GDN parameter names

## Testing
- `uv run pytest tests/test_grpo_callbacks.py`
- `make style && make quality`
- `uv run pytest` *(fails during collection in two pre-existing tokenizer tests because the cached tokenizer download is not gzip data: `gzip.BadGzipFile: Not a gzipped file (b've')`)*

GPU_TESTS=bypass