### PR TITLE
Add LiteRegistry Podman gateway sandbox backend for Terminal RL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
         | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
     && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
         | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
-    && apt-get update -y && apt-get install -y --no-install-recommends google-cloud-sdk \
+    && apt-get update -y && apt-get install -y --no-install-recommends google-cloud-cli \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 # Taken from https://beaker.org/api/v3/release (add | jq -r '.version' if you want it programmatically).

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,17 @@ RUN --mount=type=cache,target=${UV_CACHE_DIR} \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     uv run --frozen python -m nltk.downloader punkt punkt_tab words
 
+# LiteRegistry gateway for the Terminal-RL sandbox fleet, co-located with the training job
+# (started on the Ray head by scripts/general_agent/terminal/rl/gateway/start_colocated_gateway.sh,
+# which resolves the fleet's Redis through the head registry on weka). It lives in its own venv:
+# literegistry pins starlette==1.3.1 and pulls streamlit/pandas, which the training env cannot take.
+ARG LITEREGISTRY_VERSION=1.0.49
+ENV LITEREGISTRY_GATEWAY_VENV=/opt/literegistry-gateway-venv
+RUN --mount=type=cache,target=${UV_CACHE_DIR} \
+    uv venv --python 3.12 "${LITEREGISTRY_GATEWAY_VENV}" && \
+    uv pip install --python "${LITEREGISTRY_GATEWAY_VENV}/bin/python" "literegistry==${LITEREGISTRY_VERSION}" && \
+    "${LITEREGISTRY_GATEWAY_VENV}/bin/python" -c "import literegistry.gateway, literegistry.head_registry; print('literegistry gateway venv OK')"
+
 # Separate COPY commands required: Docker copies directory *contents*, not the directory itself
 COPY configs configs
 COPY scripts scripts

