### PR TITLE
Drop OLMoE-1B-7B from OLMo-core SFT support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project will be documented in this file.
 ### Deprecated
 
 ### Removed
+- Remove legacy OLMoE-1B-7B from the OLMo-core SFT support list (https://github.com/allenai/open-instruct/pull/1846).
 
 ### Fixed
 - SFT's default checkpoint intervals collided: `olmo_core_finetune.py` forced `ephemeral_save_interval=500` through `parser.set_defaults` while `checkpointing_steps` also defaults to 500, and olmo-core requires the former to be strictly smaller, so any run that did not override one of them was rejected at startup. The forced default is now 250, and a non-positive `--ephemeral_save_interval` disables ephemeral checkpoints entirely, matching the existing `-1` convention for `max_checkpoints` (https://github.com/allenai/open-instruct/pull/1810).

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can run the following command for getting started:
 bash scripts/train/tulu3/finetune_8b.sh
 ```
 
-**OLMo-core SFT**: For supported models (OLMo, OLMoE, Qwen3), we recommend the more GPU-efficient [OLMo-core SFT implementation](https://github.com/allenai/OLMo-core/tree/main/src/scripts/train/sft). See `open_instruct/olmo_core_utils.py` for the list of supported models.
+**OLMo-core SFT**: For supported models (OLMo 2, Olmo 3, Olmo Hybrid, Qwen3), we recommend the more GPU-efficient [OLMo-core SFT implementation](https://github.com/allenai/OLMo-core/tree/main/src/scripts/train/sft). See `open_instruct/olmo_core_utils.py` for the list of supported models.
 
 
 ### Preference Tuning

--- a/open_instruct/olmo_core_utils.py
+++ b/open_instruct/olmo_core_utils.py
@@ -373,7 +373,6 @@ OLMO_MODEL_CONFIG_MAP: dict[str, str] = {
     "allenai/Olmo-Hybrid-7B": "olmo3_hybrid_7B",
     "allenai/Olmo-Hybrid-Instruct-SFT-7B": "olmo3_hybrid_7B",
     "allenai/Olmo-Hybrid-Think-SFT-7B": "olmo3_hybrid_7B",
-    "allenai/OLMoE-1B-7B-0924": "olmoe_1B_7B",
     "Qwen/Qwen3-0.6B": "qwen3_0_6B",
     "Qwen/Qwen3-0.6B-Base": "qwen3_0_6B",
     "Qwen/Qwen3-1.7B": "qwen3_1_7B",

--- a/open_instruct/test_olmo_core_finetune.py
+++ b/open_instruct/test_olmo_core_finetune.py
@@ -79,6 +79,15 @@ class IsHfCheckpointTest(unittest.TestCase):
         self.assertTrue(olmo_core_utils.is_hf_checkpoint("/weka/checkpoints/some-model-hf/step1"))
 
 
+class SupportedOlmoCoreModelsTest(unittest.TestCase):
+    def test_legacy_olmoe_hf_model_id_is_not_supported(self) -> None:
+        model_id = "allenai/OLMoE-1B-7B-0924"
+
+        self.assertNotIn(model_id, olmo_core_utils.OLMO_MODEL_CONFIG_MAP)
+        with self.assertRaisesRegex(ValueError, f"Model/config '{model_id}' not found"):
+            olmo_core_utils.get_transformer_config(model_id, vocab_size=50304, attn_backend="torch")
+
+
 class TestCheckpointerDefaults(unittest.TestCase):
     def test_default_intervals_build_a_checkpointer(self) -> None:
         """The two defaults must not collide: olmo-core requires ephemeral < save_interval."""


### PR DESCRIPTION
### Summary

- Remove the legacy `allenai/OLMoE-1B-7B-0924` model ID from the OLMo-core SFT support map.
- Update the README so its supported-model summary matches the remaining map.
- Add a CPU regression test that rejects the retired public model ID.

This addresses the independently scoped OLMo-core SFT portion of #1837. It intentionally does not claim to remove all legacy OLMoE support.

Refs #1837

### Why

Issue #1837 explicitly identifies the public OLMoE model ID and the README support claim as an independently removable OLMo-core SFT surface. Removing both keeps the documented support list and the default HF model-ID lookup aligned with that requested deprecation, while leaving the broader cross-repository and legacy-trainer decisions separate.

Related merged PR #1820 reviewed and fixed checkpoint weight naming, but its final diff does not remove this mapping, edit the README, or add a negative model-ID test. Its pull-request body explicitly leaves OLMoE removal to #1837. This PR therefore does not duplicate #1820.

### Scope

This small change preserves:

- the direct OLMo-core `olmoe_1B_7B` config-name path;
- legacy HF trainer and reward-model OLMoE support;
- Olmo Hybrid, OLMoE2, Qwen MoE, and generic MoE conversion code;
- shared checkpoint-export helpers.

Those surfaces need separate cross-repository decisions and should not be bundled into this patch.

### Duplicate-work audit

- #1837 remains open and unassigned. No PR implements its model-ID/README removal; related merged PR #1820 owns the checkpoint-naming background described below.
- The complete issue timeline contains cross-references to merged PR #1820 and companion issue allenai/OLMo-core#838.
- Open, closed, and merged PR searches by issue number, OLMoE model ID, config symbol, map symbol, and affected files found no removal implementation.
- Latest upstream main `e6c3044` still contains the model-ID mapping and README claim.
- Two independent source-level reviews confirmed that both changes touch `olmo_core_utils.py`, but different hunks and behavior: #1820 changes checkpoint save naming/verification, while `d1715b1` removes the model-map entry, updates the README, and adds a negative lookup test.

### Validation

- `uv run --frozen pytest open_instruct/test_olmo_core_finetune.py -q` — 15 passed, including the new regression test.
- `uv run --frozen pytest open_instruct/test_olmo_core_hybrid.py -q -k 'not conversion_covers_every_model_parameter'` — 7 passed; the deselected existing test requires Triton on macOS.
- `uv run --frozen pytest tests -q` — 54 passed.
- `make style` — 121 files unchanged.
- `make quality` — Ruff, compileall, and ty passed.
- `git diff --check` — passed.

Full test collection is not portable to this macOS environment because several existing collection paths import Linux-only vLLM, and one existing Hybrid construction test requires Triton. Fork GPU CI is expected to be handled by the repository's normal maintainer/merge-queue workflow.