### PR TITLE
Fix four broken references in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Try some of the models we train with Open Instruct. There is a [free demo](https
 - [2023-09-25] Supported using [vLLM](https://github.com/vllm-project/vllm/) for our evaluations, which speeds up the evaluation by 10x.
 - [2023-09-17] Supported [LoRA](https://arxiv.org/abs/2106.09685) and [QLoRA](https://arxiv.org/abs/2305.14314) finetuning. See [here](#parameter-efficient-finetuning) for more details.
 - [2023-08-18] Added support for [ToxiGen](https://github.com/microsoft/TOXIGEN)/[TruthfulQA](https://github.com/sylinrl/TruthfulQA) evaluation. Check our `scripts/eval/` for examples of running them.
-- [2023-08-08] Supported several new instruction dataset, including [LIMA](https://huggingface.co/datasets/GAIR/lima) / [WizardLM](https://github.com/nlpxucan/WizardLM) / [Open-Orca](https://huggingface.co/datasets/Open-Orca/OpenOrca). See the [preparation script](./scripts/data/prepare_train_data.sh) for details. Performance hasn't been evaluated yet.
+- [2023-08-08] Supported several new instruction dataset, including [LIMA](https://huggingface.co/datasets/GAIR/lima) / [WizardLM](https://github.com/nlpxucan/WizardLM) / [Open-Orca](https://huggingface.co/datasets/Open-Orca/OpenOrca). See the [preparation script](./scripts/data/sft_v1_v2/prepare_tulu_v1_v2.sh) for details. Performance hasn't been evaluated yet.
 - [2023-08-06] Supported LLaMa 2 finetuning and FlashAttention-2 by bumping the version of transformers and many other dependencies.
 - [2023-06-29] Added [licensing info](#licensing) for our released models.
 - [2023-06-09] Released Tülu (a suite of LLaMa models fully-finetuned on a strong mix of datasets) and many other checkpoints on HuggingFace [[Links]](#released-checkpoints).

--- a/docs/algorithms/finetune.md
+++ b/docs/algorithms/finetune.md
@@ -198,8 +198,6 @@ bash scripts/train/olmo2/finetune_13b.sh
 
     Based on our internal evaluation, the SFT model is roughly on par with the original `allenai/OLMo-2-1124-7B` model, though there are some slight differences. Note that your results may vary slightly due to the random seeds used in the training.
 
-    ![finetune_plot](finetune/olmo2_13b_sft_eval.png)
-
 ???+ info
 
     We haven't quite figured out how to make our internal evaluation toolchains more open yet. Stay tuned!

--- a/docs/algorithms/trained_model_location.md
+++ b/docs/algorithms/trained_model_location.md
@@ -60,7 +60,7 @@ Let's use [https://wandb.ai/ai2-llm/open_instruct_public/runs/tyfe1095](https://
 gs://ai2-llm/post-training//costah/output/tulu3_8b_dpo__1__1742613782
 ```
 
-![](trained_model_location/gcs.png)
+![](trained_model_location/gsc.png)
 
 To download, you can run the following command:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Try some of the models we train with Open Instruct. There is a [free demo](https
 - [2023-09-25] Supported using [vLLM](https://github.com/vllm-project/vllm/) for our evaluations, which speeds up the evaluation by 10x.
 - [2023-09-17] Supported [LoRA](https://arxiv.org/abs/2106.09685) and [QLoRA](https://arxiv.org/abs/2305.14314) finetuning. See [here](#parameter-efficient-finetuning) for more details.
 - [2023-08-18] Added support for [ToxiGen](https://github.com/microsoft/TOXIGEN)/[TruthfulQA](https://github.com/sylinrl/TruthfulQA) evaluation. Check our `scripts/eval/` for examples of running them.
-- [2023-08-08] Supported several new instruction dataset, including [LIMA](https://huggingface.co/datasets/GAIR/lima) / [WizardLM](https://github.com/nlpxucan/WizardLM) / [Open-Orca](https://huggingface.co/datasets/Open-Orca/OpenOrca). See the [preparation script](./scripts/data/prepare_train_data.sh) for details. Performance hasn't been evaluated yet.
+- [2023-08-08] Supported several new instruction dataset, including [LIMA](https://huggingface.co/datasets/GAIR/lima) / [WizardLM](https://github.com/nlpxucan/WizardLM) / [Open-Orca](https://huggingface.co/datasets/Open-Orca/OpenOrca). See the [preparation script](https://github.com/allenai/open-instruct/blob/main/scripts/data/sft_v1_v2/prepare_tulu_v1_v2.sh) for details. Performance hasn't been evaluated yet.
 - [2023-08-06] Supported LLaMa 2 finetuning and FlashAttention-2 by bumping the version of transformers and many other dependencies.
 - [2023-06-29] Added [licensing info](#licensing) for our released models.
 - [2023-06-09] Released Tülu (a suite of LLaMa models fully-finetuned on a strong mix of datasets) and many other checkpoints on HuggingFace [[Links]](#released-checkpoints).

--- a/docs/tulu1_tulu2.md
+++ b/docs/tulu1_tulu2.md
@@ -63,7 +63,7 @@ Evaluation scripts for different datasets are put under `./scripts`. For example
 
 ### Human evaluation
 
-We release our human evaluation interface and collected annotations in the `./human_eval` folder. Please see the corresponding [README](./human_eval/README.md) for more details.
+We release our human evaluation interface and collected annotations in the `./human_eval` folder. Please see the corresponding [README](https://github.com/allenai/open-instruct/blob/main/human_eval/README.md) for more details.
 
 
 ## Training


### PR DESCRIPTION
## Problem

`uv run mkdocs build` on `main` emits a warning for each of these. All four render as a dead link or a missing image on the published docs site:

```
WARNING - Doc file 'index.md' contains a link './scripts/data/prepare_train_data.sh', but the target is not found among documentation files.
WARNING - Doc file 'tulu1_tulu2.md' contains a link './human_eval/README.md', but the target is not found among documentation files.
WARNING - Doc file 'algorithms/finetune.md' contains a link 'finetune/olmo2_13b_sft_eval.png', but the target is not found among documentation files.
WARNING - Doc file 'algorithms/trained_model_location.md' contains a link 'trained_model_location/gcs.png', but the target is not found among documentation files.
```

## Each one, and how it was diagnosed

**1. `scripts/data/prepare_train_data.sh`** (`docs/index.md`, and the identical line in `README.md`)

Git records this as a **rename, not a deletion**:

```
$ git show --name-status f43d69adb -- scripts/data
R096    scripts/data/prepare_train_data.sh -> scripts/data/sft_v1_v2/prepare_tulu_v1_v2.sh
```

96% similarity, in #387. Repointed at the current path, which still exists. `README.md` carried the same dead link, so it is fixed too and the two stay consistent.

**2. `human_eval/README.md`** (`docs/tulu1_tulu2.md`)

The file exists — it is just at the repo root, outside the `docs/` tree, so mkdocs cannot resolve a relative link to it. Switched to an absolute GitHub URL.

**3. `trained_model_location/gcs.png`**

The file on disk is **`gsc.png`** — the letters are transposed. The surrounding section is titled "Google Cloud Storage", so `gcs` is the correct spelling and the *asset* carries the typo. I fixed the reference, since that is a one-line change and leaves the tracked binary alone. If you would rather rename the asset to `gcs.png` and leave the markdown as authored, that works equally well — happy to switch.

**4. `finetune/olmo2_13b_sft_eval.png`**

This image was **never committed**:

```
$ git log --all --oneline -- 'docs/algorithms/finetune/olmo2_13b_sft_eval.png'
(no output)
```

The directory has `olmo2_7b_sft_eval.png`, `olmo2_32b_sft_eval.png` and `tulu3_8b_eval.png`, so the 13B section is the odd one out. I removed the dead image reference and left the surrounding prose intact. If the image exists somewhere internally, adding it back is the better fix and I will happily drop this hunk.

## Testing

- `uv run mkdocs build` — all four warnings gone. The only remaining warning is the unrelated `mkdocs-material` emoji-plugin deprecation.
- Confirmed each new target resolves on disk: `scripts/data/sft_v1_v2/prepare_tulu_v1_v2.sh`, `human_eval/README.md`, `docs/algorithms/trained_model_location/gsc.png`.

Docs only — no files under `open_instruct/` are touched, so the CHANGELOG check does not apply and no GPU code paths are affected.

Note: the build still logs an INFO for `installation.md`'s `./Dockerfile` link. That one is fixed separately in #1828; this branch is cut from `main` so it still appears here.

GPU_TESTS=bypass