--- a/docs/algorithms/gateway_sandbox_backend.md
+++ b/docs/algorithms/gateway_sandbox_backend.md
@@ -1,0 +1,106 @@
+# Gateway sandbox backend (LiteRegistry Podman)
+
+The `gateway` sandbox backend runs terminal-RL sandbox containers on an
+**external fleet of Podman servers** behind a
+[LiteRegistry](https://github.com/goncalorafaria/literegistry) gateway, instead
+of podman `system service` daemons colocated inside the training job.
+
+```text
+training job (Ray env actors)                LiteRegistry deployment (separate Beaker experiment)
+┌───────────────────────────────┐            ┌─────────────────────────────────────────────┐
+│ EnvironmentPool               │   HTTP     │ gateway ──► podman replica 1..N (containers)│
+│  └─ SWERLVanilluxSandboxEnv   ├───────────►│    │   ──► docker-mirror replica 1..M       │
+│      └─ GatewayBackend        │            │    └──► Redis (service registry + affinity) │
+└───────────────────────────────┘            └─────────────────────────────────────────────┘
+```
+
+Why: with colocated podman, a podman daemon crash or a full `/tmp` takes down
+rollouts on that training node and there is no way to repair it without
+restarting the job. With the gateway, the sandbox fleet is deployed, scaled,
+and repaired independently of training: replicas heartbeat into Redis, the
+gateway load-balances new sessions across live replicas, and a dead replica
+just stops receiving handshakes.
+
+## Using it
+
+Set `"backend": "gateway"` and `"gateway_url"` in `--tool_configs`:
+
+```bash
+--tools swerl_vanillux_sandbox \
+--tool_configs '{"backend": "gateway", "gateway_url": "http://GATEWAY_HOST:PORT", "task_data_hf_repo": "allenai/tmax-15k-open-instruct", "test_timeout": 120, "image": "python:3.12-slim"}'
+```
+
+(`$SWERL_GATEWAY_URL` is the env-var fallback when `gateway_url` is unset.)
+
+Everything podman-related disappears from the launch script: no
+`scripts/docker/docker_login.sh`, no `SWERL_PODMAN_SERVICE_COUNT` /
+`SWERL_DOCKER_*` / `MIRROR_URL` / `PODMAN_NUM_LOCKS` env vars, no `DOCKER_PAT`
+secret, no `BEAKER_ALLOW_SUBCONTAINERS`. Task images are pulled by the podman
+replicas through the deployment's own docker.io pull-through mirrors.
+
+Reference scripts: `scripts/general_agent/terminal/rl/gateway/`.
+
+## Session lifecycle
+
+- `reset()` → `POST /affinity/handshake {service, image}`: the gateway picks a
+  replica, the replica `podman run`s a container from the task image, and the
+  returned `affinity_id` (= container ID) is bound to that replica in Redis.
+- every `bash` step → `POST /affinity/podman {affinity_id, command, stdin,
+  timeout, workdir}`: the gateway routes to the bound replica, which
+  `podman exec`s in the container. Each request refreshes the binding TTL.
+- episode end → `POST /affinity/close {affinity_id}`: removes the container
+  and releases the binding.
+
+## How `GatewayBackend` works around the per-exec contract
+
+The replicas enforce hard per-exec limits (60s timeout cap, 1MB stdin, and
+they *abort* rather than truncate >1MB stdout / >256KB stderr, after which the
+gateway retries the exec — re-running the command). `run_command()` therefore
+never executes agent commands as a bare exec:
+
+1. **launch** — one exec ships the command via stdin into
+   `/tmp/.swerl_gateway/<token>/cmd.sh` and starts it detached under
+   `timeout`, with stdout/stderr redirected to files and the exit code written
+   to an `rc` file. A bare `mkdir <token>` acts as a lock so a gateway-level
+   retry cannot double-launch the command.
+2. **wait+read** — repeated execs block in-container (up to 45s each) until
+   the `rc` file exists, then emit the exit code plus `head -c`-bounded
+   stdout/stderr in the same response. Fast commands complete in one round
+   trip; a 600s verifier costs one cheap request per ~45s.
+
+File I/O (`write_file`, `read_file`, `put_archive` for task seeds/tests) moves
+as base64 chunks sized under the stdin/stdout caps; every chunk write is
+idempotent so gateway retries are safe.
+
+A keepalive thread (default every 300s, `SWERL_GATEWAY_KEEPALIVE_S`, `0`
+disables) runs a no-op exec while the container idles between agent turns, so
+the affinity binding (15-minute TTL by default) cannot expire during a long
+generation pause. If a binding is lost anyway (404), the backend re-handshakes
+and retries the command once — the same restart-and-retry semantics
+`DockerBackend` uses when a local container disappears.
+
+## Failure modes vs colocated podman
+
+| failure | colocated podman | gateway |
+|---|---|---|
+| podman daemon crash / wedge | rollouts on the node fail until job restart | replica drops out of Redis; new handshakes go elsewhere; in-flight episodes on it fail their reset retries and are retried |
+| node `/tmp` or storage full | DataPreparationActor hangs (see `reference_tmax_disk_full_sandbox_hang`) | contained to one replica; fix/restart it independently |
+| replica preempted/restarted | n/a | its containers are cleaned up on restart; episodes re-handshake |
+| training job killed | containers die with the node | containers leak on replicas until the binding TTL expires and the replica restarts (see gaps below) |
+
+## Known gaps (in the LiteRegistry deployment, as of 2026-08-31)
+
+- **No per-container memory / pids limits**: colocated podman ran containers
+  with `mem_limit=4g`; replica containers are currently unbounded, so one
+  runaway rollout can pressure a whole replica node. Needs `--memory` support
+  in the replica's `podman run`.
+- **Oversized output wedges a session**: a bare exec producing >1MB stdout
+  makes the replica return 413 and the gateway retry (re-running the command)
+  up to 20 times, serializing behind the per-container lock. `GatewayBackend`
+  never triggers this (all output is file-redirected), but any other client
+  sharing the deployment can.
+- **No idle-container janitor on replicas**: containers whose client vanished
+  without `close()` persist until the replica restarts.
+- **Handshake pull races the gateway timeout**: a cold image pull slower than
+  the gateway's per-request timeout makes the gateway retry the handshake on
+  another replica, orphaning the first container.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
     - algorithms/grpo_fast_internals.md
     - algorithms/rl_with_environments.md
     - algorithms/rollout_loop_internals.md
+    - algorithms/gateway_sandbox_backend.md
     - algorithms/monitoring_and_debugging_runs.md
     - algorithms/terminal_rl_trajectory_analysis.md
     - algorithms/dr_research_rl_trajectory_analysis.md

--- a/open_instruct/environments/backends.py
+++ b/open_instruct/environments/backends.py
@@ -828,6 +828,13 @@ class GatewayBackend(SandboxBackend):
     _REQUEST_ATTEMPTS = 4
     _RETRY_BASE_DELAY_S = 0.5
     _RETRY_MAX_DELAY_S = 8.0
+    # Strict affinity answers 503 with this text when the replica that owns the
+    # binding has dropped off the registry roster. A live replica reappears
+    # within one retry; a dead/rescheduled one stays off the roster until the
+    # binding TTL (~15 min) expires, so after this many such answers the
+    # session is treated as lost and re-handshaken instead of retried.
+    _OWNER_UNREGISTERED_MARKER = "no longer registered"
+    _OWNER_UNREGISTERED_ATTEMPTS = 2
     _TIMING_LOGS = _env_flag("SWERL_SANDBOX_TIMING_LOGS", False)
     _TIMING_LOG_THRESHOLD_S = _env_float("SWERL_SANDBOX_TIMING_LOG_THRESHOLD_S", 1.0)
 
@@ -899,12 +906,15 @@ class GatewayBackend(SandboxBackend):
         (replica connection dropped mid-request / temporarily unreachable /
         gateway rediscovering) — safe because every exec this backend issues is
         idempotent. 404 maps to :class:`GatewaySessionLostError` so callers can
-        re-handshake.
+        re-handshake, as does a repeated 503 saying the binding's owner is no
+        longer registered (the replica died; waiting out the TTL would only
+        fail every request until then).
         """
         url = f"{self._gateway_url}/{endpoint.lstrip('/')}"
         max_attempts = attempts or self._REQUEST_ATTEMPTS
         session = http_session or self._session
         last_error: Exception | None = None
+        owner_unregistered_answers = 0
         for attempt in range(1, max_attempts + 1):
             self._last_request_monotonic = time.monotonic()
             try:
@@ -916,6 +926,12 @@ class GatewayBackend(SandboxBackend):
                     raise GatewaySessionLostError(
                         f"Gateway affinity session lost ({endpoint}): {response.text[:500]}", status_code=404
                     )
+                if response.status_code == 503 and self._OWNER_UNREGISTERED_MARKER in response.text:
+                    owner_unregistered_answers += 1
+                    if owner_unregistered_answers >= self._OWNER_UNREGISTERED_ATTEMPTS:
+                        raise GatewaySessionLostError(
+                            f"Gateway affinity owner unregistered ({endpoint}): {response.text[:500]}", status_code=503
+                        )
                 if response.status_code in (500, 502, 503, 504, 408):
                     last_error = GatewayBackendError(
                         f"Gateway returned HTTP {response.status_code} for {endpoint}: {response.text[:500]}",

--- a/open_instruct/environments/backends.py
+++ b/open_instruct/environments/backends.py
@@ -1,22 +1,26 @@
 """Sandbox backend abstraction for code/command execution."""
 
 import atexit
+import base64
 import contextlib
 import errno
 import fcntl
 import io
 import os
+import posixpath
 import random
 import shlex
 import shutil
 import subprocess
 import tarfile
+import threading
 import time
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 import docker as docker_sdk
+import requests
 
 from open_instruct import logger_utils
 
@@ -770,18 +774,529 @@ class ApptainerBackend(SandboxBackend):
             )
 
 
+# ---------------------------------------------------------------------------
+# LiteRegistry Podman gateway
+# ---------------------------------------------------------------------------
+
+
+# Server-side contract (literegistry PodmanRequest / PodmanAffinityConfig).
+_SERVER_EXEC_TIMEOUT_CAP_S = 60.0
+_SERVER_STDIN_LIMIT_BYTES = 1024 * 1024
+# Base64 inflates by 4/3; keep a healthy margin below the stdin limit.
+_UPLOAD_CHUNK_BYTES = 512 * 1024
+# Stay well below the replica's 1MB stdout / 256KB stderr caps: exceeding them
+# does not truncate, it aborts the exec (and the gateway then retries it).
+_MAX_STDOUT_BYTES = 512 * 1024
+_MAX_STDERR_BYTES = 128 * 1024
+_READ_CHUNK_BYTES = 384 * 1024
+
+# One wait-exec blocks inside the container until the command finishes or the
+# in-container wait budget expires, so completed commands return in one round
+# trip and long commands cost one cheap request per ~45s.
+_WAIT_EXEC_TIMEOUT_S = 55.0
+_IN_CONTAINER_WAIT_S = 45
+_DONE_MARKER = "__SWERL_GATEWAY_DONE__"
+_PENDING_MARKER = "__SWERL_GATEWAY_PENDING__"
+
+_WORK_DIR = "/tmp/.swerl_gateway"
+
+
+class GatewayBackendError(RuntimeError):
+    """A gateway request failed or returned an invalid response."""
+
+    def __init__(self, message: str, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class GatewaySessionLostError(GatewayBackendError):
+    """The affinity binding or container no longer exists on the gateway."""
+
+
+class GatewayBackend(SandboxBackend):
+    """Run sandbox commands in a remote Podman container via a LiteRegistry gateway."""
+
+    _HANDSHAKE_ATTEMPTS = 5
+    _HANDSHAKE_TIMEOUT_S = 240.0
+    _REQUEST_ATTEMPTS = 4
+    _RETRY_BASE_DELAY_S = 0.5
+    _RETRY_MAX_DELAY_S = 8.0
+    _TIMING_LOGS = _env_flag("SWERL_SANDBOX_TIMING_LOGS", False)
+    _TIMING_LOG_THRESHOLD_S = _env_float("SWERL_SANDBOX_TIMING_LOG_THRESHOLD_S", 1.0)
+
+    def __init__(
+        self,
+        image: str = "python:3.12-slim",
+        timeout: int = 1800,
+        mem_limit: str | None = None,
+        gateway_url: str = "",
+        service: str = "podman",
+        client_id: str | None = None,
+        keepalive_interval_s: float | None = None,
+    ):
+        """
+        Args:
+            image: OCI image for the session container (pulled by the replica,
+                normally through the gateway's own docker.io mirror).
+            timeout: Default per-command timeout in seconds.
+            mem_limit: Ignored. The LiteRegistry Podman replicas do not expose
+                per-container memory limits yet; kept for kwarg symmetry with
+                ``DockerBackend``.
+            gateway_url: Base URL of the LiteRegistry gateway, e.g.
+                ``http://host:8080``. Falls back to ``$SWERL_GATEWAY_URL``.
+            service: Affinity service name registered in the gateway.
+            client_id: Optional identifier sent with the handshake (shows up in
+                replica logs); defaults to a per-backend UUID.
+            keepalive_interval_s: Seconds between keepalive execs that refresh
+                the gateway's affinity TTL while the container sits idle
+                between agent turns (generation can outlast the binding TTL).
+                Defaults to ``$SWERL_GATEWAY_KEEPALIVE_S`` or 300; ``0``
+                disables the keepalive thread.
+        """
+        resolved_url = (gateway_url or os.getenv("SWERL_GATEWAY_URL", "")).rstrip("/")
+        if not resolved_url:
+            raise ValueError(
+                "GatewayBackend requires a gateway URL. Set env_config.gateway_url or $SWERL_GATEWAY_URL."
+            )
+        self._gateway_url = resolved_url
+        self._image = image
+        self._timeout = timeout
+        if mem_limit:
+            logger.debug("GatewayBackend ignores mem_limit=%s (not supported by the Podman replicas)", mem_limit)
+        self._service = service
+        self._client_id = client_id or f"open-instruct-{uuid.uuid4().hex[:12]}"
+        if keepalive_interval_s is None:
+            keepalive_interval_s = _env_float("SWERL_GATEWAY_KEEPALIVE_S", 300.0)
+        self._keepalive_interval_s = keepalive_interval_s
+        self._affinity_id: str | None = None
+        self._instance_id: str | None = None
+        self._session = requests.Session()
+        self._exec_lock = threading.Lock()
+        self._last_request_monotonic = time.monotonic()
+        self._keepalive_stop: threading.Event | None = None
+        self._keepalive_thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------ HTTP
+
+    def _post(
+        self,
+        endpoint: str,
+        payload: dict,
+        request_timeout: float,
+        attempts: int | None = None,
+        http_session: requests.Session | None = None,
+    ) -> dict:
+        """POST one JSON payload to the gateway with bounded retries.
+
+        Retries cover connection errors, request timeouts, and 500/502/503/504
+        (replica connection dropped mid-request / temporarily unreachable /
+        gateway rediscovering) — safe because every exec this backend issues is
+        idempotent. 404 maps to :class:`GatewaySessionLostError` so callers can
+        re-handshake.
+        """
+        url = f"{self._gateway_url}/{endpoint.lstrip('/')}"
+        max_attempts = attempts or self._REQUEST_ATTEMPTS
+        session = http_session or self._session
+        last_error: Exception | None = None
+        for attempt in range(1, max_attempts + 1):
+            self._last_request_monotonic = time.monotonic()
+            try:
+                response = session.post(url, json=payload, timeout=request_timeout)
+            except (requests.ConnectionError, requests.Timeout) as e:
+                last_error = GatewayBackendError(f"Gateway request to {endpoint} failed: {e}")
+            else:
+                if response.status_code == 404:
+                    raise GatewaySessionLostError(
+                        f"Gateway affinity session lost ({endpoint}): {response.text[:500]}", status_code=404
+                    )
+                if response.status_code in (500, 502, 503, 504, 408):
+                    last_error = GatewayBackendError(
+                        f"Gateway returned HTTP {response.status_code} for {endpoint}: {response.text[:500]}",
+                        status_code=response.status_code,
+                    )
+                elif response.status_code >= 400:
+                    raise GatewayBackendError(
+                        f"Gateway returned HTTP {response.status_code} for {endpoint}: {response.text[:500]}",
+                        status_code=response.status_code,
+                    )
+                else:
+                    try:
+                        result = response.json()
+                    except ValueError as e:
+                        raise GatewayBackendError(f"Gateway returned non-JSON for {endpoint}: {e}") from e
+                    if not isinstance(result, dict):
+                        raise GatewayBackendError(f"Gateway returned a non-object response for {endpoint}")
+                    return result
+            if attempt < max_attempts:
+                delay = min(self._RETRY_BASE_DELAY_S * (2 ** (attempt - 1)), self._RETRY_MAX_DELAY_S)
+                delay += random.uniform(0.0, 0.5)
+                logger.warning(
+                    "Gateway request %s attempt %s/%s failed (%s); retrying in %.2fs",
+                    endpoint,
+                    attempt,
+                    max_attempts,
+                    last_error,
+                    delay,
+                )
+                time.sleep(delay)
+        assert last_error is not None
+        raise last_error
+
+    def _exec(
+        self,
+        command: str,
+        stdin: str = "",
+        exec_timeout: float = 30.0,
+        workdir: str = "/",
+        http_session: requests.Session | None = None,
+    ) -> dict:
+        """Run one bounded exec in the session container via the gateway."""
+        if self._affinity_id is None:
+            raise GatewayBackendError("Container not started. Call start() first.")
+        exec_timeout = min(exec_timeout, _SERVER_EXEC_TIMEOUT_CAP_S - 1.0)
+        return self._post(
+            "affinity/podman",
+            {
+                "service": self._service,
+                "affinity_id": self._affinity_id,
+                "command": command,
+                "stdin": stdin,
+                "timeout": exec_timeout,
+                "workdir": workdir,
+            },
+            # The replica itself allows exec_timeout + 5s; leave headroom for
+            # gateway queueing before giving up on the HTTP request.
+            request_timeout=exec_timeout + 20.0,
+            http_session=http_session,
+        )
+
+    # ------------------------------------------------------------- lifecycle
+
+    def start(self) -> None:
+        previous = self._affinity_id
+        if previous is not None:
+            self.close()
+        start_time = time.perf_counter()
+        result = self._post(
+            "affinity/handshake",
+            {"service": self._service, "image": self._image, "client_id": self._client_id},
+            request_timeout=self._HANDSHAKE_TIMEOUT_S,
+            attempts=self._HANDSHAKE_ATTEMPTS,
+        )
+        affinity_id = result.get("affinity_id")
+        if not isinstance(affinity_id, str) or not affinity_id:
+            raise GatewayBackendError(f"Gateway handshake returned no affinity_id: {result}")
+        self._affinity_id = affinity_id
+        self._instance_id = result.get("instance_id")
+        elapsed_s = time.perf_counter() - start_time
+        if self._TIMING_LOGS and elapsed_s >= self._TIMING_LOG_THRESHOLD_S:
+            logger.info(
+                "GatewayBackend.start timing image=%s container=%s instance=%s total=%.3fs",
+                self._image,
+                affinity_id[:12],
+                self._instance_id,
+                elapsed_s,
+            )
+        logger.info(
+            "Gateway container started: %s (image=%s, instance=%s, previous=%s)",
+            affinity_id[:12],
+            self._image,
+            self._instance_id,
+            previous[:12] if previous else None,
+        )
+        self._start_keepalive()
+
+    def close(self) -> None:
+        self._stop_keepalive()
+        if self._affinity_id is None:
+            return
+        affinity_id = self._affinity_id
+        self._affinity_id = None
+        self._instance_id = None
+        try:
+            self._post(
+                "affinity/close",
+                {"service": self._service, "affinity_id": affinity_id},
+                request_timeout=60.0,
+                attempts=2,
+            )
+            logger.info("Closed gateway container: %s", affinity_id[:12])
+        except GatewaySessionLostError:
+            logger.info("Gateway container already gone at close: %s", affinity_id[:12])
+        except GatewayBackendError as e:
+            # The replica reaps leftover containers on restart; do not fail
+            # the episode over a close error.
+            logger.warning("Failed to close gateway container %s: %s", affinity_id[:12], e)
+
+    # -------------------------------------------------------------- commands
+
+    def run_command(self, command: str, timeout: int | None = None) -> ExecutionResult:
+        if self._affinity_id is None:
+            raise GatewayBackendError("Container not started. Call start() first.")
+        effective_timeout = self._timeout if timeout is None else timeout
+        with self._exec_lock:
+            start_time = time.perf_counter()
+            try:
+                result = self._run_command_once(command, effective_timeout)
+            except GatewaySessionLostError as e:
+                # Mirrors DockerBackend's restart-and-retry-once semantics when
+                # the container disappears mid-episode.
+                logger.warning(
+                    "Gateway container disappeared before exec (%s). Restarting and retrying command once.", e
+                )
+                self._affinity_id = None
+                self.start()
+                result = self._run_command_once(command, effective_timeout)
+            elapsed_s = time.perf_counter() - start_time
+            if self._TIMING_LOGS and elapsed_s >= self._TIMING_LOG_THRESHOLD_S:
+                logger.info(
+                    "GatewayBackend.exec timing image=%s container=%s total=%.3fs",
+                    self._image,
+                    (self._affinity_id or "?")[:12],
+                    elapsed_s,
+                )
+            return result
+
+    def _run_command_once(self, command: str, effective_timeout: float) -> ExecutionResult:
+        token = uuid.uuid4().hex[:16]
+        job_dir = f"{_WORK_DIR}/{token}"
+        quoted_dir = shlex.quote(job_dir)
+        # Launch the command detached. The bare `mkdir` acts as a lock: if the
+        # gateway retries this exec after the first attempt actually ran, the
+        # second attempt exits without launching a duplicate.
+        # `{ ... & }` groups the background operator with just the setsid
+        # command; otherwise `&` would background the whole `&&` chain and
+        # `cat` would read /dev/null instead of the request stdin. If the job
+        # dir already exists, a previous attempt of this same request already
+        # launched the command (the gateway retried a request whose response
+        # was lost), so skip straight to waiting instead of double-launching.
+        detached = shlex.quote(
+            f"timeout --signal=TERM --kill-after=10 {shlex.quote(str(effective_timeout))} "
+            f"bash {job_dir}/cmd.sh > {job_dir}/out 2> {job_dir}/err < /dev/null; "
+            f"echo $? > {job_dir}/rc.tmp && mv {job_dir}/rc.tmp {job_dir}/rc"
+        )
+        launcher = (
+            f"mkdir -p {shlex.quote(_WORK_DIR)} && "
+            f"if mkdir {quoted_dir} 2> /dev/null; then "
+            f"cat > {quoted_dir}/cmd.sh && "
+            "{ setsid nohup bash -c " + detached + " > /dev/null 2>&1 < /dev/null & } && echo LAUNCHED; "
+            "else echo LAUNCHED; fi"
+        )
+        launch = self._exec(launcher, stdin=command, exec_timeout=30.0)
+        if "LAUNCHED" not in launch.get("stdout", ""):
+            raise GatewayBackendError(
+                f"Gateway command launcher failed (exit={launch.get('exit_code')}): {launch.get('stderr', '')[:500]}"
+            )
+
+        # Wait for the rc file, then emit bounded output in the same exec.
+        waiter = (
+            f"if timeout {_IN_CONTAINER_WAIT_S} bash -c 'until [ -f {job_dir}/rc ]; do sleep 0.1; done'; then "
+            f'echo {_DONE_MARKER}; echo "RC=$(cat {quoted_dir}/rc)"; '
+            f"head -c {_MAX_STDOUT_BYTES} {quoted_dir}/out; "
+            f"head -c {_MAX_STDERR_BYTES} {quoted_dir}/err >&2; "
+            f"else echo {_PENDING_MARKER}; fi"
+        )
+        # Budget: command timeout, plus TERM->KILL grace, plus slack for the
+        # detached launcher and filesystem latency.
+        deadline = time.monotonic() + effective_timeout + 60.0
+        while True:
+            response = self._exec(waiter, exec_timeout=_WAIT_EXEC_TIMEOUT_S, workdir="/")
+            stdout = response.get("stdout", "")
+            if _DONE_MARKER in stdout:
+                break
+            if _PENDING_MARKER not in stdout:
+                raise GatewayBackendError(
+                    f"Gateway wait exec returned no marker (exit={response.get('exit_code')}): "
+                    f"stdout={stdout[:200]!r} stderr={response.get('stderr', '')[:200]!r}"
+                )
+            if time.monotonic() > deadline:
+                self._exec(f"rm -rf {quoted_dir}", exec_timeout=15.0)
+                raise GatewayBackendError(
+                    f"Gateway command did not finish within {effective_timeout}s plus grace; giving up."
+                )
+
+        payload = stdout.split(_DONE_MARKER, 1)[1].lstrip("\n")
+        rc_line, _, out = payload.partition("\n")
+        try:
+            exit_code = int(rc_line.removeprefix("RC=").strip())
+        except ValueError:
+            raise GatewayBackendError(f"Gateway wait exec returned an invalid rc line: {rc_line!r}") from None
+        stderr = response.get("stderr", "")
+        self._exec(f"rm -rf {quoted_dir}", exec_timeout=15.0)
+        if exit_code == 124:
+            stderr = f"Command timed out after {effective_timeout}s.\n" + stderr
+        return ExecutionResult(stdout=out, stderr=stderr, exit_code=exit_code)
+
+    # ------------------------------------------------------------- keepalive
+
+    def _start_keepalive(self) -> None:
+        if self._keepalive_interval_s <= 0 or self._keepalive_thread is not None:
+            return
+        self._keepalive_stop = threading.Event()
+        self._keepalive_thread = threading.Thread(
+            target=self._keepalive_loop, name="gateway-backend-keepalive", daemon=True
+        )
+        self._keepalive_thread.start()
+
+    def _stop_keepalive(self) -> None:
+        if self._keepalive_stop is not None:
+            self._keepalive_stop.set()
+        self._keepalive_thread = None
+        self._keepalive_stop = None
+
+    def _keepalive_loop(self) -> None:
+        """Refresh the affinity TTL while the container idles between turns.
+
+        The binding TTL (15 minutes by default) only refreshes on traffic; a
+        long generation pause between agent turns would otherwise let it
+        expire mid-episode. Uses its own HTTP session (requests.Session is not
+        thread-safe) and skips ticks when a command exec is in flight.
+        """
+        stop = self._keepalive_stop
+        session = requests.Session()
+        assert stop is not None
+        while not stop.wait(self._keepalive_interval_s):
+            affinity_id = self._affinity_id
+            if affinity_id is None:
+                continue
+            if time.monotonic() - self._last_request_monotonic < self._keepalive_interval_s / 2:
+                continue
+            if not self._exec_lock.acquire(blocking=False):
+                continue  # A real command is in flight; it refreshes the TTL.
+            try:
+                self._exec("true", exec_timeout=15.0, http_session=session)
+            except Exception as e:
+                logger.warning("Gateway keepalive failed for %s: %s", affinity_id[:12], e)
+            finally:
+                self._exec_lock.release()
+        session.close()
+
+    # --------------------------------------------------------------- file IO
+
+    def write_file(self, path: str, content: str | bytes) -> None:
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        quoted = shlex.quote(path)
+        parent = shlex.quote(posixpath.dirname(path) or "/")
+        with self._exec_lock:
+            if len(content) <= _UPLOAD_CHUNK_BYTES:
+                result = self._exec(
+                    f"mkdir -p {parent} && base64 -d > {quoted}",
+                    stdin=base64.b64encode(content).decode(),
+                    exec_timeout=30.0,
+                )
+                if result.get("exit_code") != 0:
+                    raise GatewayBackendError(f"write_file failed for {path!r}: {result.get('stderr', '')[:500]}")
+                return
+            self._upload_chunked(content, target_command=f"cat > {quoted}", parent_dir=parent, label=path)
+
+    def put_archive(self, root: str, tar_bytes: bytes) -> None:
+        quoted_root = shlex.quote(root)
+        with self._exec_lock:
+            start_time = time.perf_counter()
+            if len(tar_bytes) <= _UPLOAD_CHUNK_BYTES:
+                result = self._exec(
+                    f"mkdir -p {quoted_root} && base64 -d | tar -xf - -C {quoted_root}",
+                    stdin=base64.b64encode(tar_bytes).decode(),
+                    exec_timeout=45.0,
+                )
+                if result.get("exit_code") != 0:
+                    raise GatewayBackendError(f"put_archive failed at root={root!r}: {result.get('stderr', '')[:500]}")
+            else:
+                self._upload_chunked(
+                    tar_bytes, target_command=f"tar -xf - -C {quoted_root}", parent_dir=quoted_root, label=root
+                )
+            elapsed_s = time.perf_counter() - start_time
+            if self._TIMING_LOGS and elapsed_s >= self._TIMING_LOG_THRESHOLD_S:
+                logger.info(
+                    "GatewayBackend.put_archive timing image=%s root=%s bytes=%s total=%.3fs",
+                    self._image,
+                    root,
+                    len(tar_bytes),
+                    elapsed_s,
+                )
+
+    def _upload_chunked(self, data: bytes, target_command: str, parent_dir: str, label: str) -> None:
+        """Upload ``data`` in idempotent base64 chunk files, then assemble.
+
+        Each chunk exec overwrites its own part file, so a gateway-level retry
+        of any single request cannot corrupt the payload.
+        """
+        token = uuid.uuid4().hex[:16]
+        stage_dir = f"{_WORK_DIR}/upload_{token}"
+        quoted_stage = shlex.quote(stage_dir)
+        chunks = [data[i : i + _UPLOAD_CHUNK_BYTES] for i in range(0, len(data), _UPLOAD_CHUNK_BYTES)]
+        result = self._exec(f"mkdir -p {quoted_stage}", exec_timeout=15.0)
+        if result.get("exit_code") != 0:
+            raise GatewayBackendError(f"upload staging failed for {label!r}: {result.get('stderr', '')[:500]}")
+        for index, chunk in enumerate(chunks):
+            result = self._exec(
+                f"base64 -d > {quoted_stage}/part.{index:06d}",
+                stdin=base64.b64encode(chunk).decode(),
+                exec_timeout=30.0,
+            )
+            if result.get("exit_code") != 0:
+                raise GatewayBackendError(
+                    f"upload chunk {index} failed for {label!r}: {result.get('stderr', '')[:500]}"
+                )
+        result = self._exec(
+            f"mkdir -p {parent_dir} && cat {quoted_stage}/part.* | {target_command} && rm -rf {quoted_stage}",
+            exec_timeout=_WAIT_EXEC_TIMEOUT_S,
+        )
+        if result.get("exit_code") != 0:
+            raise GatewayBackendError(f"upload assembly failed for {label!r}: {result.get('stderr', '')[:500]}")
+
+    def read_file(self, path: str, binary: bool = False) -> str | bytes:
+        quoted = shlex.quote(path)
+        with self._exec_lock:
+            probe = self._exec(
+                f"if [ ! -e {quoted} ]; then exit 40; elif [ -d {quoted} ]; then exit 41; fi; wc -c < {quoted}",
+                exec_timeout=15.0,
+            )
+            exit_code = probe.get("exit_code")
+            if exit_code == 40:
+                raise FileNotFoundError(f"File not found in container: '{path}'")
+            if exit_code == 41:
+                raise IsADirectoryError(f"Path '{path}' is a directory, not a file.")
+            if exit_code != 0:
+                raise GatewayBackendError(f"read_file probe failed for {path!r}: {probe.get('stderr', '')[:500]}")
+            try:
+                size = int(probe.get("stdout", "").strip())
+            except ValueError:
+                raise GatewayBackendError(
+                    f"read_file probe returned an invalid size for {path!r}: {probe.get('stdout', '')!r}"
+                ) from None
+
+            parts: list[bytes] = []
+            for offset in range(0, max(size, 1), _READ_CHUNK_BYTES):
+                result = self._exec(
+                    f"tail -c +{offset + 1} {quoted} | head -c {_READ_CHUNK_BYTES} | base64 -w0", exec_timeout=30.0
+                )
+                if result.get("exit_code") != 0:
+                    raise GatewayBackendError(f"read_file failed for {path!r}: {result.get('stderr', '')[:500]}")
+                parts.append(base64.b64decode(result.get("stdout", "").strip()))
+        content = b"".join(parts)
+        if binary:
+            return content
+        return content.decode("utf-8", errors="replace")
+
+
 def create_backend(backend_type: str, **kwargs) -> SandboxBackend:
     """Factory function to create a sandbox backend.
 
     Args:
-        backend_type: ``"docker"`` or ``"apptainer"``.
+        backend_type: ``"docker"``, ``"apptainer"``, or ``"gateway"``.
         **kwargs: Backend-specific arguments.
 
     Returns:
         SandboxBackend instance (not yet started).
     """
+    if backend_type != "gateway":
+        kwargs.pop("gateway_url", None)
     if backend_type == "docker":
         return DockerBackend(**kwargs)
     if backend_type == "apptainer":
         return ApptainerBackend(**kwargs)
-    raise ValueError(f"Unknown backend type: {backend_type}. Supported: 'docker', 'apptainer'.")
+    if backend_type == "gateway":
+        return GatewayBackend(**kwargs)
+    raise ValueError(f"Unknown backend type: {backend_type}. Supported: 'docker', 'apptainer', 'gateway'.")

--- a/open_instruct/environments/backends.py
+++ b/open_instruct/environments/backends.py
@@ -792,9 +792,16 @@ _READ_CHUNK_BYTES = 384 * 1024
 
 # One wait-exec blocks inside the container until the command finishes or the
 # in-container wait budget expires, so completed commands return in one round
-# trip and long commands cost one cheap request per ~45s.
+# trip and long commands cost one cheap request per ~30s. The gap between the
+# two budgets is headroom for `podman exec` spawn/teardown on a loaded replica
+# (observed >20s under fleet-wide load); the replica 408s the whole exec if the
+# in-container wait plus that overhead exceeds its own budget.
 _WAIT_EXEC_TIMEOUT_S = 55.0
-_IN_CONTAINER_WAIT_S = 45
+_IN_CONTAINER_WAIT_S = 30
+# A wait exec that returns neither marker was itself cut short (e.g. its bash
+# reaped by the session's cgroup OOM killer alongside the command); the command
+# state lives in files, so re-issuing the same exec is safe.
+_MAX_MARKERLESS_WAITS = 3
 _DONE_MARKER = "__SWERL_GATEWAY_DONE__"
 _PENDING_MARKER = "__SWERL_GATEWAY_PENDING__"
 
@@ -1099,18 +1106,28 @@ class GatewayBackend(SandboxBackend):
         # Budget: command timeout, plus TERM->KILL grace, plus slack for the
         # detached launcher and filesystem latency.
         deadline = time.monotonic() + effective_timeout + 60.0
+        markerless_waits = 0
         while True:
             response = self._exec(waiter, exec_timeout=_WAIT_EXEC_TIMEOUT_S, workdir="/")
             stdout = response.get("stdout", "")
             if _DONE_MARKER in stdout:
                 break
             if _PENDING_MARKER not in stdout:
-                raise GatewayBackendError(
-                    f"Gateway wait exec returned no marker (exit={response.get('exit_code')}): "
-                    f"stdout={stdout[:200]!r} stderr={response.get('stderr', '')[:200]!r}"
+                markerless_waits += 1
+                if markerless_waits >= _MAX_MARKERLESS_WAITS:
+                    raise GatewayBackendError(
+                        f"Gateway wait exec returned no marker {markerless_waits}x in a row "
+                        f"(exit={response.get('exit_code')}): "
+                        f"stdout={stdout[:200]!r} stderr={response.get('stderr', '')[:200]!r}"
+                    )
+                logger.warning(
+                    "Gateway wait exec returned no marker (exit=%s); retrying (%s/%s)",
+                    response.get("exit_code"),
+                    markerless_waits,
+                    _MAX_MARKERLESS_WAITS,
                 )
             if time.monotonic() > deadline:
-                self._exec(f"rm -rf {quoted_dir}", exec_timeout=15.0)
+                self._cleanup_job_dir(quoted_dir)
                 raise GatewayBackendError(
                     f"Gateway command did not finish within {effective_timeout}s plus grace; giving up."
                 )
@@ -1122,10 +1139,23 @@ class GatewayBackend(SandboxBackend):
         except ValueError:
             raise GatewayBackendError(f"Gateway wait exec returned an invalid rc line: {rc_line!r}") from None
         stderr = response.get("stderr", "")
-        self._exec(f"rm -rf {quoted_dir}", exec_timeout=15.0)
+        self._cleanup_job_dir(quoted_dir)
         if exit_code == 124:
             stderr = f"Command timed out after {effective_timeout}s.\n" + stderr
         return ExecutionResult(stdout=out, stderr=stderr, exit_code=exit_code)
+
+    def _cleanup_job_dir(self, quoted_dir: str) -> None:
+        """Best-effort removal of a finished command's scratch dir.
+
+        The command's result is already in hand by the time this runs, so a
+        failure here (typically a 408 from `podman exec` latency on a loaded
+        replica) must never turn a completed command into a tool error. The
+        dir is tiny and dies with the session container anyway.
+        """
+        try:
+            self._exec(f"rm -rf {quoted_dir}", exec_timeout=15.0)
+        except GatewayBackendError as e:
+            logger.warning("Gateway job-dir cleanup failed (ignored): %s", str(e)[:200])
 
     # ------------------------------------------------------------- keepalive
 

--- a/open_instruct/environments/backends.py
+++ b/open_instruct/environments/backends.py
@@ -828,13 +828,15 @@ class GatewayBackend(SandboxBackend):
     _REQUEST_ATTEMPTS = 4
     _RETRY_BASE_DELAY_S = 0.5
     _RETRY_MAX_DELAY_S = 8.0
-    # Strict affinity answers 503 with this text when the replica that owns the
-    # binding has dropped off the registry roster. A live replica reappears
-    # within one retry; a dead/rescheduled one stays off the roster until the
-    # binding TTL (~15 min) expires, so after this many such answers the
+    # Strict affinity answers 503 with these texts when the replica that owns
+    # the binding is gone: "no longer registered" once it has dropped off the
+    # registry roster, "server is unavailable" while it is still on the roster
+    # (heartbeat tolerance ~4 min) but refuses connections. A live replica
+    # recovers within one retry; a dead one keeps failing every request until
+    # the roster catches up, so after this many consecutive such answers the
     # session is treated as lost and re-handshaken instead of retried.
-    _OWNER_UNREGISTERED_MARKER = "no longer registered"
-    _OWNER_UNREGISTERED_ATTEMPTS = 2
+    _OWNER_LOST_MARKERS = ("no longer registered", "server is unavailable")
+    _OWNER_LOST_ATTEMPTS = 3
     _TIMING_LOGS = _env_flag("SWERL_SANDBOX_TIMING_LOGS", False)
     _TIMING_LOG_THRESHOLD_S = _env_float("SWERL_SANDBOX_TIMING_LOG_THRESHOLD_S", 1.0)
 
@@ -905,16 +907,20 @@ class GatewayBackend(SandboxBackend):
         Retries cover connection errors, request timeouts, and 500/502/503/504
         (replica connection dropped mid-request / temporarily unreachable /
         gateway rediscovering) — safe because every exec this backend issues is
-        idempotent. 404 maps to :class:`GatewaySessionLostError` so callers can
-        re-handshake, as does a repeated 503 saying the binding's owner is no
-        longer registered (the replica died; waiting out the TTL would only
-        fail every request until then).
+        idempotent. 404 (binding expired) and 410 (gateway probed the binding's
+        owner and found it gone; literegistry >= 1.0.49 answers
+        ``{"code": "affinity_owner_lost", "recoverable": false}``) map to
+        :class:`GatewaySessionLostError` so callers can re-handshake, as do
+        consecutive 503s saying the owner is unavailable / no longer registered
+        (the replica died; the gateway only concludes that itself once the
+        roster heartbeat tolerance has passed, ~4 min, and waiting for that
+        would fail every request until then).
         """
         url = f"{self._gateway_url}/{endpoint.lstrip('/')}"
         max_attempts = attempts or self._REQUEST_ATTEMPTS
         session = http_session or self._session
         last_error: Exception | None = None
-        owner_unregistered_answers = 0
+        owner_lost_answers = 0
         for attempt in range(1, max_attempts + 1):
             self._last_request_monotonic = time.monotonic()
             try:
@@ -922,15 +928,16 @@ class GatewayBackend(SandboxBackend):
             except (requests.ConnectionError, requests.Timeout) as e:
                 last_error = GatewayBackendError(f"Gateway request to {endpoint} failed: {e}")
             else:
-                if response.status_code == 404:
+                if response.status_code in (404, 410):
                     raise GatewaySessionLostError(
-                        f"Gateway affinity session lost ({endpoint}): {response.text[:500]}", status_code=404
+                        f"Gateway affinity session lost ({endpoint}): {response.text[:500]}",
+                        status_code=response.status_code,
                     )
-                if response.status_code == 503 and self._OWNER_UNREGISTERED_MARKER in response.text:
-                    owner_unregistered_answers += 1
-                    if owner_unregistered_answers >= self._OWNER_UNREGISTERED_ATTEMPTS:
+                if response.status_code == 503 and any(m in response.text for m in self._OWNER_LOST_MARKERS):
+                    owner_lost_answers += 1
+                    if owner_lost_answers >= self._OWNER_LOST_ATTEMPTS:
                         raise GatewaySessionLostError(
-                            f"Gateway affinity owner unregistered ({endpoint}): {response.text[:500]}", status_code=503
+                            f"Gateway affinity owner gone ({endpoint}): {response.text[:500]}", status_code=503
                         )
                 if response.status_code in (500, 502, 503, 504, 408):
                     last_error = GatewayBackendError(

--- a/open_instruct/environments/backends.py
+++ b/open_instruct/environments/backends.py
@@ -811,9 +811,22 @@ _WORK_DIR = "/tmp/.swerl_gateway"
 class GatewayBackendError(RuntimeError):
     """A gateway request failed or returned an invalid response."""
 
-    def __init__(self, message: str, status_code: int | None = None):
+    def __init__(self, message: str, status_code: int | None = None, body: str = ""):
         super().__init__(message)
         self.status_code = status_code
+        self.body = body
+
+
+class SandboxLostError(SandboxOOMError):
+    """The sandbox container was killed or stopped mid-episode and cannot be recovered.
+
+    Raised by :class:`GatewayBackend` when the replica reports the session
+    container gone (removed by its resource watchdog / OOM reaper, or stopped
+    because its init process died). Subclasses :class:`SandboxOOMError` so
+    environments end the episode (reward 0, done=True) exactly like a
+    DockerBackend OOM kill, instead of silently continuing in a fresh, empty
+    container.
+    """
 
 
 class GatewaySessionLostError(GatewayBackendError):
@@ -837,6 +850,15 @@ class GatewayBackend(SandboxBackend):
     # session is treated as lost and re-handshaken instead of retried.
     _OWNER_LOST_MARKERS = ("no longer registered", "server is unavailable")
     _OWNER_LOST_ATTEMPTS = 3
+    # The replica removed the session container itself (resource watchdog /
+    # OOM reaper / idle janitor) while the gateway binding still existed.
+    # Unlike an expired binding or a dead replica, this is the sandbox dying
+    # under the agent's own commands, so it ends the episode (SandboxLostError)
+    # instead of re-handshaking into a fresh, empty container.
+    _CONTAINER_REMOVED_MARKER = "container_not_found"
+    # `podman exec` on a container whose init process died (agent killed PID 1,
+    # or the OOM killer took it): the container is stopped but not removed.
+    _CONTAINER_STOPPED_MARKERS = ("container state improper", "can only create exec sessions on running containers")
     _TIMING_LOGS = _env_flag("SWERL_SANDBOX_TIMING_LOGS", False)
     _TIMING_LOG_THRESHOLD_S = _env_float("SWERL_SANDBOX_TIMING_LOG_THRESHOLD_S", 1.0)
 
@@ -932,12 +954,15 @@ class GatewayBackend(SandboxBackend):
                     raise GatewaySessionLostError(
                         f"Gateway affinity session lost ({endpoint}): {response.text[:500]}",
                         status_code=response.status_code,
+                        body=response.text,
                     )
                 if response.status_code == 503 and any(m in response.text for m in self._OWNER_LOST_MARKERS):
                     owner_lost_answers += 1
                     if owner_lost_answers >= self._OWNER_LOST_ATTEMPTS:
                         raise GatewaySessionLostError(
-                            f"Gateway affinity owner gone ({endpoint}): {response.text[:500]}", status_code=503
+                            f"Gateway affinity owner gone ({endpoint}): {response.text[:500]}",
+                            status_code=503,
+                            body=response.text,
                         )
                 if response.status_code in (500, 502, 503, 504, 408):
                     last_error = GatewayBackendError(
@@ -1069,8 +1094,17 @@ class GatewayBackend(SandboxBackend):
             try:
                 result = self._run_command_once(command, effective_timeout)
             except GatewaySessionLostError as e:
-                # Mirrors DockerBackend's restart-and-retry-once semantics when
-                # the container disappears mid-episode.
+                if self._CONTAINER_REMOVED_MARKER in e.body:
+                    # The replica reaped the container (memory/pids budget or
+                    # idle janitor) between commands: same terminal condition
+                    # as DockerBackend's OOM kill.
+                    raise SandboxLostError(
+                        f"Sandbox container {(self._affinity_id or '?')[:12]} (image={self._image}) was removed "
+                        f"by its replica: {e.body[:300]}. Aborting episode."
+                    ) from e
+                # Binding expired / replica died: mirrors DockerBackend's
+                # restart-and-retry-once semantics when the container
+                # disappears mid-episode.
                 logger.warning(
                     "Gateway container disappeared before exec (%s). Restarting and retrying command once.", e
                 )
@@ -1114,6 +1148,7 @@ class GatewayBackend(SandboxBackend):
         )
         launch = self._exec(launcher, stdin=command, exec_timeout=30.0)
         if "LAUNCHED" not in launch.get("stdout", ""):
+            self._raise_if_container_stopped(launch)
             raise GatewayBackendError(
                 f"Gateway command launcher failed (exit={launch.get('exit_code')}): {launch.get('stderr', '')[:500]}"
             )
@@ -1130,14 +1165,33 @@ class GatewayBackend(SandboxBackend):
         # detached launcher and filesystem latency.
         deadline = time.monotonic() + effective_timeout + 60.0
         markerless_waits = 0
+        saw_sigkill = False
         while True:
-            response = self._exec(waiter, exec_timeout=_WAIT_EXEC_TIMEOUT_S, workdir="/")
+            try:
+                response = self._exec(waiter, exec_timeout=_WAIT_EXEC_TIMEOUT_S, workdir="/")
+            except GatewaySessionLostError as e:
+                if saw_sigkill or self._CONTAINER_REMOVED_MARKER in e.body:
+                    # The wait exec was SIGKILLed and/or the replica reports
+                    # the container gone: the resource watchdog reaped the
+                    # session under this command.
+                    raise SandboxLostError(
+                        f"Sandbox container {(self._affinity_id or '?')[:12]} (image={self._image}) was killed "
+                        f"while running a command (sigkill_seen={saw_sigkill}): {e.body[:300]}. Aborting episode."
+                    ) from e
+                raise
             stdout = response.get("stdout", "")
             if _DONE_MARKER in stdout:
                 break
             if _PENDING_MARKER not in stdout:
                 markerless_waits += 1
+                if response.get("exit_code") == 137:
+                    saw_sigkill = True
+                self._raise_if_container_stopped(response)
                 if markerless_waits >= _MAX_MARKERLESS_WAITS:
+                    # Repeated markerless waits are either a container being
+                    # torn down or a very slow replica; a trivial exec tells
+                    # them apart before this becomes a plain tool error.
+                    self._probe_container_alive()
                     raise GatewayBackendError(
                         f"Gateway wait exec returned no marker {markerless_waits}x in a row "
                         f"(exit={response.get('exit_code')}): "
@@ -1166,6 +1220,26 @@ class GatewayBackend(SandboxBackend):
         if exit_code == 124:
             stderr = f"Command timed out after {effective_timeout}s.\n" + stderr
         return ExecutionResult(stdout=out, stderr=stderr, exit_code=exit_code)
+
+    def _raise_if_container_stopped(self, response: dict) -> None:
+        """Map a replica exec failure on a stopped container to SandboxLostError."""
+        stderr = response.get("stderr", "") or ""
+        if any(marker in stderr for marker in self._CONTAINER_STOPPED_MARKERS):
+            raise SandboxLostError(
+                f"Sandbox container {(self._affinity_id or '?')[:12]} (image={self._image}) is stopped "
+                f"(its init process died): {stderr[:300]}. Aborting episode."
+            )
+
+    def _probe_container_alive(self) -> None:
+        """Run a trivial exec; raise SandboxLostError if the container is gone or stopped."""
+        try:
+            probe = self._exec("true", exec_timeout=15.0)
+        except GatewaySessionLostError as e:
+            raise SandboxLostError(
+                f"Sandbox container {(self._affinity_id or '?')[:12]} (image={self._image}) is gone: "
+                f"{e.body[:300]}. Aborting episode."
+            ) from e
+        self._raise_if_container_stopped(probe)
 
     def _cleanup_job_dir(self, quoted_dir: str) -> None:
         """Best-effort removal of a finished command's scratch dir.

--- a/open_instruct/environments/swerl_sandbox.py
+++ b/open_instruct/environments/swerl_sandbox.py
@@ -503,6 +503,7 @@ class SWERLSandboxEnvConfig(BaseEnvConfig):
     backend: str = "docker"
     image: str = "python:3.12-slim"
     mem_limit: str = "4g"
+    gateway_url: str = ""
     penalty: float = -0.05
     task_data_dir: str = ""
     task_data_hf_repo: str = ""

--- a/open_instruct/environments/swerl_vanillux_sandbox.py
+++ b/open_instruct/environments/swerl_vanillux_sandbox.py
@@ -550,6 +550,7 @@ class SWERLVanilluxSandboxEnvConfig(BaseEnvConfig):
     backend: str = "docker"
     image: str = "python:3.12-slim"
     mem_limit: str = "4g"
+    gateway_url: str = ""
     penalty: float = -0.05
     task_data_dir: str = ""
     task_data_hf_repo: str = ""

--- a/open_instruct/environments/swerl_vanillux_sandbox.py
+++ b/open_instruct/environments/swerl_vanillux_sandbox.py
@@ -420,7 +420,10 @@ class SWERLVanilluxSandboxEnv(RLEnvironment):
             except SandboxOOMError as e:
                 logger.warning(f"[{self._task_id}] sandbox OOM: {e}")
                 return StepResult(
-                    result=("Sandbox container was killed by the OOM reaper. Ending episode with reward 0."),
+                    result=(
+                        "Sandbox container was killed (memory/pids limit exceeded or its init process died). "
+                        "Ending episode with reward 0."
+                    ),
                     reward=0.0,
                     done=True,
                     metadata={"oom_killed": True, "task_id": self._task_id},

--- a/open_instruct/grpo_fast.py
+++ b/open_instruct/grpo_fast.py
@@ -181,12 +181,17 @@ WEIGHT_SYNC_TIMEOUT_S = 7200.0
 EXCLUDED_ENV_VARS = {"CUDA_VISIBLE_DEVICES", "ROCR_VISIBLE_DEVICES"}
 
 
-def _build_vlm_name_mapper(model_name: str):
+def _build_vlm_name_mapper(model_name: str, model_type: str | None = None):
     """Sometimes we have different weight names btw vLLM and HF, so we build
     a mapping. E.g., Qwen3.5/3.6 have 'language_model.' prefixed in vLLM but not HF.
     Match the "qwen35"/"qwen3_5" spellings too — local checkpoint dirs (e.g.
     warm-start paths like .../swerl_qwen35_9b_..._cg) drop the dot, and missing the
-    mapper makes the trainer->vLLM weight sync fail with 'no module named model'."""
+    mapper makes the trainer->vLLM weight sync fail with 'no module named model'.
+    Prefer the config's model_type when given: derived checkpoints (e.g. allenai/tmax-2b)
+    carry none of these spellings in their name. The trainer's text-only class reports
+    the text sub-config's type ("qwen3_5_text"), hence the prefix match."""
+    if model_type is not None and model_type.lower().startswith(("qwen3_5", "qwen3_6")):
+        return lambda weight_name: f"language_model.{weight_name}"
     name = model_name.lower()
     if any(v in name for v in ("qwen3.5", "qwen3.6", "qwen35", "qwen36", "qwen3_5", "qwen3_6")):
         return lambda weight_name: f"language_model.{weight_name}"
@@ -715,7 +720,9 @@ class PolicyTrainerRayProcess(RayProcess):
             vllm_engines=self.vllm_engines,
             model_update_group=self.model_update_group,
             gather_whole_model=self.args.gather_whole_model,
-            name_mapper=_build_vlm_name_mapper(self._model_name_or_path),
+            name_mapper=_build_vlm_name_mapper(
+                self._model_name_or_path, getattr(self.model.module.config, "model_type", None)
+            ),
         )
 
     def update_ref_policy(self):

--- a/scripts/general_agent/terminal/rl/gateway/check_gateway_deployment.py
+++ b/scripts/general_agent/terminal/rl/gateway/check_gateway_deployment.py
@@ -1,0 +1,154 @@
+"""Preflight check for a LiteRegistry Podman gateway deployment.
+
+Run this before launching a gateway-backend terminal RL job to verify the
+deployment end to end from the machine you care about:
+
+1. gateway /health and the docker.io mirror route /v2/
+2. GatewayBackend protocol: exec, state persistence, >60s commands, command
+   timeouts, oversized output, chunked file IO, put_archive
+3. one full SWERLVanilluxSandboxEnv episode on a real tmax task image,
+   asserting the verifier awards reward 1.0
+
+Usage:
+    uv run python scripts/general_agent/terminal/rl/gateway/check_gateway_deployment.py \
+        --gateway_url http://HOST:PORT [--skip_episode]
+
+The episode check needs the allenai/tmax-15k-open-instruct task data (downloads
+on first use) and pulls one small task image on a replica.
+"""
+
+import argparse
+import asyncio
+import io
+import os
+import sys
+import tarfile
+import time
+
+import requests
+
+from open_instruct import logger_utils
+from open_instruct.environments.backends import GatewayBackend
+from open_instruct.environments.base import EnvCall
+from open_instruct.environments.swerl_vanillux_sandbox import SWERLVanilluxSandboxEnv
+
+logger = logger_utils.setup_logger(__name__)
+
+# A tmax-15k task whose verifier checks for an exact CSV we can write directly,
+# so a passing run proves the tests-upload -> verifier -> reward-parse path.
+EPISODE_TASK_ID = "task_000035_88acd16c"
+EPISODE_IMAGE = "hamishi740/swerl-tmax-v3:d6f61374e053"
+EPISODE_SOLVE_COMMAND = (
+    "mkdir -p /home/user/pipeline && "
+    "printf 'timestamp,distance\\n1000,22.36\\n1001,29.15\\n1003,7.07\\n' > /home/user/pipeline/cleaned.csv"
+)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, condition: bool, extra: str = "") -> None:
+    print(f"[{'PASS' if condition else 'FAIL'}] {name}" + (f" ({extra})" if extra else ""))
+    if not condition:
+        FAILURES.append(name)
+
+
+def check_gateway_health(gateway_url: str) -> None:
+    health = requests.get(f"{gateway_url}/health", timeout=15).json()
+    check("gateway /health", health.get("status") == "healthy", str(health))
+    mirror_status = requests.get(f"{gateway_url}/v2/", timeout=15).status_code
+    check("docker mirror /v2/", mirror_status == 200, f"HTTP {mirror_status}")
+
+
+def check_backend_protocol(gateway_url: str) -> None:
+    backend = GatewayBackend(image="python:3.12-slim", timeout=120, gateway_url=gateway_url)
+    start_time = time.time()
+    backend.start()
+    check("handshake", True, f"{time.time() - start_time:.1f}s on {backend._instance_id}")
+    try:
+        result = backend.run_command("echo out && echo err >&2 && exit 3")
+        check(
+            "exec stdout/stderr/exit_code",
+            (result.stdout.strip(), result.stderr.strip(), result.exit_code) == ("out", "err", 3),
+            repr(result),
+        )
+
+        backend.run_command("echo state > /workspace/state.txt")
+        result = backend.run_command("cat /workspace/state.txt")
+        check("state persists across execs", result.stdout.strip() == "state")
+
+        start_time = time.time()
+        result = backend.run_command("sleep 70 && echo done", timeout=120)
+        check(
+            "command past the 60s replica cap",
+            result.stdout.strip() == "done" and result.exit_code == 0,
+            f"{time.time() - start_time:.1f}s",
+        )
+
+        result = backend.run_command("sleep 30", timeout=5)
+        check("command timeout -> exit 124", result.exit_code == 124 and "timed out" in result.stderr)
+
+        result = backend.run_command("head -c 5000000 /dev/zero | tr '\\0' 'a'", timeout=60)
+        check("oversized stdout bounded, no wedge", result.exit_code == 0 and 0 < len(result.stdout) <= 512 * 1024)
+        result = backend.run_command("echo alive")
+        check("session alive after oversized stdout", result.stdout.strip() == "alive")
+
+        blob = os.urandom(1_500_000)
+        backend.write_file("/workspace/blob.bin", blob)
+        check("chunked write/read 1.5MB", backend.read_file("/workspace/blob.bin", binary=True) == blob)
+
+        tar_stream = io.BytesIO()
+        with tarfile.open(fileobj=tar_stream, mode="w") as tar:
+            data = b"archive\n"
+            info = tarfile.TarInfo(name="sub/file.txt")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        backend.put_archive("/workspace/unpacked", tar_stream.getvalue())
+        result = backend.run_command("cat /workspace/unpacked/sub/file.txt")
+        check("put_archive", result.stdout == "archive\n")
+    finally:
+        backend.close()
+    check("close", True)
+
+
+async def check_episode(gateway_url: str) -> None:
+    env = SWERLVanilluxSandboxEnv(
+        backend="gateway",
+        image="python:3.12-slim",
+        task_data_hf_repo="allenai/tmax-15k-open-instruct",
+        test_timeout=120,
+        timeout=60,
+        gateway_url=gateway_url,
+    )
+    await env.setup()
+    start_time = time.time()
+    await env.reset(task_id=EPISODE_TASK_ID, max_steps=10, image=EPISODE_IMAGE)
+    check("episode reset (task image pull + task data)", True, f"{time.time() - start_time:.1f}s")
+    result = await env.step(EnvCall(id="1", name="bash", args={"command": EPISODE_SOLVE_COMMAND}))
+    check("episode solve step", result.metadata.get("exit_code") == 0, str(result.metadata))
+    result = await env.step(
+        EnvCall(id="2", name="bash", args={"command": "echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"})
+    )
+    check("episode verifier reward", result.done and result.reward == 1.0, f"reward={result.reward}")
+    await env.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--gateway_url", required=True, help="LiteRegistry gateway base URL, e.g. http://host:port")
+    parser.add_argument("--skip_episode", action="store_true", help="Skip the full tmax-task episode check")
+    args = parser.parse_args()
+    gateway_url = args.gateway_url.rstrip("/")
+
+    check_gateway_health(gateway_url)
+    check_backend_protocol(gateway_url)
+    if not args.skip_episode:
+        asyncio.run(check_episode(gateway_url))
+
+    if FAILURES:
+        print(f"\n{len(FAILURES)} check(s) FAILED: {FAILURES}")
+        sys.exit(1)
+    print("\nAll gateway deployment checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/general_agent/terminal/rl/gateway/qwen35_4b_gateway_smoke.sh
+++ b/scripts/general_agent/terminal/rl/gateway/qwen35_4b_gateway_smoke.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Smoke test for the LiteRegistry Podman *gateway* sandbox backend.
+#
+# Runs a small terminal RL job (Qwen3.5-4B, 4 GPUs: 2 learners + 2 vLLM engines)
+# whose sandboxes are remote containers behind a LiteRegistry gateway
+# (backend=gateway) instead of podman services colocated in this job.
+# Note what is absent compared to the podman-colocated scripts: no
+# docker_login.sh, no SWERL_PODMAN_* / MIRROR_URL / DOCKER_PAT /
+# BEAKER_ALLOW_SUBCONTAINERS plumbing.
+#
+# Usage: ./scripts/train/build_image_and_launch.sh scripts/general_agent/terminal/rl/gateway/qwen35_4b_gateway_smoke_2gpu.sh
+
+BEAKER_IMAGE="${1:?Usage: $0 <beaker-image>}"
+
+# LiteRegistry gateway (redis + gateway + podman replicas + docker mirrors).
+GATEWAY_URL=http://neptune-cs-aus-265.reviz.ai2.in:56992
+
+MODEL=Qwen/Qwen3.5-4B
+EXP_NAME=swerl_qwen35_4b_gateway_smoke
+
+uv run python mason.py \
+       --cluster ai2/saturn \
+       --image "$BEAKER_IMAGE" \
+       --description "Gateway-backend terminal RL smoke (Qwen3.5-4B; 2 GPU; LiteRegistry podman gateway)" \
+       --pure_docker_mode \
+       --workspace ai2/general-tool-use \
+       --priority urgent \
+       --preemptible \
+       --num_nodes 1 \
+       --max_retries 0 \
+       --env REPO_PATH=/stage \
+       --env PYTORCH_ALLOC_CONF=expandable_segments:True \
+       --env VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+       --env VLLM_DISABLE_COMPILE_CACHE=1 \
+       --env VLLM_USE_V1=1 \
+       --env GIT_COMMIT="$(git rev-parse --short HEAD)" \
+       --env SWERL_SANDBOX_TIMING_LOGS=1 \
+       --env SWERL_RESET_FAILURE_ZERO_REWARD=1 \
+       --env SWERL_SANDBOX_TIMING_LOG_THRESHOLD_S=1.0 \
+       --gpus 4 \
+       --no_auto_dataset_cache \
+       -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
+    --dataset_mixer_list allenai/tmax-15k-open-instruct 1.0 \
+    --dataset_mixer_list_splits train \
+    --max_prompt_token_length 2048 \
+    --per_turn_max_tokens 8192 \
+    --response_length 16384 \
+    --pack_length 18432 \
+    --per_device_train_batch_size 1 \
+    --num_unique_prompts_rollout 4 \
+    --num_samples_per_prompt_rollout 8 \
+    --async_steps 2 \
+    --model_name_or_path $MODEL \
+    --tokenizer_name_or_path $MODEL \
+    --temperature 1.0 \
+    --learning_rate 1e-6 \
+    --total_episodes 320 \
+    --lr_scheduler_type constant \
+    --deepspeed_stage 3 \
+    --num_epochs 1 \
+    --num_learners_per_node 2 \
+    --vllm_num_engines 2 \
+    --vllm_tensor_parallel_size 1 \
+    --vllm_gpu_memory_utilization 0.85 \
+    --beta 0.0 \
+    --use_vllm_logprobs true \
+    --truncated_importance_sampling_ratio_cap 0.0 \
+    --seed 42 \
+    --gradient_checkpointing \
+    --vllm_enable_prefix_caching \
+    --vllm_gdn_prefill_backend triton \
+    --push_to_hub false \
+    --with_tracking \
+    --wandb_project oe-general-agents \
+    --save_traces \
+    --tools swerl_vanillux_sandbox \
+    --tool_configs "{\"backend\": \"gateway\", \"gateway_url\": \"$GATEWAY_URL\", \"task_data_hf_repo\": \"allenai/tmax-15k-open-instruct\", \"test_timeout\": 120, \"image\": \"python:3.12-slim\"}" \
+    --pool_size 64 \
+    --max_steps 32 \
+    --verification_reward 1.0 \
+    --tool_parser_type vllm_qwen3_xml \
+    --system_prompt_override_file scripts/train/debug/envs/swerl_vanillux_sandbox_system_prompt.txt \
+    --active_sampling \
+    --backend_timeout 1200 \
+    --inflight_updates true \
+    --use_liger_grpo_loss \
+    --liger_grpo_loss_chunk_size 8 \
+    --advantage_normalization_type centered \
+    --loss_fn dppo \
+    --dppo_divergence_type tv \
+    --dppo_divergence_threshold 0.1 \
+    --rollouts_save_path /weka/oe-adapt-default/allennlp/deletable_rollouts/ \
+    --output_dir /output \
+    --exp_name $EXP_NAME \
+    --local_eval_every 10 \
+    --save_freq 100 \
+    --try_launch_beaker_eval_jobs_on_weka False

--- a/scripts/general_agent/terminal/rl/gateway/qwen35_9b_dppo_repro_4node_64k_gateway.sh
+++ b/scripts/general_agent/terminal/rl/gateway/qwen35_9b_dppo_repro_4node_64k_gateway.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Gateway-backend variant of qwen35_9b_dppo_repro_4node_64k.sh: identical DPPO
+# recipe, but sandboxes run in remote containers behind a LiteRegistry Podman
+# gateway (backend=gateway) instead of podman services colocated in this job.
+# All SWERL_PODMAN_* / MIRROR_URL / DOCKER_PAT / subcontainer plumbing and
+# docker_login.sh are gone; the training nodes never run podman themselves.
+
+BEAKER_IMAGE="${1:?Usage: $0 <beaker-image>}"
+
+# LiteRegistry gateway (redis + gateway + podman replicas + docker mirrors).
+GATEWAY_URL=http://neptune-cs-aus-265.reviz.ai2.in:56992
+
+MODEL=hamishivi/Qwen3.5-9B
+TOKENIZER=hamishivi/Qwen3.5-9B
+
+EXP_NAME=swerl_qwen35_9b_dppo_repro_4node_64k_gateway
+
+uv run python mason.py \
+       --cluster ai2/jupiter \
+       --image "$BEAKER_IMAGE" \
+       --description "tmax-15k DPPO Qwen35 9b (repro; 4-node; 64k; LiteRegistry podman gateway)" \
+       --pure_docker_mode \
+       --workspace ai2/general-tool-use \
+       --priority urgent \
+       --preemptible \
+       --num_nodes 4 \
+       --max_retries 5 \
+       --env REPO_PATH=/stage \
+       --env PYTORCH_ALLOC_CONF=expandable_segments:True \
+       --env VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+       --env VLLM_DISABLE_COMPILE_CACHE=1 \
+       --env VLLM_USE_V1=1 \
+       --env GIT_COMMIT="$(git rev-parse --short HEAD)" \
+       --env SWERL_SANDBOX_TIMING_LOGS=1 \
+       --env SWERL_RESET_FAILURE_ZERO_REWARD=1 \
+       --env SWERL_SANDBOX_TIMING_LOG_THRESHOLD_S=1.0 \
+       --gpus 8 \
+       --no_auto_dataset_cache \
+       -- source configs/beaker_configs/ray_node_setup.sh \&\& python open_instruct/grpo_fast.py \
+    --dataset_mixer_list allenai/tmax-15k-open-instruct 1.0 \
+    --dataset_mixer_list_splits train \
+    --max_prompt_token_length 2048 \
+    --per_turn_max_tokens 16384 \
+    --response_length 65536 \
+    --pack_length 67584 \
+    --per_device_train_batch_size 1 \
+    --num_unique_prompts_rollout 8 \
+    --num_samples_per_prompt_rollout 32 \
+    --async_steps 4 \
+    --model_name_or_path $MODEL \
+    --tokenizer_name_or_path $TOKENIZER \
+    --temperature 1.0 \
+    --learning_rate 1e-6 \
+    --total_episodes 128000 \
+    --lr_scheduler_type constant \
+    --deepspeed_stage 3 \
+    --sequence_parallel_size 4 \
+    --num_epochs 1 \
+    --num_learners_per_node 8 8 \
+    --vllm_num_engines 16 \
+    --vllm_tensor_parallel_size 1 \
+    --beta 0.0 \
+    --use_vllm_logprobs true \
+    --truncated_importance_sampling_ratio_cap 0.0 \
+    --seed 42 \
+    --gradient_checkpointing \
+    --vllm_enable_prefix_caching \
+    --push_to_hub false \
+    --with_tracking \
+    --wandb_project oe-general-agents \
+    --save_traces \
+    --save_trainer_logprobs true \
+    --tools swerl_vanillux_sandbox \
+    --tool_configs "{\"backend\": \"gateway\", \"gateway_url\": \"$GATEWAY_URL\", \"task_data_hf_repo\": \"allenai/tmax-15k-open-instruct\", \"test_timeout\": 120, \"image\": \"python:3.12-slim\"}" \
+    --pool_size 512 \
+    --max_steps 64 \
+    --verification_reward 1.0 \
+    --tool_parser_type vllm_qwen3_xml \
+    --system_prompt_override_file scripts/train/debug/envs/swerl_vanillux_sandbox_system_prompt.txt \
+    --active_sampling \
+    --backend_timeout 1200 \
+    --vllm_gdn_prefill_backend triton \
+    --checkpoint_state_freq 10 \
+    --inflight_updates true \
+    --lm_head_fp32 true \
+    --use_liger_grpo_loss \
+    --liger_grpo_loss_chunk_size 8 \
+    --advantage_normalization_type centered \
+    --loss_fn dppo \
+    --dppo_divergence_type tv \
+    --dppo_divergence_threshold 0.1 \
+    --rollouts_save_path /weka/oe-adapt-default/allennlp/deletable_rollouts/ \
+    --output_dir /output \
+    --exp_name $EXP_NAME \
+    --local_eval_every 10 \
+    --save_freq 20 \
+    --try_launch_beaker_eval_jobs_on_weka False

--- a/scripts/general_agent/terminal/rl/gateway/start_colocated_gateway.sh
+++ b/scripts/general_agent/terminal/rl/gateway/start_colocated_gateway.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Run a LiteRegistry gateway inside the training job and point the sandbox backend at it.
+#
+# Source this on EVERY node before configs/beaker_configs/ray_node_setup.sh:
+#   source scripts/general_agent/terminal/rl/gateway/start_colocated_gateway.sh && source configs/beaker_configs/ray_node_setup.sh && python ...
+#
+# The Beaker leader (Ray head) starts the gateway, supervised (restarted if it exits); all
+# nodes export SWERL_GATEWAY_URL=http://<leader>:<port>, which GatewayBackend picks up when
+# --tool_configs carries no gateway_url. The gateway finds the fleet's Redis through the head
+# registry on weka, so a Redis restart on another host is followed automatically, and because
+# the gateway shares the job's lifetime there is no separate gateway task to lose.
+#
+# Inputs (env):
+#   LITEREGISTRY_REGISTRY      required, e.g. head+sqlite:///weka/oe-adapt-default/gfaria/podman_deployments/<deploy>/head.sqlite3
+#   LITEREGISTRY_GATEWAY_VENV  venv with literegistry installed (image default /opt/literegistry-gateway-venv)
+#   GATEWAY_PORT               default: derived from BEAKER_EXPERIMENT_ID into 20000-29999 (same on every node)
+#   GATEWAY_WORKERS            default 8
+#   GATEWAY_WAIT_S             seconds to wait for a healthy gateway before failing the job (default 600)
+#   GATEWAY_MIN_REPLICAS       fail if the roster shows fewer podman replicas after the wait (default 1)
+
+_gw_log() { echo "[start_colocated_gateway] $*"; }
+
+if [ -z "${LITEREGISTRY_REGISTRY:-}" ]; then
+    _gw_log "ERROR: LITEREGISTRY_REGISTRY is not set (e.g. head+sqlite:///weka/.../head.sqlite3)"
+    return 1 2>/dev/null || exit 1
+fi
+LITEREGISTRY_GATEWAY_VENV="${LITEREGISTRY_GATEWAY_VENV:-/opt/literegistry-gateway-venv}"
+if [ ! -x "${LITEREGISTRY_GATEWAY_VENV}/bin/python" ]; then
+    _gw_log "ERROR: no python at ${LITEREGISTRY_GATEWAY_VENV}/bin/python (image built without the gateway venv?)"
+    return 1 2>/dev/null || exit 1
+fi
+
+GATEWAY_WORKERS="${GATEWAY_WORKERS:-8}"
+GATEWAY_WAIT_S="${GATEWAY_WAIT_S:-600}"
+GATEWAY_MIN_REPLICAS="${GATEWAY_MIN_REPLICAS:-1}"
+_gw_rank="${BEAKER_REPLICA_RANK:-0}"
+_gw_leader="${BEAKER_LEADER_REPLICA_HOSTNAME:-$(hostname -f 2>/dev/null || hostname)}"
+if [ -z "${GATEWAY_PORT:-}" ]; then
+    # Deterministic per experiment so every replica computes the same URL without talking.
+    GATEWAY_PORT=$("${LITEREGISTRY_GATEWAY_VENV}/bin/python" -c \
+        "import hashlib,os; seed=os.environ.get('BEAKER_EXPERIMENT_ID') or os.environ.get('BEAKER_WORKLOAD_ID') or 'local'; print(20000 + int(hashlib.sha256(seed.encode()).hexdigest(), 16) % 10000)")
+fi
+export SWERL_GATEWAY_URL="http://${_gw_leader}:${GATEWAY_PORT}"
+_gw_log "rank=${_gw_rank} leader=${_gw_leader} SWERL_GATEWAY_URL=${SWERL_GATEWAY_URL} registry=${LITEREGISTRY_REGISTRY}"
+
+if [ "${_gw_rank}" = "0" ]; then
+    if ! "${LITEREGISTRY_GATEWAY_VENV}/bin/python" -c "import socket,sys; s=socket.socket(); s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1); s.bind(('0.0.0.0', ${GATEWAY_PORT})); s.close()" 2>/dev/null; then
+        _gw_log "ERROR: port ${GATEWAY_PORT} is already in use on ${_gw_leader}; set GATEWAY_PORT to a free port"
+        return 1 2>/dev/null || exit 1
+    fi
+    (
+        while true; do
+            "${LITEREGISTRY_GATEWAY_VENV}/bin/python" -m literegistry.gateway \
+                --registry="${LITEREGISTRY_REGISTRY}" \
+                --host=0.0.0.0 \
+                --port="${GATEWAY_PORT}" \
+                --workers="${GATEWAY_WORKERS}" \
+                --register=False 2>&1 | sed -u 's/^/[literegistry-gateway] /'
+            _gw_log "gateway process exited; restarting in 5s"
+            sleep 5
+        done
+    ) &
+    _gw_log "gateway supervisor started (pid $!)"
+fi
+
+# Every node waits: a worker whose leader gateway never comes up fails here instead of during rollouts.
+_gw_deadline=$((SECONDS + GATEWAY_WAIT_S))
+_gw_replicas=-1
+while [ $SECONDS -lt $_gw_deadline ]; do
+    if curl -fsS -m 10 "${SWERL_GATEWAY_URL}/health" >/dev/null 2>&1; then
+        _gw_replicas=$(curl -fsS -m 10 "${SWERL_GATEWAY_URL}/v1/models" 2>/dev/null | "${LITEREGISTRY_GATEWAY_VENV}/bin/python" -c \
+            "import json,sys; d=json.load(sys.stdin); print(sum(len(m.get('metadata', [])) for m in d['data'] if m.get('id') == 'podman'))" 2>/dev/null || echo -1)
+        if [ "${_gw_replicas}" -ge "${GATEWAY_MIN_REPLICAS}" ] 2>/dev/null; then
+            break
+        fi
+    fi
+    sleep 5
+done
+if [ "${_gw_replicas}" -lt "${GATEWAY_MIN_REPLICAS}" ] 2>/dev/null || [ "${_gw_replicas}" = "-1" ]; then
+    _gw_log "ERROR: gateway at ${SWERL_GATEWAY_URL} not healthy with >=${GATEWAY_MIN_REPLICAS} podman replicas after ${GATEWAY_WAIT_S}s (saw ${_gw_replicas})"
+    return 1 2>/dev/null || exit 1
+fi
+_gw_log "gateway healthy: ${_gw_replicas} podman replicas on the roster"

--- a/scripts/general_agent/terminal/rl/gateway/tmax_2b_gateway_local_4gpu.sh
+++ b/scripts/general_agent/terminal/rl/gateway/tmax_2b_gateway_local_4gpu.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Local 4-GPU terminal RL through the LiteRegistry gateway backend — no Beaker/mason.py,
+# and no podman anywhere on this machine: every sandbox container runs on the remote
+# replica fleet behind $GATEWAY_URL.
+# Layout: 2 learner GPUs (ZeRO-3 + liger loss) + 2 vLLM engine GPUs. Sized for 4x L40S 46GB
+# (Qwen3.5-4B OOMs in the ZeRO-3 dummy optimizer step on 44GB cards even with 3 learners;
+# allenai/tmax-2b keeps the Qwen3.5 tokenizer/tool format and fits).
+# Same training args as qwen35_4b_gateway_smoke.sh with a short response length so a
+# handful of steps finishes quickly; this validates the plumbing, not model quality.
+
+export GATEWAY_URL="${GATEWAY_URL:-http://jupiter-cs-aus-148.reviz.ai2.in:45216}"
+MODEL=allenai/tmax-2b
+EXP_NAME="${EXP_NAME:-tmax_2b_gateway_local_4gpu}"
+
+export VLLM_ALLOW_INSECURE_SERIALIZATION=1
+export VLLM_DISABLE_COMPILE_CACHE=1
+export VLLM_USE_V1=1
+export NCCL_CUMEM_ENABLE=0
+export RAY_ENABLE_UV_RUN_RUNTIME_ENV=0   # ray workers crash re-wrapping themselves in `uv run` here
+export SWERL_SANDBOX_TIMING_LOGS=1
+
+mkdir -p "$HOME/.triton/autotune"
+
+ray stop --force
+ray start --head --port=8888 --dashboard-host=0.0.0.0
+
+uv run python open_instruct/grpo_fast.py \
+    --dataset_mixer_list allenai/tmax-15k-open-instruct 1.0 \
+    --dataset_mixer_list_splits train \
+    --max_prompt_token_length 2048 \
+    --per_turn_max_tokens 4096 \
+    --response_length 8192 \
+    --pack_length 10240 \
+    --per_device_train_batch_size 1 \
+    --num_unique_prompts_rollout 4 \
+    --num_samples_per_prompt_rollout 8 \
+    --async_steps 2 \
+    --model_name_or_path $MODEL \
+    --tokenizer_name_or_path $MODEL \
+    --temperature 1.0 \
+    --learning_rate 1e-6 \
+    --total_episodes 192 \
+    --lr_scheduler_type constant \
+    --deepspeed_stage 3 \
+    --num_epochs 1 \
+    --num_learners_per_node 2 \
+    --vllm_num_engines 2 \
+    --vllm_tensor_parallel_size 1 \
+    --vllm_gpu_memory_utilization 0.80 \
+    --beta 0.0 \
+    --use_vllm_logprobs true \
+    --truncated_importance_sampling_ratio_cap 0.0 \
+    --seed 42 \
+    --gradient_checkpointing \
+    --vllm_enable_prefix_caching \
+    --vllm_gdn_prefill_backend triton \
+    --push_to_hub false \
+    --with_tracking \
+    --wandb_project oe-general-agents \
+    --save_traces \
+    --tools swerl_vanillux_sandbox \
+    --tool_configs "{\"backend\": \"gateway\", \"gateway_url\": \"$GATEWAY_URL\", \"task_data_hf_repo\": \"allenai/tmax-15k-open-instruct\", \"test_timeout\": 120, \"image\": \"python:3.12-slim\"}" \
+    --pool_size 64 \
+    --max_steps 32 \
+    --verification_reward 1.0 \
+    --tool_parser_type vllm_qwen3_xml \
+    --system_prompt_override_file scripts/train/debug/envs/swerl_vanillux_sandbox_system_prompt.txt \
+    --active_sampling \
+    --backend_timeout 1200 \
+    --inflight_updates true \
+    --use_liger_grpo_loss \
+    --liger_grpo_loss_chunk_size 8 \
+    --advantage_normalization_type centered \
+    --loss_fn dppo \
+    --dppo_divergence_type tv \
+    --dppo_divergence_threshold 0.1 \
+    --output_dir output/$EXP_NAME \
+    --exp_name $EXP_NAME \
+    --local_eval_every 10 \
+    --save_freq 100

--- a/scripts/general_agent/terminal/rl/gateway/tmax_2b_gateway_local_4gpu.sh
+++ b/scripts/general_agent/terminal/rl/gateway/tmax_2b_gateway_local_4gpu.sh
@@ -2,14 +2,18 @@
 
 # Local 4-GPU terminal RL through the LiteRegistry gateway backend — no Beaker/mason.py,
 # and no podman anywhere on this machine: every sandbox container runs on the remote
-# replica fleet behind $GATEWAY_URL.
+# replica fleet. The gateway runs locally too (start_colocated_gateway.sh), resolving the
+# fleet's Redis through the head registry $LITEREGISTRY_REGISTRY on weka; set
+# LITEREGISTRY_GATEWAY_VENV to a venv with `pip install literegistry==1.0.49`.
 # Layout: 2 learner GPUs (ZeRO-3 + liger loss) + 2 vLLM engine GPUs. Sized for 4x L40S 46GB
 # (Qwen3.5-4B OOMs in the ZeRO-3 dummy optimizer step on 44GB cards even with 3 learners;
 # allenai/tmax-2b keeps the Qwen3.5 tokenizer/tool format and fits).
 # Same training args as qwen35_4b_gateway_smoke.sh with a short response length so a
 # handful of steps finishes quickly; this validates the plumbing, not model quality.
 
-export GATEWAY_URL="${GATEWAY_URL:-http://jupiter-cs-aus-148.reviz.ai2.in:45216}"
+export LITEREGISTRY_REGISTRY="${LITEREGISTRY_REGISTRY:-head+sqlite:///weka/oe-adapt-default/gfaria/podman_deployments/lr1049-big-20260910/head.sqlite3}"
+export LITEREGISTRY_GATEWAY_VENV="${LITEREGISTRY_GATEWAY_VENV:-/opt/literegistry-gateway-venv}"
+export GATEWAY_WORKERS="${GATEWAY_WORKERS:-4}"
 MODEL=allenai/tmax-2b
 EXP_NAME="${EXP_NAME:-tmax_2b_gateway_local_4gpu}"
 
@@ -21,6 +25,8 @@ export RAY_ENABLE_UV_RUN_RUNTIME_ENV=0   # ray workers crash re-wrapping themsel
 export SWERL_SANDBOX_TIMING_LOGS=1
 
 mkdir -p "$HOME/.triton/autotune"
+
+source scripts/general_agent/terminal/rl/gateway/start_colocated_gateway.sh || exit 1
 
 ray stop --force
 ray start --head --port=8888 --dashboard-host=0.0.0.0
@@ -60,7 +66,7 @@ uv run python open_instruct/grpo_fast.py \
     --wandb_project oe-general-agents \
     --save_traces \
     --tools swerl_vanillux_sandbox \
-    --tool_configs "{\"backend\": \"gateway\", \"gateway_url\": \"$GATEWAY_URL\", \"task_data_hf_repo\": \"allenai/tmax-15k-open-instruct\", \"test_timeout\": 120, \"image\": \"python:3.12-slim\"}" \
+    --tool_configs '{"backend": "gateway", "task_data_hf_repo": "allenai/tmax-15k-open-instruct", "test_timeout": 120, "image": "python:3.12-slim"}' \
     --pool_size 64 \
     --max_steps 32 \
     --verification_reward 1.0 \

--- a/tests/test_gateway_backend.py
+++ b/tests/test_gateway_backend.py
@@ -32,6 +32,8 @@ class FakeGateway:
         self.closed = []
         self.container_counter = 0
         self.fail_next_posts: list[tuple[int, str]] = []  # (status_code, body)
+        self.markerless_rounds = 0  # how many wait execs return neither marker (e.g. killed, exit 137)
+        self.fail_cleanup_posts: list[tuple[int, str]] = []  # (status_code, body) for rm -rf execs only
 
     def response(self, status_code, payload):
         response = MagicMock()
@@ -65,6 +67,11 @@ class FakeGateway:
                 200, {"stdout": "LAUNCHED\n", "stderr": "", "exit_code": 0, "success": True, "timed_out": False}
             )
         if _DONE_MARKER in command:
+            if self.markerless_rounds > 0:
+                self.markerless_rounds -= 1
+                return self.response(
+                    200, {"stdout": "", "stderr": "", "exit_code": 137, "success": False, "timed_out": True}
+                )
             if self.pending_rounds > 0:
                 self.pending_rounds -= 1
                 return self.response(
@@ -89,6 +96,9 @@ class FakeGateway:
                 },
             )
         if "rm -rf" in command:
+            if self.fail_cleanup_posts:
+                status, body = self.fail_cleanup_posts.pop(0)
+                return self.response(status, body)
             return self.response(
                 200, {"stdout": "", "stderr": "", "exit_code": 0, "success": True, "timed_out": False}
             )
@@ -168,6 +178,35 @@ def test_run_command_retries_transient_503(backend_and_gateway):
     fake.scripted_results.append((0, "ok\n", ""))
     result = backend.run_command("echo ok")
     assert result.exit_code == 0
+
+
+def test_run_command_cleanup_failure_does_not_fail_command(backend_and_gateway, monkeypatch):
+    # The post-completion `rm -rf` is best-effort: a replica that 408s it under
+    # load (podman exec latency) must not turn a finished command into an error.
+    backend, fake = backend_and_gateway
+    monkeypatch.setattr(GatewayBackend, "_RETRY_BASE_DELAY_S", 0.0)
+    fake.fail_cleanup_posts.extend([(408, '{"detail":"command timed out"}')] * 4)
+    fake.scripted_results.append((0, "done\n", ""))
+    result = backend.run_command("echo done")
+    assert (result.stdout, result.exit_code) == ("done\n", 0)
+    assert not fake.fail_cleanup_posts
+
+
+def test_run_command_retries_markerless_wait(backend_and_gateway):
+    # A wait exec cut short (exit 137, no marker) is re-issued; the command's
+    # state lives in files so the retry picks up the real result.
+    backend, fake = backend_and_gateway
+    fake.markerless_rounds = 2
+    fake.scripted_results.append((0, "survived\n", ""))
+    result = backend.run_command("echo survived")
+    assert result.stdout == "survived\n"
+
+
+def test_run_command_persistent_markerless_wait_raises(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.markerless_rounds = 10
+    with pytest.raises(GatewayBackendError, match="no marker"):
+        backend.run_command("echo doomed")
 
 
 def test_non_retryable_http_error_raises(backend_and_gateway):

--- a/tests/test_gateway_backend.py
+++ b/tests/test_gateway_backend.py
@@ -1,0 +1,205 @@
+"""Unit tests for GatewayBackend (LiteRegistry Podman gateway sandbox backend)."""
+
+import base64
+from unittest.mock import MagicMock
+
+import pytest
+
+from open_instruct.environments.backends import (
+    _DONE_MARKER,
+    _PENDING_MARKER,
+    GatewayBackend,
+    GatewayBackendError,
+    create_backend,
+)
+
+GATEWAY_URL = "http://gateway.test:8080"
+
+
+class FakeGateway:
+    """In-memory fake of the gateway's /affinity/* HTTP contract.
+
+    Executes a tiny simulation of the in-container filesystem protocol used by
+    GatewayBackend: the launcher exec stores the command, the wait exec
+    replays the scripted result, uploads decode base64 stdin.
+    """
+
+    def __init__(self):
+        self.handshakes = 0
+        self.requests = []
+        self.scripted_results = []  # (exit_code, stdout, stderr) per launched command
+        self.pending_rounds = 0  # how many wait execs answer PENDING first
+        self.closed = []
+        self.container_counter = 0
+        self.fail_next_posts: list[tuple[int, str]] = []  # (status_code, body)
+
+    def response(self, status_code, payload):
+        response = MagicMock()
+        response.status_code = status_code
+        if isinstance(payload, dict):
+            response.json.return_value = payload
+            response.text = str(payload)
+        else:
+            response.text = payload
+        return response
+
+    def post(self, url, json=None, timeout=None):
+        self.requests.append((url, json))
+        if self.fail_next_posts:
+            status, body = self.fail_next_posts.pop(0)
+            return self.response(status, body)
+        if url.endswith("/affinity/handshake"):
+            self.handshakes += 1
+            self.container_counter += 1
+            cid = f"{'c' * 11}{self.container_counter}"
+            return self.response(
+                200, {"affinity_id": cid, "container_id": cid, "instance_id": "podman-test", "image": json["image"]}
+            )
+        if url.endswith("/affinity/close"):
+            self.closed.append(json["affinity_id"])
+            return self.response(200, {"removed": True})
+        assert url.endswith("/affinity/podman")
+        command = json["command"]
+        if "mkdir" in command and "cat >" in command and "LAUNCHED" in command:
+            return self.response(
+                200, {"stdout": "LAUNCHED\n", "stderr": "", "exit_code": 0, "success": True, "timed_out": False}
+            )
+        if _DONE_MARKER in command:
+            if self.pending_rounds > 0:
+                self.pending_rounds -= 1
+                return self.response(
+                    200,
+                    {
+                        "stdout": f"{_PENDING_MARKER}\n",
+                        "stderr": "",
+                        "exit_code": 0,
+                        "success": True,
+                        "timed_out": False,
+                    },
+                )
+            exit_code, stdout, stderr = self.scripted_results.pop(0)
+            return self.response(
+                200,
+                {
+                    "stdout": f"{_DONE_MARKER}\nRC={exit_code}\n{stdout}",
+                    "stderr": stderr,
+                    "exit_code": exit_code,
+                    "success": exit_code == 0,
+                    "timed_out": False,
+                },
+            )
+        if "rm -rf" in command:
+            return self.response(
+                200, {"stdout": "", "stderr": "", "exit_code": 0, "success": True, "timed_out": False}
+            )
+        raise AssertionError(f"FakeGateway got an unexpected command: {command!r}")
+
+
+@pytest.fixture()
+def backend_and_gateway():
+    backend = GatewayBackend(image="test-image", timeout=30, gateway_url=GATEWAY_URL, keepalive_interval_s=0)
+    fake = FakeGateway()
+    backend._session = fake
+    backend.start()
+    return backend, fake
+
+
+def test_requires_gateway_url(monkeypatch):
+    monkeypatch.delenv("SWERL_GATEWAY_URL", raising=False)
+    with pytest.raises(ValueError, match="gateway URL"):
+        GatewayBackend(image="test-image")
+
+
+def test_gateway_url_from_env(monkeypatch):
+    monkeypatch.setenv("SWERL_GATEWAY_URL", "http://from-env:1234/")
+    backend = GatewayBackend(image="test-image", keepalive_interval_s=0)
+    assert backend._gateway_url == "http://from-env:1234"
+
+
+def test_create_backend_factory(monkeypatch):
+    backend = create_backend("gateway", image="img", gateway_url=GATEWAY_URL, mem_limit="4g", keepalive_interval_s=0)
+    assert isinstance(backend, GatewayBackend)
+    # Non-gateway backends must not receive gateway_url.
+    docker_backend = create_backend("docker", image="img", gateway_url=GATEWAY_URL)
+    assert not hasattr(docker_backend, "_gateway_url")
+
+
+def test_run_command_immediate_done(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.scripted_results.append((0, "hello\n", "warn\n"))
+    result = backend.run_command("echo hello")
+    assert (result.stdout, result.stderr, result.exit_code) == ("hello\n", "warn\n", 0)
+    # launch exec carries the command via stdin, not the command field
+    launch = next(payload for _, payload in fake.requests if payload and "LAUNCHED" in payload.get("command", ""))
+    assert launch["stdin"] == "echo hello"
+
+
+def test_run_command_polls_through_pending(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.pending_rounds = 2
+    fake.scripted_results.append((3, "slow\n", ""))
+    result = backend.run_command("slow-command", timeout=600)
+    assert result.exit_code == 3
+    assert result.stdout == "slow\n"
+
+
+def test_run_command_timeout_exit_code(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.scripted_results.append((124, "", ""))
+    result = backend.run_command("sleep 999", timeout=5)
+    assert result.exit_code == 124
+    assert "timed out" in result.stderr
+
+
+def test_run_command_rehandshakes_on_lost_session(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    first_container = backend._affinity_id
+    fake.fail_next_posts.append((404, "binding expired"))
+    fake.scripted_results.append((0, "recovered\n", ""))
+    result = backend.run_command("echo recovered")
+    assert result.stdout == "recovered\n"
+    assert fake.handshakes == 2
+    assert backend._affinity_id != first_container
+
+
+def test_run_command_retries_transient_503(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.fail_next_posts.append((503, "replica busy"))
+    fake.scripted_results.append((0, "ok\n", ""))
+    result = backend.run_command("echo ok")
+    assert result.exit_code == 0
+
+
+def test_non_retryable_http_error_raises(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.fail_next_posts.append((422, "validation error"))
+    with pytest.raises(GatewayBackendError, match="422"):
+        backend.run_command("echo nope")
+
+
+def test_write_file_small_single_exec(backend_and_gateway):
+    backend, fake = backend_and_gateway
+
+    seen = {}
+    original_exec = backend._exec
+
+    def spy(command, stdin="", **kwargs):
+        if "base64 -d" in command:
+            seen["stdin"] = stdin
+            return {"exit_code": 0, "stdout": "", "stderr": ""}
+        return original_exec(command, stdin=stdin, **kwargs)
+
+    backend._exec = spy
+    backend.write_file("/workspace/x.txt", "content")
+    assert base64.b64decode(seen["stdin"]) == b"content"
+
+
+def test_close_releases_binding(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    container = backend._affinity_id
+    backend.close()
+    assert fake.closed == [container]
+    assert backend._affinity_id is None
+    # Second close is a no-op.
+    backend.close()
+    assert fake.closed == [container]

--- a/tests/test_gateway_backend.py
+++ b/tests/test_gateway_backend.py
@@ -180,6 +180,45 @@ def test_run_command_retries_transient_503(backend_and_gateway):
     assert result.exit_code == 0
 
 
+def test_run_command_retries_single_owner_unregistered_503(backend_and_gateway):
+    # One roster miss is absorbed by the normal retry: the binding stays bound
+    # to the same container, no re-handshake.
+    backend, fake = backend_and_gateway
+    first_container = backend._affinity_id
+    fake.fail_next_posts.append((503, "strict affinity server is no longer registered"))
+    fake.scripted_results.append((0, "ok\n", ""))
+    result = backend.run_command("echo ok")
+    assert result.exit_code == 0
+    assert fake.handshakes == 1
+    assert backend._affinity_id == first_container
+
+
+def test_run_command_rehandshakes_on_repeated_owner_unregistered_503(backend_and_gateway):
+    # A replica that died/rescheduled stays off the roster until the binding
+    # TTL expires (~15 min); a repeated "no longer registered" 503 must be
+    # treated like a lost session (re-handshake + retry once), not retried
+    # to exhaustion.
+    backend, fake = backend_and_gateway
+    first_container = backend._affinity_id
+    fake.fail_next_posts.extend([(503, "strict affinity server is no longer registered")] * 2)
+    fake.scripted_results.append((0, "recovered\n", ""))
+    result = backend.run_command("echo recovered")
+    assert result.stdout == "recovered\n"
+    assert fake.handshakes == 2
+    assert backend._affinity_id != first_container
+    # The dead binding saw exactly the launcher exec and its single quick retry.
+    dead_binding_posts = [payload for _, payload in fake.requests if payload.get("affinity_id") == first_container]
+    assert len(dead_binding_posts) == 2
+
+
+def test_close_tolerates_owner_unregistered_503(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.fail_next_posts.extend([(503, "strict affinity server is no longer registered")] * 2)
+    backend.close()  # must not raise; container is gone with its replica
+    assert backend._affinity_id is None
+    assert fake.closed == []
+
+
 def test_run_command_cleanup_failure_does_not_fail_command(backend_and_gateway, monkeypatch):
     # The post-completion `rm -rf` is best-effort: a replica that 408s it under
     # load (podman exec latency) must not turn a finished command into an error.

--- a/tests/test_gateway_backend.py
+++ b/tests/test_gateway_backend.py
@@ -193,27 +193,67 @@ def test_run_command_retries_single_owner_unregistered_503(backend_and_gateway):
     assert backend._affinity_id == first_container
 
 
-def test_run_command_rehandshakes_on_repeated_owner_unregistered_503(backend_and_gateway):
-    # A replica that died/rescheduled stays off the roster until the binding
-    # TTL expires (~15 min); a repeated "no longer registered" 503 must be
-    # treated like a lost session (re-handshake + retry once), not retried
-    # to exhaustion.
+@pytest.mark.parametrize(
+    "body",
+    [
+        "strict affinity server is no longer registered",
+        '{"error":"strict affinity server is unavailable","status":"failed"}',
+    ],
+)
+def test_run_command_rehandshakes_on_repeated_owner_gone_503(backend_and_gateway, body):
+    # A replica that died keeps failing every request: "server is unavailable"
+    # while the roster still lists it (~4 min heartbeat tolerance), then "no
+    # longer registered" until the binding TTL expires (~15 min). Consecutive
+    # such 503s must be treated like a lost session (re-handshake + retry
+    # once), not retried to exhaustion and surfaced as a tool error.
     backend, fake = backend_and_gateway
     first_container = backend._affinity_id
-    fake.fail_next_posts.extend([(503, "strict affinity server is no longer registered")] * 2)
+    fake.fail_next_posts.extend([(503, body)] * GatewayBackend._OWNER_LOST_ATTEMPTS)
     fake.scripted_results.append((0, "recovered\n", ""))
     result = backend.run_command("echo recovered")
     assert result.stdout == "recovered\n"
     assert fake.handshakes == 2
     assert backend._affinity_id != first_container
-    # The dead binding saw exactly the launcher exec and its single quick retry.
+    # The dead binding saw exactly the launcher exec and its quick retries.
     dead_binding_posts = [payload for _, payload in fake.requests if payload.get("affinity_id") == first_container]
-    assert len(dead_binding_posts) == 2
+    assert len(dead_binding_posts) == GatewayBackend._OWNER_LOST_ATTEMPTS
+
+
+_OWNER_LOST_410 = (
+    410,
+    '{"error":"strict affinity server is no longer registered","code":"affinity_owner_lost","recoverable":false}',
+)
+
+
+def test_run_command_rehandshakes_on_410_owner_lost(backend_and_gateway):
+    # literegistry >= 1.0.49: the gateway probes the bound replica and answers
+    # 410 affinity_owner_lost when it is gone. Not retryable -- re-handshake at
+    # once, without burning the 503 retry budget first.
+    backend, fake = backend_and_gateway
+    first_container = backend._affinity_id
+    fake.fail_next_posts.append(_OWNER_LOST_410)
+    fake.scripted_results.append((0, "recovered\n", ""))
+    result = backend.run_command("echo recovered")
+    assert result.stdout == "recovered\n"
+    assert fake.handshakes == 2
+    assert backend._affinity_id != first_container
+    dead_binding_posts = [payload for _, payload in fake.requests if payload.get("affinity_id") == first_container]
+    assert len(dead_binding_posts) == 1
+
+
+def test_close_tolerates_410_owner_lost(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.fail_next_posts.append(_OWNER_LOST_410)
+    backend.close()  # container died with its replica; nothing left to release
+    assert backend._affinity_id is None
+    assert fake.closed == []
 
 
 def test_close_tolerates_owner_unregistered_503(backend_and_gateway):
     backend, fake = backend_and_gateway
-    fake.fail_next_posts.extend([(503, "strict affinity server is no longer registered")] * 2)
+    fake.fail_next_posts.extend(
+        [(503, "strict affinity server is no longer registered")] * GatewayBackend._OWNER_LOST_ATTEMPTS
+    )
     backend.close()  # must not raise; container is gone with its replica
     assert backend._affinity_id is None
     assert fake.closed == []

--- a/tests/test_gateway_backend.py
+++ b/tests/test_gateway_backend.py
@@ -10,6 +10,8 @@ from open_instruct.environments.backends import (
     _PENDING_MARKER,
     GatewayBackend,
     GatewayBackendError,
+    SandboxLostError,
+    SandboxOOMError,
     create_backend,
 )
 
@@ -32,8 +34,11 @@ class FakeGateway:
         self.closed = []
         self.container_counter = 0
         self.fail_next_posts: list[tuple[int, str]] = []  # (status_code, body)
+        self.fail_posts_skip = 0  # let this many posts through before applying fail_next_posts
         self.markerless_rounds = 0  # how many wait execs return neither marker (e.g. killed, exit 137)
         self.fail_cleanup_posts: list[tuple[int, str]] = []  # (status_code, body) for rm -rf execs only
+        self.launcher_results: list[dict] = []  # canned replica responses for launcher execs
+        self.probe_results: list[dict] = []  # canned replica responses for the `true` liveness probe
 
     def response(self, status_code, payload):
         response = MagicMock()
@@ -48,8 +53,11 @@ class FakeGateway:
     def post(self, url, json=None, timeout=None):
         self.requests.append((url, json))
         if self.fail_next_posts:
-            status, body = self.fail_next_posts.pop(0)
-            return self.response(status, body)
+            if self.fail_posts_skip > 0:
+                self.fail_posts_skip -= 1
+            else:
+                status, body = self.fail_next_posts.pop(0)
+                return self.response(status, body)
         if url.endswith("/affinity/handshake"):
             self.handshakes += 1
             self.container_counter += 1
@@ -62,7 +70,15 @@ class FakeGateway:
             return self.response(200, {"removed": True})
         assert url.endswith("/affinity/podman")
         command = json["command"]
+        if command == "true":
+            if self.probe_results:
+                return self.response(200, self.probe_results.pop(0))
+            return self.response(
+                200, {"stdout": "", "stderr": "", "exit_code": 0, "success": True, "timed_out": False}
+            )
         if "mkdir" in command and "cat >" in command and "LAUNCHED" in command:
+            if self.launcher_results:
+                return self.response(200, self.launcher_results.pop(0))
             return self.response(
                 200, {"stdout": "LAUNCHED\n", "stderr": "", "exit_code": 0, "success": True, "timed_out": False}
             )
@@ -282,9 +298,88 @@ def test_run_command_retries_markerless_wait(backend_and_gateway):
 
 
 def test_run_command_persistent_markerless_wait_raises(backend_and_gateway):
+    # Container answers the liveness probe: a slow replica, so a plain tool
+    # error (the episode continues).
     backend, fake = backend_and_gateway
     fake.markerless_rounds = 10
     with pytest.raises(GatewayBackendError, match="no marker"):
+        backend.run_command("echo doomed")
+    assert fake.handshakes == 1
+
+
+_CONTAINER_NOT_FOUND_404 = (
+    404,
+    '{"detail":{"error":"container_not_found","container_id":"' + "c" * 64 + '",'
+    '"message":"container does not exist or belongs to another instance"}}',
+)
+_STOPPED_CONTAINER_EXEC = {
+    "stdout": "",
+    "stderr": "Error: can only create exec sessions on running containers: container state improper",
+    "exit_code": 255,
+    "success": False,
+    "timed_out": False,
+}
+
+
+def test_container_removed_between_commands_ends_episode(backend_and_gateway):
+    # The replica's resource watchdog (or idle janitor) removed the container
+    # while the agent was thinking: the sandbox died under the agent's own
+    # commands, so end the episode like a DockerBackend OOM kill instead of
+    # silently continuing in a fresh, empty container.
+    backend, fake = backend_and_gateway
+    fake.fail_next_posts.append(_CONTAINER_NOT_FOUND_404)
+    with pytest.raises(SandboxLostError, match="removed by its replica"):
+        backend.run_command("echo doomed")
+    assert isinstance(SandboxLostError("x"), SandboxOOMError)  # env's OOM handler catches it
+    assert fake.handshakes == 1
+
+
+def test_sigkilled_wait_then_container_gone_ends_episode(backend_and_gateway):
+    # Watchdog kill mid-command: the wait exec comes back SIGKILLed (exit 137,
+    # no marker), then the container is gone.
+    backend, fake = backend_and_gateway
+    fake.markerless_rounds = 1  # exit 137
+    fake.fail_posts_skip = 2  # launcher + the SIGKILLed wait go through; the wait retry gets the 404
+    fake.fail_next_posts.append(_CONTAINER_NOT_FOUND_404)
+    with pytest.raises(SandboxLostError, match="sigkill_seen=True"):
+        backend.run_command("python hog.py")
+    assert fake.handshakes == 1
+
+
+def test_expired_binding_mid_command_still_rehandshakes(backend_and_gateway):
+    # No SIGKILL seen and the gateway (not the replica) lost the binding:
+    # infra-side loss, keep the restart-and-retry-once semantics.
+    backend, fake = backend_and_gateway
+    fake.fail_next_posts.append((404, '{"error":"strict affinity binding was not found or has expired"}'))
+    fake.scripted_results.append((0, "recovered\n", ""))
+    assert backend.run_command("echo recovered").stdout == "recovered\n"
+    assert fake.handshakes == 2
+
+
+def test_stopped_container_on_launch_ends_episode(backend_and_gateway):
+    # PID 1 of the sandbox died (agent ran `kill -9 1` / OOM took init): the
+    # container is stopped but not removed, every exec fails with exit 255.
+    backend, fake = backend_and_gateway
+    fake.launcher_results.append(_STOPPED_CONTAINER_EXEC)
+    with pytest.raises(SandboxLostError, match="is stopped"):
+        backend.run_command("echo doomed")
+    assert fake.handshakes == 1
+
+
+def test_persistent_markerless_wait_with_stopped_container_ends_episode(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.markerless_rounds = 10
+    fake.probe_results.append(_STOPPED_CONTAINER_EXEC)
+    with pytest.raises(SandboxLostError, match="is stopped"):
+        backend.run_command("echo doomed")
+
+
+def test_persistent_markerless_wait_with_removed_container_ends_episode(backend_and_gateway):
+    backend, fake = backend_and_gateway
+    fake.markerless_rounds = 3
+    fake.fail_posts_skip = 4  # launcher + 3 markerless waits go through; the liveness probe gets the 404
+    fake.fail_next_posts.append(_CONTAINER_NOT_FOUND_404)
+    with pytest.raises(SandboxLostError, match="is gone"):
         backend.run_command("echo doomed")
 
 


### PR DESCRIPTION
## What

Adds `backend: "gateway"` for Terminal RL sandboxes: containers run on an **external LiteRegistry deployment** (Redis registry + gateway + rootless podman replicas + docker.io pull-through mirrors) instead of podman services colocated in the training job. A podman crash / full disk becomes a replica-local event handled by load balancing, instead of killing rollouts on a training node for the rest of the run.

```
training job (Ray env actors) --HTTP--> gateway --> podman replica 1..N (one container per episode)
                                           |------> docker-mirror replicas
                                           '------> Redis (registry + affinity bindings)
```

**Usage** — one tool_configs change, all podman plumbing (docker_login.sh, `SWERL_PODMAN_*`, `MIRROR_URL`, `DOCKER_PAT`, subcontainer perms) drops out of launch scripts:

```bash
--tool_configs '{"backend": "gateway", "gateway_url": "http://HOST:PORT", ...}'
```

## Key implementation notes

The replicas enforce a hard per-exec contract (60s timeout cap, 1MB stdin, >1MB stdout *aborts* the exec and the gateway re-runs it, wedging the session). `GatewayBackend` therefore:
- launches commands **detached in-container** (rc/out/err files, `mkdir` lock against duplicate launch), awaits them with ≤45s blocking wait-execs, reads output back bounded — so 600s verifiers and giant outputs are safe;
- moves file payloads as **idempotent base64 chunks** (gateway retries can re-send any request safely);
- runs a keepalive thread so the affinity TTL can't expire during long generation gaps; a lost binding (404) re-handshakes and retries once, mirroring `DockerBackend`'s restart semantics;
- retries transient 500/502/503/504/408 and connection drops with backoff.

Also: `scripts/general_agent/terminal/rl/gateway/check_gateway_deployment.py` — a 15-check preflight to run against any deployment before launching (health, protocol, chunked IO, and a full vanillux episode on a real tmax task asserting reward 1.0); a 4-GPU smoke script; a gateway twin of the 9B DPPO 4-node/64k prod script; `docs/algorithms/gateway_sandbox_backend.md` (architecture, failure modes vs colocated podman, known upstream gaps). Drive-by: Dockerfile `google-cloud-sdk` → `google-cloud-cli` (upstream apt rename broke cold-cache builds).

## Validation

- 11 unit tests (`tests/test_gateway_backend.py`) + existing backend/env/pool suites pass
- Live preflight vs the test deployment: 15/15 incl. real-task episode with verifier reward 1.0
- 128 concurrent episodes against 3 replicas: 0 errors
- **Beaker smoke** [01M1DA9TFAX4J0XSF3176W2C1Z](https://beaker.org/ex/01M1DA9TFAX4J0XSF3176W2C1Z): Qwen3.5-4B DPPO on tmax-15k via the gateway — 10/10 training steps, exit 0, **zero gateway errors, 0.00 bash tool failure rate** (~26 calls/rollout), warm resets 4-6s ([wandb](https://wandb.ai/ai2-llm/oe-general-agents/runs/g9m5swce))

## Before switching prod over

1. Scale the deployment (test stack has 3 replicas; start ~16 + mirror warming) and re-run the preflight
2. Upstream fixes tracked in the doc: per-container `--memory`/`--pids-limit` (we lose today's 4g cap), truncate-not-413 on oversized output, idle-container/image janitors on replicas, cold-pull vs handshake-timeout race

GPU_TESTS=bypass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FR23dR1uE8z7VWVeHiscxF
