### PR TITLE
Update the installation docs to match the current toolchain

### DIFF
--- a/docs/get_started/installation.md
+++ b/docs/get_started/installation.md
@@ -1,51 +1,85 @@
-
 # Installation
 
-Our setup mostly follows our [Dockerfile](./Dockerfile), which uses Python 3.10. *Note that Open Instruct is a research codebase and does not guarantee backward compatibility.* We offer two installation strategies:
+Our setup follows our [Dockerfile](https://github.com/allenai/open-instruct/blob/main/Dockerfile). *Note that Open Instruct is a research codebase and does not guarantee backward compatibility.*
 
-* **Local installation**: This is the recommended way to install Open Instruct. You can install the dependencies by running the following commands:
-```bash
-pip install --upgrade pip "setuptools<70.0.0" wheel
-# TODO, unpin setuptools when this issue in flash attention is resolved
-pip install torch==2.5.1 torchvision==0.20.1 --index-url https://download.pytorch.org/whl/cu121
-pip install packaging
-pip install flash-attn==2.7.2.post1 --no-build-isolation
-pip install -r requirements.txt
-pip install -e .
-python -m nltk.downloader punkt
-```
+## Local installation with uv
 
-* **Local installation with uv (preview)**: We are experimenting with using [uv](https://docs.astral.sh/uv/). You can install via
+We use [uv](https://docs.astral.sh/uv/) for installation and for running code. Install uv, then:
+
 ```bash
 uv sync
-uv sync --extra compile # to install flash attention
 ```
 
+This creates a `.venv/` from `uv.lock` and installs the `dev` and `cuda12` dependency groups by
+default. The project requires Python 3.12; uv downloads and manages that interpreter for you, so
+you do not need it installed system-wide.
 
-* **Docker installation**: You can also use the Dockerfile to build a Docker image. You can build the image with the following command:
+To build against CUDA 13 instead of CUDA 12:
 
 ```bash
-docker build . -t open_instruct_dev
-# if you are interally at AI2, you can create an image like this:
+uv sync --no-default-groups --group dev --group cuda13
+```
+
+The `cuda12` and `cuda13` groups are mutually exclusive — they pin different builds of torch, vLLM,
+and flash-attention — so select exactly one.
+
+Run commands through uv rather than activating the venv:
+
+```bash
+uv run python open_instruct/finetune.py --help
+```
+
+### Git LFS
+
+Test fixtures under `open_instruct/test_data/` are stored in [Git LFS](https://git-lfs.com/).
+Install it and run `git lfs install` before cloning, otherwise those files are checked out as
+pointer text and the tests that read them fail. If you already cloned, run `git lfs pull`. See
+[CONTRIBUTING.md](https://github.com/allenai/open-instruct/blob/main/CONTRIBUTING.md#git-lfs).
+
+### Platform support
+
+The dependency set resolves for Linux (`x86_64` and `aarch64`) and macOS.
+
+Training requires a CUDA GPU on Linux. macOS is only useful for editing, linting, and running part
+of the test suite: `vllm`, `flash-attn`, `liger-kernel`, and `bitsandbytes` are all excluded on
+Darwin, so any module that imports them cannot be collected. `uv run pytest` will report collection
+errors for those files on macOS; that is expected, and CI runs the full suite on Linux.
+
+### About `requirements.txt`
+
+`requirements.txt` is generated from `uv.lock` by a pre-commit hook and exists for reference and
+for tooling that expects it. It is not the supported installation path — use `uv sync`. Do not edit
+it by hand; edit `pyproject.toml` and let the hook re-export it.
+
+## Docker installation
+
+You can also build a Docker image:
+
+```bash
+docker build . \
+    --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) \
+    --build-arg GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) \
+    -t open_instruct_dev
+```
+
+The image defaults to CUDA 12 (`nvidia/cuda:12.8.1-devel-ubuntu22.04`). Pass `CUDA_VERSION=13` to
+build the CUDA 13 variant (`nvidia/cuda:13.0.3-devel-ubuntu22.04`) instead:
+
+```bash
+docker build . --build-arg CUDA_VERSION=13 -t open_instruct_dev
+```
+
+`GIT_COMMIT` and `GIT_BRANCH` are optional; they are recorded as environment variables in the image
+so a running job can report which revision it was built from.
+
+If you are internally at Ai2, you can create a Beaker image like this:
+
+```bash
 beaker_user=$(beaker account whoami --format json | jq -r '.[0].name')
 beaker image delete $beaker_user/open_instruct_dev
 beaker image create open_instruct_dev -n open_instruct_dev -w ai2/$beaker_user
 ```
 
-Optionally you can build the base image with the following command:
-
-```bash
-docker build --build-arg CUDA=12.1.0 --build-arg TARGET=cudnn8-devel --build-arg DIST=ubuntu20.04 -f  Dockerfile.base . -t cuda-no-conda:12.1-cudnn8-dev-ubuntu20.04
-```
-
-* **Docker with uv**: You can also use the Dockerfile to build a Docker image with uv. You can build the image with the following command:
-
-```bash
-docker build -f Dockerfile.uv --build-arg UV_CACHE_DIR=$UV_CACHE_DIR -t open_instruct_dev_uv .
-# if you are interally at AI2, you can create an image like this:
-beaker_user=$(beaker account whoami --format json | jq -r '.[0].name')
-beaker image delete $beaker_user/open_instruct_dev_uv
-beaker image create open_instruct_dev_uv -n open_instruct_dev_uv -w ai2/$beaker_user
-```
-
-If you are internally at AI2, you may launch experiments using our always-up-to-date auto-built image `nathanl/open_instruct_auto`.
+In practice most Ai2 experiments are launched with
+`./scripts/train/build_image_and_launch.sh <script>`, which builds and uploads the image for you.
+See [Ai2 internal setup](ai2_internal_setup.md).


### PR DESCRIPTION
## Problem

`docs/get_started/installation.md` is the "Get Started" page of the published docs site. Its content has not been updated since #628, and it now contradicts the repo on nearly every instruction. Following it does not produce a working environment.

| The page says | The repo says |
|---|---|
| "uses Python 3.10" | `requires-python = "==3.12.*"` |
| `torch==2.5.1 torchvision==0.20.1` on `cu121` | `torch>=2.10.0`, indexes `pytorch-cu128` / `pytorch-cu130` |
| `flash-attn==2.7.2.post1` | `flash-attn>=2.8.3` |
| `"setuptools<70.0.0"` | `setuptools>=75.6.0,<80.0.0` |
| `uv sync --extra compile` | there is no `compile` extra — only `code` and `dr-tulu` |
| `docker build -f Dockerfile.uv ...` | no such file |
| `docker build -f Dockerfile.base ...` | no such file |
| `--build-arg CUDA=12.1.0 --build-arg TARGET=... --build-arg DIST=...` | the Dockerfile takes `CUDA_VERSION` (12 or 13), `GIT_COMMIT`, `GIT_BRANCH` |

The page also links `[Dockerfile](./Dockerfile)`, which resolves relative to `docs/get_started/`. `uv run mkdocs build` on main emits:

```
INFO - Doc file 'get_started/installation.md' contains an unrecognized relative link './Dockerfile', it was left as is.
```

That warning is gone after this change.

The root `README.md` Setup section is already correct — only this docs-site page drifted.

## What this changes

Rewrites the page around `uv sync`, matching the README and the actual `Dockerfile`:

- `uv sync`, with the Python 3.12 requirement stated and the note that uv manages the interpreter (`python-preference = "only-managed"`).
- The CUDA 13 variant, using the same group selection the Dockerfile uses: `--no-default-groups --group dev --group cuda13`, and a note that `cuda12`/`cuda13` are declared as conflicting groups.
- Corrected Docker section: real build args, both CUDA base images, and a pointer to `build_image_and_launch.sh` for Ai2 users.

It also adds the two things that actually block a fresh clone and were documented nowhere on this page:

- **Git LFS.** Without it, `open_instruct/test_data/*.jsonl` check out as pointer text and the tests reading them fail. This is covered in CONTRIBUTING.md but not on the installation page.
- **The macOS caveat.** `vllm`, `flash-attn`, `liger-kernel` and `bitsandbytes` are all `platform_system != 'Darwin'`, so several test modules cannot be collected on macOS. This currently reads as a broken install rather than an intended exclusion.

Finally, notes that `requirements.txt` is generated from `uv.lock` by a pre-commit hook rather than being an install path.

## Testing

Every claim above was checked against `pyproject.toml` and `Dockerfile` at 8759c91 rather than assumed.

- `uv run mkdocs build` — succeeds, and the `installation.md` relative-link warning present on main is gone.
- `uv sync` on macOS (arm64) — the documented command works; produced Python 3.12.13, torch 2.10.0, transformers 5.4.0.
- `git lfs pull` — confirmed it is required; without it `open_instruct/test_data/sft_sample.jsonl` is a pointer file.
- `uv run pytest` on macOS — confirmed the six modules that fail collection all do so on `import vllm`, matching the documented caveat.

Docs-only change: no `open_instruct/` files touched, so the CHANGELOG check does not apply, and no GPU code paths are affected.

GPU_TESTS=bypass