### PR TITLE
fix: add Beaker provenance to OLMo-core wandb runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Fixed
+- Add Beaker workload and experiment provenance to OLMo-core W&B run configs without mutating the training config (https://github.com/allenai/open-instruct/pull/1824).
 - SFT's default checkpoint intervals collided: `olmo_core_finetune.py` forced `ephemeral_save_interval=500` through `parser.set_defaults` while `checkpointing_steps` also defaults to 500, and olmo-core requires the former to be strictly smaller, so any run that did not override one of them was rejected at startup. The forced default is now 250, and a non-positive `--ephemeral_save_interval` disables ephemeral checkpoints entirely, matching the existing `-1` convention for `max_checkpoints` (https://github.com/allenai/open-instruct/pull/1810).
 - Include `--seed`, `--chat_template_name`, and `--transform_fn` in the tokenization command printed on a pre-tokenized cache miss; all three feed the cache key, so following the previous command built a cache the training job could not find (https://github.com/allenai/open-instruct/pull/1801).
 - `scripts/train/convert_olmo_core_to_hf.py` now runs: it used `torch.distributed.checkpoint.state_dict.load_state_dict`, which no longer exists, and torch's generic DCP reader cannot read olmo-core's storage layout (`'_StorageInfo' object has no attribute 'transform_descriptors'`). Loads through `olmo_core.distributed.checkpoint.load_model_and_optim_state` instead (https://github.com/allenai/open-instruct/pull/1809).

--- a/open_instruct/olmo_core_utils.py
+++ b/open_instruct/olmo_core_utils.py
@@ -318,11 +318,15 @@ def build_base_callbacks(
         ),
     }
     if with_tracking and wandb_project:
+        wandb_config = dict(config_dict)
+        beaker_config = utils.maybe_get_beaker_config()
+        if beaker_config is not None:
+            wandb_config.update(vars(beaker_config))
         result["wandb"] = train_callbacks.WandBCallback(
             name=run_name,
             entity=wandb_entity,
             project=wandb_project,
-            config=config_dict,
+            config=wandb_config,
             enabled=True,
             cancel_check_interval=10,
         )

--- a/open_instruct/test_olmo_core_finetune.py
+++ b/open_instruct/test_olmo_core_finetune.py
@@ -3,6 +3,8 @@
 import os
 import tempfile
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 
 from parameterized import parameterized
 
@@ -92,6 +94,41 @@ class TestCheckpointerDefaults(unittest.TestCase):
             with self.subTest(interval=interval):
                 callback = olmo_core_utils.build_checkpointer_callback(345, interval)
                 self.assertIsNone(callback.ephemeral_save_interval)
+
+
+class TestWandBConfig(unittest.TestCase):
+    def test_beaker_runtime_metadata_is_added_without_mutating_training_config(self) -> None:
+        config = {"seed": 42}
+        beaker_config = SimpleNamespace(
+            beaker_workload_id="01TEST",
+            beaker_experiment_url="https://beaker.org/ex/01TEST/",
+        )
+
+        with (
+            mock.patch.object(olmo_core_utils.utils, "maybe_get_beaker_config", return_value=beaker_config),
+            mock.patch.object(olmo_core_utils.olmo_core_callbacks, "BeakerCallbackV2"),
+            mock.patch.object(olmo_core_utils.train_callbacks, "GPUMemoryMonitorCallback"),
+            mock.patch.object(olmo_core_utils, "build_checkpointer_callback"),
+            mock.patch.object(olmo_core_utils.train_callbacks, "WandBCallback") as wandb_callback,
+        ):
+            olmo_core_utils.build_base_callbacks(
+                config,
+                run_name="test-run",
+                checkpointing_steps=500,
+                ephemeral_save_interval=250,
+                with_tracking=True,
+                wandb_project="test-project",
+            )
+
+        self.assertEqual(
+            wandb_callback.call_args.kwargs["config"],
+            {
+                "seed": 42,
+                "beaker_workload_id": "01TEST",
+                "beaker_experiment_url": "https://beaker.org/ex/01TEST/",
+            },
+        )
+        self.assertEqual(config, {"seed": 42})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- enrich the OLMo-core W&B callback config with `maybe_get_beaker_config()` metadata when available
- keep the original training config unchanged
- add regression coverage for Beaker workload and experiment provenance

Fixes #1812

## Testing

- Focused unit regression added in `open_instruct/test_olmo_core_finetune.py`
- Local dependency-backed test execution is not available in this environment; repository CI should run the unit/style checks for the fork PR
