### PR TITLE
Restore LOCAL_CACHE_DIR in the 1-node Olmo-3-7B SFT script

### DIFF
--- a/scripts/train/debug/oc_sft_olmo3_7b_1node.sh
+++ b/scripts/train/debug/oc_sft_olmo3_7b_1node.sh
@@ -54,6 +54,7 @@ CHAT_TEMPLATE=olmo123
 MAX_SEQ_LENGTH=32768
 MIXER="allenai/Dolci-Instruct-SFT 1.0"
 SEED=33333
+LOCAL_CACHE_DIR=/weka/oe-adapt-default/allennlp/numpy_sft_cache
 # add_bos must stay off: dataset_transformation.py asserts it for any "olmo*"
 # chat template.
 # ----------------------------------------------------------------------


### PR DESCRIPTION
The script references `$LOCAL_CACHE_DIR` twice but its definition was lost when #1811 merged. Under `set -euo pipefail` it therefore aborts with `LOCAL_CACHE_DIR: unbound variable` before launching anything, in both `tokenize` and `train` modes — so the script as shipped cannot run.

One line, restoring the assignment. Verified both modes now reach the `mason.py` invocation.

Context worth knowing but not worth a comment in the script: the value has no effect on Beaker. `setup_tokenizer_and_cache` overrides `local_cache_dir` to `/weka/oe-adapt-default/allennlp/deletable_open_instruct_dataset_cache` for any Beaker job, and both modes here are Beaker jobs, so they land on the same Weka path regardless. It is passed for parity with the 4-node script.

No CHANGELOG entry: the check in `pr_checks.yml` only fires when the diff touches `open_instruct/`, and this is scripts-only (see #1814).