### PR TITLE
Remove ModelConfig PEFT/quantization flags that nothing reads

### DIFF
--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -190,31 +190,13 @@ class ModelConfig:
     gradient_checkpointing: bool = False
     """Whether to use gradient checkpointing in the model."""
 
-    # PEFT-related args
-    use_peft: bool = False
-    """Whether to use PEFT or not for training."""
-    lora_r: int | None = 16
-    """LoRA R value."""
-    lora_alpha: int | None = 32
-    """LoRA alpha."""
-    lora_dropout: float | None = 0.05
-    """LoRA dropout."""
-    lora_target_modules: list[str] | None = None
-    """LoRA target modules."""
-    lora_modules_to_save: list[str] | None = None
-    """Model layers to unfreeze & train"""
-    lora_task_type: str = "CAUSAL_LM"
-    """The task_type to pass for LoRA (use SEQ_CLS for reward modeling)"""
-
-    # quantization args
-    load_in_8bit: bool = False
-    """use 8 bit precision for the base model - works only with LoRA"""
-    load_in_4bit: bool = False
-    """use 4 bit precision for the base model - works only with LoRA"""
-    bnb_4bit_quant_type: str | None = "nf4"
-    """precise the quantization type (fp4 or nf4)"""
-    use_bnb_nested_quant: bool = False
-    """use nested quantization"""
+    # NOTE: PEFT/LoRA and bitsandbytes quantization args used to live here, but nothing
+    # ever read them off ModelConfig, so passing e.g. `--use_peft` to a script that takes
+    # ModelConfig (reward_modeling.py) silently did full finetuning. The scripts that do
+    # support LoRA (finetune.py, dpo_tune_cache.py) declare their own `use_lora`/`use_qlora`
+    # and `lora_rank`/`lora_alpha`/`lora_dropout` on FlatArguments and read those instead.
+    # If LoRA support is added to a ModelConfig-based script, add the flags back together
+    # with the code that consumes them.
 
     def __post_init__(self):
         if self.attn_implementation is None:

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,0 +1,138 @@
+"""Unit tests for open_instruct.model_utils.ModelConfig.
+
+``ModelConfig`` is parsed straight onto the command line by ``ArgumentParserPlus``
+(see ``reward_modeling.py``), so every field on it becomes a user-visible ``--flag``.
+A field that nothing reads is therefore worse than dead code: the flag is accepted,
+it is logged to wandb via ``asdict(model_config)``, and it silently does nothing.
+
+That is exactly what happened to the PEFT/LoRA and bitsandbytes blocks -- ``--use_peft``
+and ``--load_in_4bit`` parsed fine on ``reward_modeling.py`` while the run did plain
+full finetuning. These tests keep that from coming back.
+"""
+
+import ast
+import dataclasses
+import pathlib
+import re
+import unittest
+
+from open_instruct.model_utils import ModelConfig
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Fields that are intentionally never read via attribute access. Add an entry here
+# (with a reason) rather than deleting the check if a field is genuinely write-only.
+ALLOWED_UNREAD_FIELDS: dict[str, str] = {}
+
+
+def _python_sources() -> list[pathlib.Path]:
+    """Every tracked Python file, skipping virtualenvs and vendored trees."""
+    skip = (".venv", "venv", "oe-eval-internal", "site-packages", "build", ".git")
+    return [
+        path
+        for path in REPO_ROOT.rglob("*.py")
+        if not any(part in skip for part in path.parts)
+    ]
+
+
+def _attribute_reads(field_name: str, blob: str) -> int:
+    """Count ``.field_name`` attribute accesses.
+
+    Matching on the leading dot is what makes this meaningful: several scripts declare
+    their *own* ``lora_alpha``/``lora_dropout`` on ``FlatArguments`` and read them as
+    ``args.lora_alpha``. A bare-name search would count those and mask a dead field, so
+    we deliberately accept that this also counts reads off unrelated objects -- it makes
+    the check conservative (it can only under-report deadness, never over-report it).
+    """
+    return len(re.findall(rf"\.{re.escape(field_name)}\b", blob))
+
+
+class TestModelConfigFieldsAreUsed(unittest.TestCase):
+    def setUp(self) -> None:
+        sources = _python_sources()
+        self.assertGreater(len(sources), 20, "source discovery looks broken")
+        self.blob = "\n".join(p.read_text(errors="ignore") for p in sources)
+
+    def test_every_field_is_read_somewhere(self) -> None:
+        dead = []
+        for field in dataclasses.fields(ModelConfig):
+            if field.name in ALLOWED_UNREAD_FIELDS:
+                continue
+            if _attribute_reads(field.name, self.blob) == 0:
+                dead.append(field.name)
+
+        self.assertEqual(
+            dead,
+            [],
+            "ModelConfig fields are exposed as CLI flags, so a field nothing reads is a "
+            "flag that silently does nothing. Either wire these up or remove them: "
+            f"{dead}",
+        )
+
+    def test_detects_a_deliberately_dead_field(self) -> None:
+        """Negative control: the check above must actually be able to fail.
+
+        Without this, `test_every_field_is_read_somewhere` would keep passing even if
+        `_attribute_reads` were broken into always returning a positive count.
+        """
+        self.assertEqual(_attribute_reads("field_no_source_file_mentions", self.blob), 0)
+        self.assertGreater(_attribute_reads("model_name_or_path", self.blob), 0)
+
+    def test_bare_name_matches_do_not_count_as_reads(self) -> None:
+        """A declaration alone must not look like a read."""
+        self.assertEqual(_attribute_reads("lora_r", "lora_r: int | None = 16"), 0)
+        self.assertEqual(_attribute_reads("lora_r", "peft_config.lora_r"), 1)
+
+
+class TestModelConfigHasNoUnwiredPeftFlags(unittest.TestCase):
+    """Pin the specific regression: PEFT/quantization flags with no implementation.
+
+    ``reward_modeling.py`` is the entrypoint that puts ``ModelConfig`` on the CLI and it
+    has no LoRA support, so re-adding these without also adding the code that reads them
+    would resurrect the silent no-op.
+    """
+
+    REMOVED_FLAGS = (
+        "use_peft",
+        "lora_r",
+        "lora_alpha",
+        "lora_dropout",
+        "lora_target_modules",
+        "lora_modules_to_save",
+        "lora_task_type",
+        "load_in_8bit",
+        "load_in_4bit",
+        "bnb_4bit_quant_type",
+        "use_bnb_nested_quant",
+    )
+
+    def test_peft_flags_absent_until_implemented(self) -> None:
+        present = {f.name for f in dataclasses.fields(ModelConfig)}
+        resurrected = sorted(present.intersection(self.REMOVED_FLAGS))
+        self.assertEqual(
+            resurrected,
+            [],
+            "These flags were removed because nothing consumed them. If you are adding "
+            "real PEFT support, also add the code that reads them (and drop them from "
+            f"this list): {resurrected}",
+        )
+
+    def test_reward_modeling_still_exposes_model_config(self) -> None:
+        """Guard the premise: if this stops being true, the test above loses its point."""
+        source = (REPO_ROOT / "open_instruct" / "reward_modeling.py").read_text()
+        tree = ast.parse(source)
+        exposes = any(
+            isinstance(node, ast.Call)
+            and getattr(node.func, "id", None) == "ArgumentParserPlus"
+            and "ModelConfig" in ast.unparse(node)
+            for node in ast.walk(tree)
+        )
+        self.assertTrue(
+            exposes,
+            "reward_modeling.py no longer parses ModelConfig from the CLI; revisit "
+            "whether these tests still describe the right invariant.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

`ModelConfig` had 11 PEFT/LoRA and bitsandbytes fields that nothing in the repo ever read. Since `ModelConfig` is parsed straight onto the CLI by `ArgumentParserPlus` (in `reward_modeling.py`), each of those fields is a real user-facing flag — so they parsed fine and then did nothing.

```
$ # reward_modeling.py accepts all of these without complaint:
--use_peft True    -> cfg.use_peft     = True
--lora_r 64        -> cfg.lora_r       = 64
--load_in_4bit True-> cfg.load_in_4bit = True
```

A user asking for 4-bit LoRA reward modelling silently got **full finetuning** instead. The values even reach wandb via `asdict(model_config)` on `reward_modeling.py:222`, so the run *looks* correctly configured in the dashboard while the flags are inert. The likely symptoms — an OOM on hardware that should have fit, or a model that isn't the adapter you expected — don't point back at the cause.

Verified all 11 are unread by counting `.field` attribute accesses across every non-vendored `.py` in the repo:

| field | attribute reads |
|---|---|
| `use_peft`, `lora_r`, `lora_target_modules`, `lora_modules_to_save`, `lora_task_type` | 0 |
| `load_in_8bit`, `load_in_4bit`, `bnb_4bit_quant_type`, `use_bnb_nested_quant` | 0 |
| `lora_alpha`, `lora_dropout` | 0 *on `ModelConfig`* |

`lora_alpha` / `lora_dropout` need a note: a naive search finds hits, but they are all `args.lora_alpha` in `finetune.py:641` and `dpo_tune_cache.py:371` — those read `FlatArguments`, which declares its **own** `lora_rank` / `lora_alpha` / `lora_dropout` / `use_lora` / `use_qlora`. Two parallel LoRA arg sets exist; only the `FlatArguments` one is wired up. I also checked `getattr` / `vars()` / `**asdict` so a dynamic reader wouldn't be missed — `reward_modeling.py:222` is the only dynamic use and it's logging-only.

## Why remove rather than wire up

Removing is the change I can actually justify. Implementing LoRA for reward modelling means picking target modules for a `SEQ_CLS` head, handling the adapter in the save path, and validating that the resulting RM trains sensibly — none of which I can verify without GPUs, and guessing at it would be worse than the current state. Removal makes the failure honest: `--use_peft` now errors out instead of being quietly ignored.

I left a comment at the removal site pointing at the working `FlatArguments` flags, so someone hitting this finds the supported path.

**This is user-visible**: anyone currently passing these flags to `reward_modeling.py` will now get an "unrecognized arguments" error. That seems strictly better than silence, but it is a behaviour change and I'd understand preferring a deprecation warning — happy to switch if you'd rather.

## Tests

`tests/test_model_config.py`, 5 tests:

- **`test_every_field_is_read_somewhere`** — fails if *any* `ModelConfig` field has zero readers, so the next unwired flag gets caught rather than needing this bug rediscovered. Has an `ALLOWED_UNREAD_FIELDS` escape hatch (empty) for genuinely write-only fields.
- **`test_peft_flags_absent_until_implemented`** — fails if these specific 11 come back without an implementation.
- **`test_reward_modeling_still_exposes_model_config`** — guards the premise. If `reward_modeling.py` stops putting `ModelConfig` on the CLI, the other tests lose their rationale and this says so out loud instead of passing vacuously.
- Two unit tests on the matcher itself (a bare declaration must not count as a read; a known-good field must).

I mutation-tested rather than trusting a green run:

| mutation | result |
|---|---|
| re-add `use_peft` to `ModelConfig` | ✅ 2 failed — both `test_every_field_is_read_somewhere` and `test_peft_flags_absent_until_implemented` |
| drop `ModelConfig` from `ArgumentParserPlus` | ✅ 1 failed — `test_reward_modeling_still_exposes_model_config` |

Each mutation was caught by exactly the test meant to catch it.

The read-counter deliberately matches `.field_name` with the leading dot. That means it can also count reads off unrelated objects, which makes it conservative — it can under-report deadness but never claim a live field is dead. A bare-name search would have counted `FlatArguments.lora_alpha` and masked this bug entirely.

## Checks

```
uv run --frozen pytest tests/          ->  59 passed
uv run --frozen pytest tests/test_model_config.py -> 5 passed
make style-check                        ->  121 files already formatted
make quality-check                      ->  ruff / ty / compileall all pass
```

Ran everything under `uv sync --frozen` to match the `unit-tests` job. Note that a bare `uv run --frozen pytest` hits 8 collection errors (`gzip.BadGzipFile`) — those are Git LFS pointer files in my shallow clone, and I confirmed they reproduce identically on unmodified `main`, so they're unrelated to this change.

No GPU code paths are touched: the removed fields had no readers, so no execution path changes.

`CHANGELOG=` — happy to add an entry if you'd like one; the check only requires it for `open_instruct/` changes and I wasn't sure a pure dead-flag removal warrants a user-facing line. Say the word and I'll add it with the PR link.

---

Assembled with AI assistance. Every count, table and command result above comes from a local run against this branch, and the mutation results are the part I'd point a reviewer at first.