### PR TITLE
Match the CHANGELOG instruction to what CI enforces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,9 @@
 
 
 # Workflow
-- When creating a PR, always add a summary to `CHANGELOG.md` with a link to the PR (e.g., `- Description of change (https://github.com/allenai/open-instruct/pull/123).`).
+- When a PR changes anything under `open_instruct/`, add a summary to `CHANGELOG.md` with a link to the PR (e.g., `- Description of change (https://github.com/allenai/open-instruct/pull/123).`). This is what CI enforces; PRs touching only `scripts/`, docs, or config are exempt, though an entry is still welcome for anything user-visible.
+  - The entry must contain the PR's own URL, which does not exist until the PR is opened. Add the entry, open the PR, then amend the entry with the URL and push again.
+  - To skip the check deliberately, put `CHANGELOG=<reason>` in the PR body (same mechanism as `GPU_TESTS=bypass`).
 - Always run the linter and make sure the tests pass before finishing a task.
 - Prefer running single tests, not the whole suite, when developing.
 - To run the `./scripts/train/build_image_and_launch.sh` script, you must commit the current changes.


### PR DESCRIPTION
Sync `CHANGELOG.md` instruction in `AGENTS.md` what CI enforces.

**Scope.** The instruction says to "always" add an entry. The check in `pr_checks.yml` only fires when the diff touches `open_instruct/`:

**The bypass is undocumented.** `CHANGELOG=<reason>` in the PR body skips the check, the same mechanism as `GPU_TESTS=bypass`, which *is* documented. Anyone hitting the check has no way to know the escape hatch exists.

**The PR URL is a chicken-and-egg.** The check requires the entry to contain the PR's own URL, but that URL doesn't exist until the PR is opened. Writing the entry while committing — the natural order, and what the instruction implies — produces a failing check on every new PR. Spelling out the order (entry → open PR → amend with URL) saves a round trip.

GPU_TESTS=bypass
CHANGELOG=documentation-only change to AGENTS.md
