### PR TITLE
fix: record source provenance for numpy SFT caches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 - When creating a PR, always add a summary to `CHANGELOG.md` with a link to the PR (e.g., `- Description of change (https://github.com/allenai/open-instruct/pull/123).`).
 - Always run the linter and make sure the tests pass before finishing a task.
 - Prefer running single tests, not the whole suite, when developing.
+- If a change alters SFT tokenization or assistant-label derivation, either bump `DATASET_CACHE_VERSION` when existing caches become invalid or document why old caches remain valid; validate the change with a fresh `--seed` or cache key.
 - To run the `./scripts/train/build_image_and_launch.sh` script, you must commit the current changes.
 - To launch experiment scripts, use the `build_image_and_launch.sh` script, like this: `./scripts/train/build_image_and_launch.sh $SOME_SCRIPT`.
 - For GRPO, we have three test scripts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Fixed
+- Record Open Instruct source provenance for fresh numpy SFT caches and warn when reused caches are missing provenance or were built from a different commit (https://github.com/allenai/open-instruct/pull/1825).
 - SFT's default checkpoint intervals collided: `olmo_core_finetune.py` forced `ephemeral_save_interval=500` through `parser.set_defaults` while `checkpointing_steps` also defaults to 500, and olmo-core requires the former to be strictly smaller, so any run that did not override one of them was rejected at startup. The forced default is now 250, and a non-positive `--ephemeral_save_interval` disables ephemeral checkpoints entirely, matching the existing `-1` convention for `max_checkpoints` (https://github.com/allenai/open-instruct/pull/1810).
 - Include `--seed`, `--chat_template_name`, and `--transform_fn` in the tokenization command printed on a pre-tokenized cache miss; all three feed the cache key, so following the previous command built a cache the training job could not find (https://github.com/allenai/open-instruct/pull/1801).
 - `scripts/train/convert_olmo_core_to_hf.py` now runs: it used `torch.distributed.checkpoint.state_dict.load_state_dict`, which no longer exists, and torch's generic DCP reader cannot read olmo-core's storage layout (`'_StorageInfo' object has no attribute 'transform_descriptors'`). Loads through `olmo_core.distributed.checkpoint.load_model_and_optim_state` instead (https://github.com/allenai/open-instruct/pull/1809).

--- a/open_instruct/olmo_core_finetune.py
+++ b/open_instruct/olmo_core_finetune.py
@@ -29,9 +29,11 @@ import dataclasses
 import datetime
 import glob
 import hashlib
+import json
 import os
 import pathlib
 import re
+import subprocess
 from typing import Any
 
 import torch
@@ -57,6 +59,7 @@ _DEFAULT_EPHEMERAL_SAVE_INTERVAL = 250
 _TOKENIZE_BARRIER_TIMEOUT_HOURS = 24
 
 _NUMPY_SFT_SUBDIR = "numpy_sft"
+_NUMPY_CACHE_PROVENANCE_FILE = "open_instruct_cache_provenance.json"
 
 _PART_INDEX_RE = re.compile(r"_part_(\d+)\.")
 
@@ -80,6 +83,84 @@ def _numpy_dir_is_populated(numpy_dir: str) -> bool:
     return token_chunks == labels_chunks == metadata_chunks
 
 
+def _numpy_dir_has_payload(numpy_dir: str) -> bool:
+    return bool(
+        _chunk_indices(numpy_dir, numpy_dataset_conversion.TOKEN_IDS_NPY_GLOB)
+        or _chunk_indices(numpy_dir, numpy_dataset_conversion.LABELS_MASK_NPY_GLOB)
+        or _chunk_indices(numpy_dir, numpy_dataset_conversion.TOKEN_IDS_METADATA_GLOB)
+    )
+
+
+def _current_source_commit() -> str | None:
+    commit = os.environ.get("GIT_COMMIT", "").strip()
+    if commit:
+        return commit
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=pathlib.Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    commit = result.stdout.strip()
+    return commit or None
+
+
+def _numpy_cache_provenance_path(numpy_dir: str) -> str:
+    return os.path.join(numpy_dir, _NUMPY_CACHE_PROVENANCE_FILE)
+
+
+def _record_numpy_cache_provenance(numpy_dir: str) -> None:
+    commit = _current_source_commit()
+    if commit is None:
+        return
+    provenance_path = _numpy_cache_provenance_path(numpy_dir)
+    if os.path.exists(provenance_path):
+        return
+    if _numpy_dir_has_payload(numpy_dir):
+        logger.warning(
+            f"Numpy SFT cache at {numpy_dir} already contains data but has no source provenance; "
+            "leaving provenance unset rather than attributing existing chunks to the current code."
+        )
+        return
+    os.makedirs(numpy_dir, exist_ok=True)
+    with open(provenance_path, "w", encoding="utf-8") as f:
+        json.dump({"git_commit": commit}, f)
+        f.write("\n")
+
+
+def _warn_if_numpy_cache_provenance_mismatch(numpy_dir: str) -> None:
+    current_commit = _current_source_commit()
+    if current_commit is None:
+        return
+    provenance_path = _numpy_cache_provenance_path(numpy_dir)
+    try:
+        with open(provenance_path, encoding="utf-8") as f:
+            provenance = json.load(f)
+    except FileNotFoundError:
+        logger.warning(
+            f"Numpy SFT cache at {numpy_dir} has no source provenance. It may have been built by code with "
+            "different tokenization or label derivation; rebuild the cache before validating such changes."
+        )
+        return
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(f"Could not read numpy SFT cache provenance at {provenance_path}: {e}")
+        return
+
+    cached_commit = provenance.get("git_commit") if isinstance(provenance, dict) else None
+    if not isinstance(cached_commit, str) or not cached_commit:
+        logger.warning(f"Numpy SFT cache provenance at {provenance_path} does not contain a valid git commit.")
+    elif cached_commit != current_commit:
+        logger.warning(
+            f"Numpy SFT cache at {numpy_dir} was built from Open Instruct commit {cached_commit}, but the "
+            f"current code is {current_commit}. Cached label masks may be stale if tokenization or label "
+            "derivation changed; rebuild the cache before relying on it for validation."
+        )
+
+
 def _seed_cache_suffix(seed: int, max_seq_length: int) -> str:
     return hashlib.sha256(f"{seed}:{max_seq_length}".encode()).hexdigest()[:8]
 
@@ -92,6 +173,7 @@ def _tokenize_to_numpy_dir(
     visualize: bool,
 ) -> None:
     logger.info(f"Tokenizing dataset into numpy format at {numpy_dir}")
+    _record_numpy_cache_provenance(numpy_dir)
     numpy_dataset_conversion.convert_hf_to_numpy_sft(
         output_dir=pathlib.Path(numpy_dir),
         dataset_mixer_list=args.dataset.mixer_list,
@@ -142,6 +224,7 @@ def main(args: SFTArguments, tc: dataset_transformation.TokenizerConfig) -> None
         pre_init_rank = int(os.environ.get("RANK", 0))
         if pre_init_rank == 0:
             if _numpy_dir_is_populated(numpy_dir):
+                _warn_if_numpy_cache_provenance_mismatch(numpy_dir)
                 logger.info(f"Numpy SFT files already present at {numpy_dir}; nothing to do.")
             else:
                 _tokenize_to_numpy_dir(numpy_dir, args, tc, transform_fn_args, visualize=True)
@@ -178,6 +261,7 @@ def main(args: SFTArguments, tc: dataset_transformation.TokenizerConfig) -> None
             f"      {cache_cmd}\n\n"
             "Re-launch training once the tokenization job has completed."
         )
+    _warn_if_numpy_cache_provenance_mismatch(numpy_dir)
 
     global_rank, world_size, is_main_process = olmo_core_utils.setup_distributed_env(
         seed=args.tracking.seed, timeout=datetime.timedelta(hours=_TOKENIZE_BARRIER_TIMEOUT_HOURS)

--- a/open_instruct/test_olmo_core_finetune.py
+++ b/open_instruct/test_olmo_core_finetune.py
@@ -1,8 +1,10 @@
 """Unit tests for cache-validation and checkpoint-detection helpers."""
 
+import json
 import os
 import tempfile
 import unittest
+from unittest import mock
 
 from parameterized import parameterized
 
@@ -45,6 +47,41 @@ class NumpyDirIsPopulatedTest(unittest.TestCase):
             _touch(os.path.join(tmp, "labels_mask_part_0000.npy"))
             _touch(os.path.join(tmp, "token_ids_part_0000.csv.gz"))
             self.assertFalse(olmo_core_finetune._numpy_dir_is_populated(tmp))
+
+
+class NumpyCacheProvenanceTest(unittest.TestCase):
+    def test_fresh_cache_records_source_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"GIT_COMMIT": "abc123"}):
+            olmo_core_finetune._record_numpy_cache_provenance(tmp)
+            with open(
+                os.path.join(tmp, olmo_core_finetune._NUMPY_CACHE_PROVENANCE_FILE),
+                encoding="utf-8",
+            ) as f:
+                self.assertEqual(json.load(f), {"git_commit": "abc123"})
+
+    def test_existing_partial_cache_is_not_relabelled(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp, mock.patch.dict(os.environ, {"GIT_COMMIT": "abc123"}):
+            _touch(os.path.join(tmp, "token_ids_part_0000.npy"))
+            olmo_core_finetune._record_numpy_cache_provenance(tmp)
+            self.assertFalse(os.path.exists(os.path.join(tmp, olmo_core_finetune._NUMPY_CACHE_PROVENANCE_FILE)))
+
+    def test_mismatched_source_commit_warns(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with open(
+                os.path.join(tmp, olmo_core_finetune._NUMPY_CACHE_PROVENANCE_FILE),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                json.dump({"git_commit": "old123"}, f)
+            with (
+                mock.patch.dict(os.environ, {"GIT_COMMIT": "new456"}),
+                mock.patch.object(olmo_core_finetune.logger, "warning") as warning,
+            ):
+                olmo_core_finetune._warn_if_numpy_cache_provenance_mismatch(tmp)
+            warning.assert_called_once()
+            message = warning.call_args.args[0]
+            self.assertIn("old123", message)
+            self.assertIn("new456", message)
 
 
 class IsHfCheckpointTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- record the Open Instruct source commit in fresh numpy SFT cache directories
- warn when a reused cache has missing, unreadable, or mismatched source provenance
- avoid retroactively stamping existing partial caches with the current commit
- document the cache invalidation rule for future tokenization and label-derivation changes
- add focused regression coverage

Fixes #1815

## Testing

- Focused unit regressions added in `open_instruct/test_olmo_core_finetune.py`
- Local dependency-backed test execution is not available in this environment; repository CI should run the unit/style checks for the fork PR
